### PR TITLE
feat: add recipe feature with grocery list integration

### DIFF
--- a/packages/infra/main.tf
+++ b/packages/infra/main.tf
@@ -66,6 +66,7 @@ module "policies" {
   dynamodb_user_preferences_arn       = module.dynamodb.user_preferences_arn
   dynamodb_push_subscriptions_arn     = module.dynamodb.push_subscriptions_arn
   dynamodb_shops_arn                  = module.dynamodb.shops_arn
+  dynamodb_recipes_arn                = module.dynamodb.recipes_arn
   sns_todo_notifications_arn          = module.sns.todo_notifications_topic_arn
   s3_kairos_web_arn                   = module.s3.kairos_web_arn
   s3_kairos_lambdas_arn               = module.s3.kairos_lambdas_arn

--- a/packages/infra/modules/api_gateway/openapi/recipes.yml
+++ b/packages/infra/modules/api_gateway/openapi/recipes.yml
@@ -1,0 +1,279 @@
+openapi: 3.0.1
+info:
+  title: Recipes
+  description: |
+    API for Recipe Management
+  version: "1.0"
+paths:
+  /recipes:
+    get:
+      security:
+        - CognitoAuthorizer: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectIDHeader"
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: AWS_PROXY
+        uri: ${lambda_functions["get_recipes"].invoke_arn}
+        passthroughBehavior: when_no_match
+        contentHandling: CONVERT_TO_TEXT
+      responses:
+        200:
+          description: Recipes retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/recipe"
+    put:
+      security:
+        - CognitoAuthorizer: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectIDHeader"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/createRecipeRequest"
+        required: true
+      x-amazon-apigateway-request-validator: Validate body
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: AWS_PROXY
+        uri: ${lambda_functions["add_recipe"].invoke_arn}
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+      responses:
+        201:
+          description: Recipe created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    example: "recipe-123"
+        400:
+          description: Incorrect recipe details
+    options:
+      responses:
+        200:
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Access-Control-Allow-Methods: "'GET, PUT'"
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Project-ID'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestTemplates:
+          application/json: '{"statusCode": 200}'
+        passthroughBehavior: "when_no_match"
+        type: "mock"
+  /recipes/{id}:
+    post:
+      security:
+        - CognitoAuthorizer: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectIDHeader"
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Identifier of the recipe to be updated
+          example: "recipe-123"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/updateRecipeRequest"
+        required: true
+      x-amazon-apigateway-request-validator: Validate body
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: AWS_PROXY
+        uri: ${lambda_functions["update_recipe"].invoke_arn}
+        passthroughBehavior: when_no_match
+        contentHandling: CONVERT_TO_TEXT
+      responses:
+        200:
+          description: Recipe updated successfully
+        400:
+          description: Incorrect recipe details
+    delete:
+      security:
+        - CognitoAuthorizer: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectIDHeader"
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Identifier of the recipe to be removed
+          example: "recipe-123"
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: AWS_PROXY
+        uri: ${lambda_functions["delete_recipe"].invoke_arn}
+        passthroughBehavior: when_no_match
+        contentHandling: CONVERT_TO_TEXT
+      responses:
+        200:
+          description: Recipe removed
+        400:
+          description: Invalid recipe ID
+        404:
+          description: Recipe does not exist
+    options:
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Identifier of the recipe
+          example: "recipe-123"
+      responses:
+        200:
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Access-Control-Allow-Methods: "'POST, DELETE'"
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Project-ID'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestTemplates:
+          application/json: '{"statusCode": 200}'
+        passthroughBehavior: "when_no_match"
+        type: "mock"
+components:
+  parameters:
+    ProjectIDHeader:
+      name: X-Project-ID
+      in: header
+      required: true
+      schema:
+        type: string
+      description: Project ID for multi-tenancy data isolation
+  schemas:
+    recipeIngredient:
+      title: Recipe Ingredient
+      type: object
+      required:
+        - name
+        - quantity
+        - unit
+      properties:
+        name:
+          type: string
+          example: "Milk"
+        quantity:
+          type: number
+          example: 2
+        unit:
+          type: string
+          example: "liter(s)"
+    recipe:
+      title: Recipe Details
+      type: object
+      required:
+        - id
+        - projectId
+        - name
+        - ingredients
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          example: "recipe-123"
+        projectId:
+          type: string
+          example: "project-456"
+        name:
+          type: string
+          example: "Pasta Carbonara"
+        ingredients:
+          type: array
+          items:
+            $ref: "#/components/schemas/recipeIngredient"
+        createdAt:
+          type: string
+          format: date-time
+          example: "2024-01-01T00:00:00Z"
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2024-01-01T00:00:00Z"
+    createRecipeRequest:
+      title: Create Recipe Request
+      type: object
+      required:
+        - name
+        - ingredients
+      properties:
+        name:
+          type: string
+          example: "Pasta Carbonara"
+        ingredients:
+          type: array
+          items:
+            $ref: "#/components/schemas/recipeIngredient"
+          minItems: 1
+    updateRecipeRequest:
+      title: Update Recipe Request
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: "recipe-123"
+        name:
+          type: string
+          example: "Updated Recipe Name"
+        ingredients:
+          type: array
+          items:
+            $ref: "#/components/schemas/recipeIngredient"
+  securitySchemes:
+    CognitoAuthorizer:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: cognito_user_pools
+      x-amazon-apigateway-authorizer:
+        type: cognito_user_pools
+        providerARNs:
+          - ${cognito_user_pool_arn}
+x-amazon-apigateway-request-validators:
+  Validate body:
+    validateRequestParameters: false
+    validateRequestBody: true

--- a/packages/infra/modules/dynamodb/main.recipes.tf
+++ b/packages/infra/modules/dynamodb/main.recipes.tf
@@ -1,0 +1,25 @@
+resource "aws_dynamodb_table" "recipes" {
+  name           = "Recipes"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "projectId"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "ProjectRecipesIndex"
+    hash_key        = "projectId"
+    write_capacity  = 1
+    read_capacity   = 1
+    projection_type = "ALL"
+  }
+}

--- a/packages/infra/modules/dynamodb/outputs.tf
+++ b/packages/infra/modules/dynamodb/outputs.tf
@@ -37,3 +37,7 @@ output "push_subscriptions_arn" {
 output "shops_arn" {
   value = aws_dynamodb_table.shops.arn
 }
+
+output "recipes_arn" {
+  value = aws_dynamodb_table.recipes.arn
+}

--- a/packages/infra/modules/lambda/locals.tf
+++ b/packages/infra/modules/lambda/locals.tf
@@ -386,6 +386,54 @@ locals {
           todo_notifications = "none"
         }
       }
+    },
+    "add_recipe" = {
+      environment_variables = {}
+      permissions = {
+        database = {
+          recipes            = "read-write"
+          push_subscriptions = "none"
+        }
+        sns = {
+          todo_notifications = "none"
+        }
+      }
+    },
+    "get_recipes" = {
+      environment_variables = {}
+      permissions = {
+        database = {
+          recipes            = "read-only"
+          push_subscriptions = "none"
+        }
+        sns = {
+          todo_notifications = "none"
+        }
+      }
+    },
+    "update_recipe" = {
+      environment_variables = {}
+      permissions = {
+        database = {
+          recipes            = "read-write"
+          push_subscriptions = "none"
+        }
+        sns = {
+          todo_notifications = "none"
+        }
+      }
+    },
+    "delete_recipe" = {
+      environment_variables = {}
+      permissions = {
+        database = {
+          recipes            = "read-write"
+          push_subscriptions = "none"
+        }
+        sns = {
+          todo_notifications = "none"
+        }
+      }
     }
   }
 }

--- a/packages/infra/modules/policies/data.lambda.tf
+++ b/packages/infra/modules/policies/data.lambda.tf
@@ -296,6 +296,34 @@ data "aws_iam_policy_document" "lambda_policies" {
   }
 
   dynamic "statement" {
+    for_each = each.value.permissions.database.recipes == local.permissions.read_only ? [each.key] : []
+
+    content {
+      sid     = "DatabaseReadOnlyRecipes"
+      actions = local.database_read_only_actions
+      effect  = "Allow"
+      resources = [
+        var.dynamodb_recipes_arn,
+        "${var.dynamodb_recipes_arn}/index/*",
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = each.value.permissions.database.recipes == local.permissions.read_write ? [each.key] : []
+
+    content {
+      sid     = "DatabaseReadWriteRecipes"
+      actions = local.database_read_write_actions
+      effect  = "Allow"
+      resources = [
+        var.dynamodb_recipes_arn,
+        "${var.dynamodb_recipes_arn}/index/*",
+      ]
+    }
+  }
+
+  dynamic "statement" {
     for_each = each.value.permissions.sns.todo_notifications == local.permissions.publish ? [each.key] : []
 
     content {

--- a/packages/infra/modules/policies/variables.tf
+++ b/packages/infra/modules/policies/variables.tf
@@ -24,6 +24,7 @@ variable "lambda_functions" {
         user_preferences       = optional(string, "none")
         push_subscriptions     = optional(string, "none")
         shops                  = optional(string, "none")
+        recipes                = optional(string, "none")
       })
       sns = object({
         todo_notifications = optional(string, "none")
@@ -73,6 +74,10 @@ variable "dynamodb_push_subscriptions_arn" {
 }
 
 variable "dynamodb_shops_arn" {
+  type = string
+}
+
+variable "dynamodb_recipes_arn" {
   type = string
 }
 

--- a/packages/lambdas/libs/dynamodb/enums/index.ts
+++ b/packages/lambdas/libs/dynamodb/enums/index.ts
@@ -9,6 +9,7 @@ export enum DynamoDBTable {
   USER_PREFERENCES = "UserPreferences",
   PUSH_SUBSCRIPTIONS = "PushSubscriptions",
   SHOPS = "Shops",
+  RECIPES = "Recipes",
 }
 
 export enum DynamoDBIndex {
@@ -22,6 +23,7 @@ export enum DynamoDBIndex {
   PROJECT_MEMBERS_PROJECT = "ProjectMembersIndex",
   PUSH_SUBSCRIPTIONS_USER = "UserPushSubscriptionsIndex",
   SHOPS_PROJECT = "ProjectShopsIndex",
+  RECIPES_PROJECT = "ProjectRecipesIndex",
 }
 
 export enum GroceryItemUnit {

--- a/packages/lambdas/libs/dynamodb/types/index.ts
+++ b/packages/lambdas/libs/dynamodb/types/index.ts
@@ -4,3 +4,4 @@ export * from "./todoList";
 export * from "./projects";
 export * from "./userPreferences";
 export * from "./pushSubscriptions";
+export * from "./recipes";

--- a/packages/lambdas/libs/dynamodb/types/recipes/index.ts
+++ b/packages/lambdas/libs/dynamodb/types/recipes/index.ts
@@ -1,0 +1,16 @@
+import { GroceryItemUnit } from '../../enums'
+
+export interface IRecipeIngredient {
+    name: string
+    quantity: number
+    unit: GroceryItemUnit
+}
+
+export interface IRecipe {
+    id: string
+    projectId: string
+    name: string
+    ingredients: string  // JSON-serialized IRecipeIngredient[]
+    createdAt: string
+    updatedAt: string
+}

--- a/packages/lambdas/sources/add_recipe/body/index.ts
+++ b/packages/lambdas/sources/add_recipe/body/index.ts
@@ -1,0 +1,43 @@
+import { IRequestBody, IRecipeIngredientBody } from "./types";
+
+const isValidIngredient = (ingredient: any): ingredient is IRecipeIngredientBody => {
+  return (
+    ingredient &&
+    typeof ingredient.name === 'string' && ingredient.name.trim().length > 0 &&
+    typeof ingredient.quantity === 'number' && ingredient.quantity > 0 &&
+    typeof ingredient.unit === 'string' && ingredient.unit.trim().length > 0
+  );
+};
+
+const validateBody = (body: any): body is IRequestBody => {
+  if (!body.name || typeof body.name !== 'string' || body.name.trim().length === 0) {
+    return false;
+  }
+
+  if (!Array.isArray(body.ingredients) || body.ingredients.length === 0) {
+    return false;
+  }
+
+  if (!body.ingredients.every(isValidIngredient)) {
+    return false;
+  }
+
+  return true;
+};
+
+export const getBody = (body: string | null): IRequestBody | null => {
+  if (!body) {
+    return null;
+  }
+
+  try {
+    const parsedBody = JSON.parse(body);
+    if (validateBody(parsedBody)) {
+      return parsedBody;
+    }
+  } catch (error) {
+    console.error('Failed to parse body:', error);
+  }
+
+  return null;
+};

--- a/packages/lambdas/sources/add_recipe/body/types.ts
+++ b/packages/lambdas/sources/add_recipe/body/types.ts
@@ -1,0 +1,12 @@
+import { GroceryItemUnit } from "@kairos-lambdas-libs/dynamodb/enums";
+
+export interface IRecipeIngredientBody {
+    name: string;
+    quantity: number;
+    unit: GroceryItemUnit;
+}
+
+export interface IRequestBody {
+    name: string;
+    ingredients: IRecipeIngredientBody[];
+}

--- a/packages/lambdas/sources/add_recipe/database/index.ts
+++ b/packages/lambdas/sources/add_recipe/database/index.ts
@@ -1,0 +1,26 @@
+import { DynamoDBTable, putItem } from "@kairos-lambdas-libs/dynamodb";
+import { IRecipeIngredientBody } from "../body/types";
+import { randomUUID } from "node:crypto";
+
+export const createRecipe = async (recipe: {
+  projectId: string;
+  name: string;
+  ingredients: IRecipeIngredientBody[];
+}): Promise<string> => {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+
+  await putItem({
+    tableName: DynamoDBTable.RECIPES,
+    item: {
+      id,
+      projectId: recipe.projectId,
+      name: recipe.name.trim(),
+      ingredients: JSON.stringify(recipe.ingredients),
+      createdAt: now,
+      updatedAt: now,
+    },
+  });
+
+  return id;
+};

--- a/packages/lambdas/sources/add_recipe/index.ts
+++ b/packages/lambdas/sources/add_recipe/index.ts
@@ -1,0 +1,35 @@
+import { APIGatewayProxyEvent, Handler } from "aws-lambda";
+import { middleware, AuthenticatedEvent } from "@kairos-lambdas-libs/middleware";
+import { createResponse } from "@kairos-lambdas-libs/response";
+import { getBody } from "./body";
+import { createRecipe } from "./database";
+
+export const handler: Handler<APIGatewayProxyEvent> = middleware(
+  async (event: AuthenticatedEvent) => {
+    const { projectId } = event;
+
+    if (!projectId) {
+      return createResponse({
+        statusCode: 400,
+        message: "Project ID is required",
+      });
+    }
+
+    const body = getBody(event.body);
+
+    if (!body) {
+      return createResponse({
+        statusCode: 400,
+      });
+    }
+
+    const { name, ingredients } = body;
+
+    const id = await createRecipe({ projectId, name, ingredients });
+
+    return createResponse({
+      statusCode: 201,
+      message: { id },
+    });
+  },
+);

--- a/packages/lambdas/sources/add_recipe/package.json
+++ b/packages/lambdas/sources/add_recipe/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "add_recipe",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@kairos-lambdas-libs/dynamodb": "1.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0"
+  }
+}

--- a/packages/lambdas/sources/delete_recipe/index.ts
+++ b/packages/lambdas/sources/delete_recipe/index.ts
@@ -1,0 +1,34 @@
+import { APIGatewayProxyEvent, Handler } from "aws-lambda";
+import { middleware, AuthenticatedEvent } from "@kairos-lambdas-libs/middleware";
+import { createResponse } from "@kairos-lambdas-libs/response";
+import { DynamoDBTable, deleteItem } from "@kairos-lambdas-libs/dynamodb";
+
+export const handler: Handler<APIGatewayProxyEvent> = middleware(
+  async (event: AuthenticatedEvent) => {
+    const { projectId } = event;
+
+    if (!projectId) {
+      return createResponse({
+        statusCode: 400,
+        message: "Project ID is required",
+      });
+    }
+
+    const { id } = event.pathParameters ?? {};
+
+    if (!id || typeof id !== "string") {
+      return createResponse({
+        statusCode: 400,
+      });
+    }
+
+    await deleteItem({
+      key: { id },
+      tableName: DynamoDBTable.RECIPES,
+    });
+
+    return createResponse({
+      statusCode: 200,
+    });
+  },
+);

--- a/packages/lambdas/sources/delete_recipe/package.json
+++ b/packages/lambdas/sources/delete_recipe/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "delete_recipe",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@kairos-lambdas-libs/dynamodb": "1.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0"
+  }
+}

--- a/packages/lambdas/sources/get_recipes/index.ts
+++ b/packages/lambdas/sources/get_recipes/index.ts
@@ -1,0 +1,33 @@
+import { APIGatewayProxyEvent, Handler } from "aws-lambda";
+import { middleware, AuthenticatedEvent } from "@kairos-lambdas-libs/middleware";
+import { createResponse } from "@kairos-lambdas-libs/response";
+import { DynamoDBTable, DynamoDBIndex, query } from "@kairos-lambdas-libs/dynamodb";
+
+export const handler: Handler<APIGatewayProxyEvent> = middleware(
+  async (event: AuthenticatedEvent) => {
+    const { projectId } = event;
+
+    if (!projectId) {
+      return createResponse({
+        statusCode: 400,
+        message: "Project ID is required",
+      });
+    }
+
+    const items = await query({
+      tableName: DynamoDBTable.RECIPES,
+      indexName: DynamoDBIndex.RECIPES_PROJECT,
+      attributes: { projectId },
+    });
+
+    const recipes = items.map((item) => ({
+      ...item,
+      ingredients: JSON.parse(item.ingredients || "[]"),
+    }));
+
+    return createResponse({
+      statusCode: 200,
+      message: recipes,
+    });
+  },
+);

--- a/packages/lambdas/sources/get_recipes/package.json
+++ b/packages/lambdas/sources/get_recipes/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "get_recipes",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@kairos-lambdas-libs/dynamodb": "1.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0"
+  }
+}

--- a/packages/lambdas/sources/update_recipe/body/index.ts
+++ b/packages/lambdas/sources/update_recipe/body/index.ts
@@ -1,0 +1,48 @@
+import { IRequestBody, IRecipeIngredientBody } from "./types";
+
+const isValidIngredient = (ingredient: any): ingredient is IRecipeIngredientBody => {
+  return (
+    ingredient &&
+    typeof ingredient.name === 'string' && ingredient.name.trim().length > 0 &&
+    typeof ingredient.quantity === 'number' && ingredient.quantity > 0 &&
+    typeof ingredient.unit === 'string' && ingredient.unit.trim().length > 0
+  );
+};
+
+const validateBody = (body: any): body is IRequestBody => {
+  if (!body.id || typeof body.id !== 'string') {
+    return false;
+  }
+
+  if (body.name !== undefined && (typeof body.name !== 'string' || body.name.trim().length === 0)) {
+    return false;
+  }
+
+  if (body.ingredients !== undefined) {
+    if (!Array.isArray(body.ingredients) || body.ingredients.length === 0) {
+      return false;
+    }
+    if (!body.ingredients.every(isValidIngredient)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const getBody = (body: string | null): IRequestBody | null => {
+  if (!body) {
+    return null;
+  }
+
+  try {
+    const parsedBody = JSON.parse(body);
+    if (validateBody(parsedBody)) {
+      return parsedBody;
+    }
+  } catch (error) {
+    console.error('Failed to parse body:', error);
+  }
+
+  return null;
+};

--- a/packages/lambdas/sources/update_recipe/body/types.ts
+++ b/packages/lambdas/sources/update_recipe/body/types.ts
@@ -1,0 +1,13 @@
+import { GroceryItemUnit } from "@kairos-lambdas-libs/dynamodb/enums";
+
+export interface IRecipeIngredientBody {
+    name: string;
+    quantity: number;
+    unit: GroceryItemUnit;
+}
+
+export interface IRequestBody {
+    id: string;
+    name?: string;
+    ingredients?: IRecipeIngredientBody[];
+}

--- a/packages/lambdas/sources/update_recipe/database/index.ts
+++ b/packages/lambdas/sources/update_recipe/database/index.ts
@@ -1,0 +1,25 @@
+import { DynamoDBTable, updateItem } from "@kairos-lambdas-libs/dynamodb";
+import { IRecipeIngredientBody } from "../body/types";
+
+export const updateRecipe = async (
+  id: string,
+  fields: { name?: string; ingredients?: IRecipeIngredientBody[] }
+): Promise<void> => {
+  const updatedFields: Record<string, any> = {
+    updatedAt: new Date().toISOString(),
+  };
+
+  if (fields.name !== undefined) {
+    updatedFields.name = fields.name.trim();
+  }
+
+  if (fields.ingredients !== undefined) {
+    updatedFields.ingredients = JSON.stringify(fields.ingredients);
+  }
+
+  await updateItem({
+    tableName: DynamoDBTable.RECIPES,
+    key: { id },
+    updatedFields,
+  });
+};

--- a/packages/lambdas/sources/update_recipe/index.ts
+++ b/packages/lambdas/sources/update_recipe/index.ts
@@ -1,0 +1,35 @@
+import { APIGatewayProxyEvent, Handler } from "aws-lambda";
+import { middleware, AuthenticatedEvent } from "@kairos-lambdas-libs/middleware";
+import { createResponse } from "@kairos-lambdas-libs/response";
+import { getBody } from "./body";
+import { updateRecipe } from "./database";
+
+export const handler: Handler<APIGatewayProxyEvent> = middleware(
+  async (event: AuthenticatedEvent) => {
+    const { projectId } = event;
+
+    if (!projectId) {
+      return createResponse({
+        statusCode: 400,
+        message: "Project ID is required",
+      });
+    }
+
+    const body = getBody(event.body);
+
+    if (!body) {
+      return createResponse({
+        statusCode: 400,
+      });
+    }
+
+    const { id, name, ingredients } = body;
+
+    await updateRecipe(id, { name, ingredients });
+
+    return createResponse({
+      statusCode: 200,
+      message: { id },
+    });
+  },
+);

--- a/packages/lambdas/sources/update_recipe/package.json
+++ b/packages/lambdas/sources/update_recipe/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "update_recipe",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@kairos-lambdas-libs/dynamodb": "1.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0"
+  }
+}

--- a/packages/web/src/api/recipes/add/index.ts
+++ b/packages/web/src/api/recipes/add/index.ts
@@ -1,0 +1,25 @@
+import { IRecipe, IRecipeIngredient } from '../../../types/recipe'
+import { API_BASE_URL } from '../../index'
+import { createFetchOptions } from '../../../utils/api'
+
+export const addRecipe = async (
+  recipe: { name: string; ingredients: IRecipeIngredient[] },
+  projectId?: string
+): Promise<IRecipe> => {
+  const response = await fetch(`${API_BASE_URL}/recipes`, createFetchOptions({
+    method: 'PUT',
+    body: JSON.stringify(recipe),
+  }, projectId))
+
+  if (response.ok) {
+    const data = await response.json()
+
+    if (data.id) {
+      return data
+    }
+
+    throw new Error('Unexpected response from API')
+  }
+
+  throw new Error('Failed to add recipe')
+}

--- a/packages/web/src/api/recipes/delete/index.ts
+++ b/packages/web/src/api/recipes/delete/index.ts
@@ -1,0 +1,12 @@
+import { API_BASE_URL } from '../../index'
+import { createFetchOptions } from '../../../utils/api'
+
+export const deleteRecipe = async (id: string, projectId?: string): Promise<void> => {
+  const response = await fetch(`${API_BASE_URL}/recipes/${id}`, createFetchOptions({
+    method: 'DELETE',
+  }, projectId))
+
+  if (!response.ok) {
+    throw new Error('Failed to delete recipe')
+  }
+}

--- a/packages/web/src/api/recipes/get/index.ts
+++ b/packages/web/src/api/recipes/get/index.ts
@@ -1,0 +1,13 @@
+import { IRecipe } from '../../../types/recipe'
+import { API_BASE_URL } from '../../index'
+import { createFetchOptions } from '../../../utils/api'
+
+export const getRecipes = async (projectId?: string): Promise<IRecipe[]> => {
+  const response = await fetch(`${API_BASE_URL}/recipes`, createFetchOptions({}, projectId))
+
+  if (response.ok) {
+    return await response.json()
+  }
+
+  return []
+}

--- a/packages/web/src/api/recipes/index.ts
+++ b/packages/web/src/api/recipes/index.ts
@@ -1,0 +1,4 @@
+export { addRecipe } from './add'
+export { getRecipes } from './get'
+export { updateRecipe } from './update'
+export { deleteRecipe } from './delete'

--- a/packages/web/src/api/recipes/update/index.ts
+++ b/packages/web/src/api/recipes/update/index.ts
@@ -1,0 +1,18 @@
+import { IRecipeIngredient } from '../../../types/recipe'
+import { API_BASE_URL } from '../../index'
+import { createFetchOptions } from '../../../utils/api'
+
+export const updateRecipe = async (
+  id: string,
+  fields: { name?: string; ingredients?: IRecipeIngredient[] },
+  projectId?: string
+): Promise<void> => {
+  const response = await fetch(`${API_BASE_URL}/recipes/${id}`, createFetchOptions({
+    method: 'POST',
+    body: JSON.stringify({ id, ...fields }),
+  }, projectId))
+
+  if (!response.ok) {
+    throw new Error('Failed to update recipe')
+  }
+}

--- a/packages/web/src/components/ModernPageHeader/index.tsx
+++ b/packages/web/src/components/ModernPageHeader/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { IconButton, Tooltip } from '@mui/material'
+import { Tooltip } from '@mui/material'
 import { 
   HeaderWrapper,
   HeaderCard, 
@@ -12,6 +12,14 @@ import {
   StatLabel 
 } from './index.styled'
 
+export interface ActionButtonProps {
+  icon: React.ReactNode
+  onClick: () => void
+  tooltip: string
+  ariaLabel: string
+  label?: string
+}
+
 export interface ModernPageHeaderProps {
   title: string
   icon: React.ReactNode
@@ -20,19 +28,56 @@ export interface ModernPageHeaderProps {
     label: string
     wide?: boolean
   }>
-  actionButton?: {
-    icon: React.ReactNode
-    onClick: () => void
-    tooltip: string
-    ariaLabel: string
-  }
+  actionButton?: ActionButtonProps
+  secondaryActionButton?: ActionButtonProps
 }
+
+const ActionButtonItem: React.FC<ActionButtonProps> = ({ icon, onClick, tooltip, ariaLabel, label }) => (
+  <Tooltip title={tooltip}>
+    <div
+      onClick={onClick}
+      role="button"
+      aria-label={ariaLabel}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        background: 'rgba(102, 126, 234, 0.08)',
+        borderRadius: '8px',
+        padding: label ? '0.375rem 0.75rem' : '0.375rem',
+        border: '1px solid rgba(102, 126, 234, 0.15)',
+        cursor: 'pointer',
+        transition: 'all 0.2s ease',
+      } as React.CSSProperties}
+      onMouseEnter={(e) => {
+        const target = e.currentTarget as HTMLDivElement
+        target.style.background = 'rgba(102, 126, 234, 0.12)'
+        target.style.borderColor = 'rgba(102, 126, 234, 0.25)'
+      }}
+      onMouseLeave={(e) => {
+        const target = e.currentTarget as HTMLDivElement
+        target.style.background = 'rgba(102, 126, 234, 0.08)'
+        target.style.borderColor = 'rgba(102, 126, 234, 0.15)'
+      }}
+    >
+      <div style={{ fontSize: '1rem', display: 'flex', alignItems: 'center' }}>
+        {icon}
+      </div>
+      {label && (
+        <span style={{ fontSize: '0.75rem', fontWeight: '500', color: '#667eea', whiteSpace: 'nowrap' }}>
+          {label}
+        </span>
+      )}
+    </div>
+  </Tooltip>
+)
 
 const ModernPageHeader: React.FC<ModernPageHeaderProps> = ({
   title,
   icon,
   stats,
-  actionButton
+  actionButton,
+  secondaryActionButton,
 }) => {
   return (
     <HeaderWrapper>
@@ -46,46 +91,11 @@ const ModernPageHeader: React.FC<ModernPageHeaderProps> = ({
               <HeaderTitle>{title}</HeaderTitle>
             </div>
             
-            {actionButton && (
-              <Tooltip title={actionButton.tooltip}>
-                <div
-                  onClick={actionButton.onClick}
-                  role="button"
-                  aria-label={actionButton.ariaLabel}
-                  style={{
-                    display: 'flex', 
-                    alignItems: 'center', 
-                    gap: '0.5rem',
-                    background: 'rgba(102, 126, 234, 0.08)',
-                    borderRadius: '8px',
-                    padding: '0.375rem 0.75rem',
-                    border: '1px solid rgba(102, 126, 234, 0.15)',
-                    cursor: 'pointer',
-                    transition: 'all 0.2s ease'
-                  } as React.CSSProperties}
-                onMouseEnter={(e) => {
-                  const target = e.currentTarget as HTMLDivElement;
-                  target.style.background = 'rgba(102, 126, 234, 0.12)';
-                  target.style.borderColor = 'rgba(102, 126, 234, 0.25)';
-                }}
-                onMouseLeave={(e) => {
-                  const target = e.currentTarget as HTMLDivElement;
-                  target.style.background = 'rgba(102, 126, 234, 0.08)';
-                  target.style.borderColor = 'rgba(102, 126, 234, 0.15)';
-                }}>
-                  <div style={{ fontSize: '1rem', display: 'flex', alignItems: 'center' }}>
-                    {actionButton.icon}
-                  </div>
-                  <span style={{ 
-                    fontSize: '0.75rem', 
-                    fontWeight: '500',
-                    color: '#667eea',
-                    whiteSpace: 'nowrap'
-                  }}>
-                    Switch Shop
-                  </span>
-                </div>
-              </Tooltip>
+            {(actionButton || secondaryActionButton) && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                {secondaryActionButton && <ActionButtonItem {...secondaryActionButton} />}
+                {actionButton && <ActionButtonItem {...actionButton} />}
+              </div>
             )}
           </div>
           

--- a/packages/web/src/components/RecipeDrawer/index.styled.tsx
+++ b/packages/web/src/components/RecipeDrawer/index.styled.tsx
@@ -1,0 +1,51 @@
+import { styled } from '@mui/material/styles'
+import { Box } from '@mui/material'
+
+export const DrawerHeader = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '1rem 1.25rem',
+  borderBottom: '1px solid rgba(0, 0, 0, 0.06)',
+  flexShrink: 0,
+})
+
+export const DrawerHeaderLeft = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+})
+
+export const DrawerIconBox = styled(Box)({
+  width: '2.25rem',
+  height: '2.25rem',
+  borderRadius: '10px',
+  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  '& .MuiSvgIcon-root': {
+    fontSize: '1.2rem',
+    color: 'white',
+  },
+})
+
+export const DrawerTitle = styled('span')({
+  fontSize: '1.1rem',
+  fontWeight: '700',
+  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  WebkitBackgroundClip: 'text',
+  WebkitTextFillColor: 'transparent',
+  backgroundClip: 'text',
+  letterSpacing: '0.3px',
+})
+
+export const ContentContainer = styled(Box)({
+  flex: 1,
+  overflowY: 'auto',
+  padding: '1rem 1.25rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+})

--- a/packages/web/src/components/RecipeDrawer/index.tsx
+++ b/packages/web/src/components/RecipeDrawer/index.tsx
@@ -1,0 +1,177 @@
+import { useState, useCallback, useRef } from 'react'
+import { Box, Drawer, IconButton } from '@mui/material'
+import MenuBookIcon from '@mui/icons-material/MenuBook'
+import AddIcon from '@mui/icons-material/Add'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { IRecipe, IRecipeIngredient } from '../../types/recipe'
+import RecipeList from '../RecipeList'
+import RecipeForm from '../RecipeForm'
+import {
+  DrawerHeader,
+  DrawerHeaderLeft,
+  DrawerIconBox,
+  DrawerTitle,
+  ContentContainer,
+} from './index.styled'
+
+const DRAG_CLOSE_THRESHOLD = 100
+
+interface RecipeDrawerProps {
+  open: boolean
+  onClose: () => void
+  shopId?: string
+}
+
+const RecipeDrawer = ({ open, onClose, shopId }: RecipeDrawerProps) => {
+  const [view, setView] = useState<'list' | 'form'>('list')
+  const [editingRecipe, setEditingRecipe] = useState<IRecipe | null>(null)
+  const [dragOffset, setDragOffset] = useState(0)
+  const isDragging = useRef(false)
+  const dragStartY = useRef(0)
+
+  const handleAddClick = useCallback(() => {
+    setEditingRecipe(null)
+    setView('form')
+  }, [])
+
+  const handleEditRecipe = useCallback((recipe: IRecipe) => {
+    setEditingRecipe(recipe)
+    setView('form')
+  }, [])
+
+  const handleFormDone = useCallback(() => {
+    setEditingRecipe(null)
+    setView('list')
+  }, [])
+
+  const handleClose = useCallback(() => {
+    setView('list')
+    setEditingRecipe(null)
+    onClose()
+  }, [onClose])
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    isDragging.current = true
+    dragStartY.current = e.clientY
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [])
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging.current) return
+    const offset = Math.max(0, e.clientY - dragStartY.current)
+    setDragOffset(offset)
+  }, [])
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (isDragging.current) {
+      const finalOffset = Math.max(0, e.clientY - dragStartY.current)
+      if (finalOffset >= DRAG_CLOSE_THRESHOLD) {
+        handleClose()
+      }
+    }
+    isDragging.current = false
+    setDragOffset(0)
+  }, [handleClose])
+
+  return (
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={handleClose}
+      transitionDuration={{ enter: 350, exit: 300 }}
+      PaperProps={{
+        sx: {
+          height: 'calc(100% - env(safe-area-inset-top) - 16px)',
+          borderRadius: '16px 16px 0 0',
+          overflow: 'hidden',
+          background: 'transparent',
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          paddingBottom: 'env(safe-area-inset-bottom)',
+          bgcolor: 'background.paper',
+          transform: `translateY(${dragOffset}px)`,
+          transition: isDragging.current
+            ? 'transform 0s'
+            : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        }}
+      >
+        <Box
+          role="button"
+          aria-label="Drag to close"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          sx={{
+            width: '100%',
+            flexShrink: 0,
+            cursor: 'grab',
+            touchAction: 'none',
+            userSelect: 'none',
+            '& *': { touchAction: 'none', userSelect: 'none' },
+            '&:active': { cursor: 'grabbing' },
+          }}
+        >
+          <Box
+            sx={{
+              width: '100%',
+              display: 'flex',
+              justifyContent: 'center',
+              pt: '10px',
+              pb: '2px',
+            }}
+          >
+            <Box
+              sx={{
+                width: '36px',
+                height: '4px',
+                borderRadius: '2px',
+                background: 'rgba(0,0,0,0.15)',
+              }}
+            />
+          </Box>
+          <DrawerHeader>
+            <DrawerHeaderLeft>
+              {view === 'form' && (
+                <IconButton size="small" onClick={handleFormDone} aria-label="Back to recipes">
+                  <ArrowBackIcon />
+                </IconButton>
+              )}
+              <DrawerIconBox>
+                <MenuBookIcon />
+              </DrawerIconBox>
+              <DrawerTitle>{view === 'form' ? (editingRecipe ? 'Edit Recipe' : 'New Recipe') : 'Recipes'}</DrawerTitle>
+            </DrawerHeaderLeft>
+            {view === 'list' && (
+              <IconButton onClick={handleAddClick} aria-label="Add recipe" size="small">
+                <AddIcon />
+              </IconButton>
+            )}
+          </DrawerHeader>
+        </Box>
+
+        <ContentContainer>
+          {view === 'list' ? (
+            <RecipeList
+              onEditRecipe={handleEditRecipe}
+              onUseRecipe={handleClose}
+              shopId={shopId}
+            />
+          ) : (
+            <RecipeForm
+              initialRecipe={editingRecipe}
+              onDone={handleFormDone}
+            />
+          )}
+        </ContentContainer>
+      </Box>
+    </Drawer>
+  )
+}
+
+export default RecipeDrawer

--- a/packages/web/src/components/RecipeForm/index.styled.tsx
+++ b/packages/web/src/components/RecipeForm/index.styled.tsx
@@ -1,0 +1,28 @@
+import { styled } from '@mui/material/styles'
+import { Box } from '@mui/material'
+
+export const FormContainer = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem',
+})
+
+export const IngredientRow = styled(Box)({
+  display: 'grid',
+  gridTemplateColumns: '1fr 80px 100px 36px',
+  gap: '0.5rem',
+  alignItems: 'center',
+})
+
+export const IngredientsSection = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.75rem',
+})
+
+export const FormActions = styled(Box)({
+  display: 'flex',
+  gap: '0.75rem',
+  justifyContent: 'flex-end',
+  paddingTop: '0.5rem',
+})

--- a/packages/web/src/components/RecipeForm/index.tsx
+++ b/packages/web/src/components/RecipeForm/index.tsx
@@ -1,0 +1,181 @@
+import { useState, useCallback } from 'react'
+import {
+  TextField,
+  Button,
+  IconButton,
+  MenuItem,
+  Select,
+  InputLabel,
+  FormControl,
+  Typography,
+} from '@mui/material'
+import DeleteIcon from '@mui/icons-material/Delete'
+import AddIcon from '@mui/icons-material/Add'
+import { IRecipe, IRecipeIngredient } from '../../types/recipe'
+import { GroceryItemUnit, GroceryItemUnitLabelMap } from '../../enums/groceryItem'
+import { useRecipeContext } from '../../providers/RecipeProvider'
+import { useAppState } from '../../providers/AppStateProvider'
+import { showAlert } from '../../utils/alert'
+import { FormContainer, IngredientRow, IngredientsSection, FormActions } from './index.styled'
+
+interface RecipeFormProps {
+  initialRecipe?: IRecipe | null
+  onDone: () => void
+}
+
+const DEFAULT_INGREDIENT: IRecipeIngredient = {
+  name: '',
+  quantity: 1,
+  unit: GroceryItemUnit.UNIT,
+}
+
+const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
+  const { addRecipe, updateRecipe } = useRecipeContext()
+  const { dispatch } = useAppState()
+  const [name, setName] = useState(initialRecipe?.name ?? '')
+  const [ingredients, setIngredients] = useState<IRecipeIngredient[]>(
+    initialRecipe?.ingredients ?? [{ ...DEFAULT_INGREDIENT }]
+  )
+  const [isSaving, setIsSaving] = useState(false)
+
+  const handleIngredientChange = useCallback(
+    (index: number, field: keyof IRecipeIngredient, value: string | number) => {
+      setIngredients((prev) =>
+        prev.map((ing, i) =>
+          i === index ? { ...ing, [field]: value } : ing
+        )
+      )
+    },
+    []
+  )
+
+  const handleAddIngredient = useCallback(() => {
+    setIngredients((prev) => [...prev, { ...DEFAULT_INGREDIENT }])
+  }, [])
+
+  const handleRemoveIngredient = useCallback((index: number) => {
+    setIngredients((prev) => prev.filter((_, i) => i !== index))
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      showAlert({ description: 'Recipe name is required', severity: 'error' }, dispatch)
+      return
+    }
+
+    const validIngredients = ingredients.filter((ing) => ing.name.trim().length > 0)
+    if (validIngredients.length === 0) {
+      showAlert({ description: 'At least one ingredient is required', severity: 'error' }, dispatch)
+      return
+    }
+
+    setIsSaving(true)
+    try {
+      if (initialRecipe) {
+        await updateRecipe(initialRecipe.id, { name: trimmedName, ingredients: validIngredients })
+        showAlert({ description: 'Recipe updated', severity: 'success' }, dispatch)
+      } else {
+        await addRecipe(trimmedName, validIngredients)
+        showAlert({ description: 'Recipe added', severity: 'success' }, dispatch)
+      }
+      onDone()
+    } catch (error) {
+      showAlert({ description: 'Failed to save recipe', severity: 'error' }, dispatch)
+    } finally {
+      setIsSaving(false)
+    }
+  }, [name, ingredients, initialRecipe, addRecipe, updateRecipe, dispatch, onDone])
+
+  return (
+    <FormContainer>
+      <TextField
+        label="Recipe name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        fullWidth
+        size="small"
+        placeholder="e.g. Pasta Carbonara"
+      />
+
+      <IngredientsSection>
+        <Typography variant="body2" fontWeight={600} color="text.secondary">
+          Ingredients
+        </Typography>
+
+        {ingredients.map((ingredient, index) => (
+          <IngredientRow key={index}>
+            <TextField
+              label="Name"
+              value={ingredient.name}
+              onChange={(e) => handleIngredientChange(index, 'name', e.target.value)}
+              size="small"
+              placeholder="e.g. Milk"
+            />
+            <TextField
+              label="Qty"
+              type="number"
+              value={ingredient.quantity}
+              onChange={(e) => handleIngredientChange(index, 'quantity', Number(e.target.value))}
+              size="small"
+              inputProps={{ min: 0.1, step: 0.1 }}
+            />
+            <FormControl size="small">
+              <InputLabel>Unit</InputLabel>
+              <Select
+                label="Unit"
+                value={ingredient.unit}
+                onChange={(e) => handleIngredientChange(index, 'unit', e.target.value)}
+              >
+                {Object.values(GroceryItemUnit).map((unit) => (
+                  <MenuItem key={unit} value={unit}>
+                    {GroceryItemUnitLabelMap[unit]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <IconButton
+              size="small"
+              onClick={() => handleRemoveIngredient(index)}
+              disabled={ingredients.length === 1}
+              aria-label={`Remove ingredient ${index + 1}`}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </IngredientRow>
+        ))}
+
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={handleAddIngredient}
+          sx={{ alignSelf: 'flex-start', borderRadius: '8px' }}
+        >
+          Add Ingredient
+        </Button>
+      </IngredientsSection>
+
+      <FormActions>
+        <Button variant="outlined" onClick={onDone} disabled={isSaving} sx={{ borderRadius: '8px' }}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSave}
+          disabled={isSaving}
+          sx={{
+            borderRadius: '8px',
+            background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+            boxShadow: 'none',
+            '&:hover': { boxShadow: '0 4px 12px rgba(102, 126, 234, 0.4)' },
+          }}
+        >
+          {isSaving ? 'Saving...' : (initialRecipe ? 'Update' : 'Save Recipe')}
+        </Button>
+      </FormActions>
+    </FormContainer>
+  )
+}
+
+export default RecipeForm

--- a/packages/web/src/components/RecipeItem/index.styled.tsx
+++ b/packages/web/src/components/RecipeItem/index.styled.tsx
@@ -1,0 +1,25 @@
+import { styled } from '@mui/material/styles'
+import { Box, Paper } from '@mui/material'
+
+export const RecipeCard = styled(Paper)({
+  padding: '1rem',
+  borderRadius: '12px',
+  border: '1px solid rgba(102, 126, 234, 0.1)',
+  background: 'rgba(102, 126, 234, 0.03)',
+  boxShadow: 'none',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+})
+
+export const RecipeCardHeader = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+})
+
+export const RecipeCardActions = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+})

--- a/packages/web/src/components/RecipeItem/index.tsx
+++ b/packages/web/src/components/RecipeItem/index.tsx
@@ -1,0 +1,122 @@
+import { useState, useCallback } from 'react'
+import { Typography, IconButton, Button, Chip, Tooltip } from '@mui/material'
+import EditIcon from '@mui/icons-material/Edit'
+import DeleteIcon from '@mui/icons-material/Delete'
+import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart'
+import { IRecipe } from '../../types/recipe'
+import { useRecipeContext } from '../../providers/RecipeProvider'
+import { useProjectContext } from '../../providers/ProjectProvider'
+import { addGroceryItem } from '../../api/groceryList'
+import { useAppState } from '../../providers/AppStateProvider'
+import { showAlert } from '../../utils/alert'
+import { RecipeCard, RecipeCardHeader, RecipeCardActions } from './index.styled'
+
+interface RecipeItemProps {
+  recipe: IRecipe
+  onEdit: (recipe: IRecipe) => void
+  onUseRecipe: () => void
+  shopId?: string
+}
+
+const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId }: RecipeItemProps) => {
+  const { removeRecipe } = useRecipeContext()
+  const { currentProject } = useProjectContext()
+  const { dispatch } = useAppState()
+  const [isAdding, setIsAdding] = useState(false)
+
+  const handleUseRecipe = useCallback(async () => {
+    if (!currentProject || !shopId || shopId === 'all') return
+
+    setIsAdding(true)
+    try {
+      await Promise.all(
+        recipe.ingredients.map((ingredient) =>
+          addGroceryItem(
+            {
+              name: ingredient.name,
+              quantity: ingredient.quantity,
+              unit: ingredient.unit,
+              shopId,
+              imagePath: '',
+            },
+            currentProject.id
+          )
+        )
+      )
+      showAlert({ description: `${recipe.name} ingredients added to your list!`, severity: 'success' }, dispatch)
+      onUseRecipe()
+    } catch (error) {
+      showAlert({ description: 'Failed to add ingredients', severity: 'error' }, dispatch)
+    } finally {
+      setIsAdding(false)
+    }
+  }, [currentProject, shopId, recipe, dispatch, onUseRecipe])
+
+  const handleDelete = useCallback(async () => {
+    try {
+      await removeRecipe(recipe.id)
+    } catch (error) {
+      showAlert({ description: 'Failed to delete recipe', severity: 'error' }, dispatch)
+    }
+  }, [recipe.id, removeRecipe, dispatch])
+
+  const canUseRecipe = shopId && shopId !== 'all'
+
+  return (
+    <RecipeCard>
+      <RecipeCardHeader>
+        <Typography variant="body1" fontWeight={600}>
+          {recipe.name}
+        </Typography>
+        <RecipeCardActions>
+          <Tooltip title="Edit recipe">
+            <IconButton size="small" onClick={() => onEdit(recipe)} aria-label={`Edit ${recipe.name}`}>
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Delete recipe">
+            <IconButton size="small" onClick={handleDelete} aria-label={`Delete ${recipe.name}`}>
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </RecipeCardActions>
+      </RecipeCardHeader>
+
+      <Chip
+        label={`${recipe.ingredients.length} ingredient${recipe.ingredients.length !== 1 ? 's' : ''}`}
+        size="small"
+        sx={{
+          alignSelf: 'flex-start',
+          background: 'rgba(102, 126, 234, 0.1)',
+          color: '#667eea',
+          fontWeight: 500,
+          fontSize: '0.7rem',
+        }}
+      />
+
+      <Tooltip title={canUseRecipe ? `Add all ingredients to current shop's list` : 'Open a specific shop to use this recipe'}>
+        <span>
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<AddShoppingCartIcon />}
+            onClick={handleUseRecipe}
+            disabled={isAdding || !canUseRecipe}
+            sx={{
+              mt: 0.5,
+              borderRadius: '8px',
+              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+              boxShadow: 'none',
+              '&:hover': { boxShadow: '0 4px 12px rgba(102, 126, 234, 0.4)' },
+              '&:disabled': { background: 'rgba(0,0,0,0.12)' },
+            }}
+          >
+            {isAdding ? 'Adding...' : 'Use Recipe'}
+          </Button>
+        </span>
+      </Tooltip>
+    </RecipeCard>
+  )
+}
+
+export default RecipeItem

--- a/packages/web/src/components/RecipeList/index.tsx
+++ b/packages/web/src/components/RecipeList/index.tsx
@@ -1,0 +1,62 @@
+import { Box, Typography } from '@mui/material'
+import MenuBookIcon from '@mui/icons-material/MenuBook'
+import { IRecipe } from '../../types/recipe'
+import { useRecipeContext } from '../../providers/RecipeProvider'
+import RecipeItem from '../RecipeItem'
+
+interface RecipeListProps {
+  onEditRecipe: (recipe: IRecipe) => void
+  onUseRecipe: () => void
+  shopId?: string
+}
+
+const RecipeList = ({ onEditRecipe, onUseRecipe, shopId }: RecipeListProps) => {
+  const { recipes, isLoading } = useRecipeContext()
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+        <Typography color="text.secondary">Loading recipes...</Typography>
+      </Box>
+    )
+  }
+
+  if (recipes.length === 0) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          py: 6,
+          gap: 1.5,
+        }}
+      >
+        <MenuBookIcon sx={{ fontSize: '3rem', color: 'rgba(102, 126, 234, 0.4)' }} />
+        <Typography variant="body1" fontWeight={600} color="text.secondary">
+          No recipes yet
+        </Typography>
+        <Typography variant="body2" color="text.disabled" textAlign="center">
+          Add your first recipe using the + button above
+        </Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+      {recipes.map((recipe) => (
+        <RecipeItem
+          key={recipe.id}
+          recipe={recipe}
+          onEdit={onEditRecipe}
+          onUseRecipe={onUseRecipe}
+          shopId={shopId}
+        />
+      ))}
+    </Box>
+  )
+}
+
+export default RecipeList

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -11,6 +11,7 @@ import { AppStateProvider } from './providers/AppStateProvider'
 import { BrowserRouter } from 'react-router'
 import AuthProvider from './providers/AuthProvider'
 import { ProjectProvider } from './providers/ProjectProvider'
+import { RecipeProvider } from './providers/RecipeProvider'
 
 const requestPersistentStorage = async (): Promise<void> => {
   if (navigator.storage && navigator.storage.persist) {
@@ -34,9 +35,11 @@ if (container) {
       <AuthProvider>
         <ProjectProvider>
           <AppStateProvider>
-            <BrowserRouter>
-              <App />
-            </BrowserRouter>
+            <RecipeProvider>
+              <BrowserRouter>
+                <App />
+              </BrowserRouter>
+            </RecipeProvider>
           </AppStateProvider>
         </ProjectProvider>
       </AuthProvider>

--- a/packages/web/src/providers/RecipeProvider/index.tsx
+++ b/packages/web/src/providers/RecipeProvider/index.tsx
@@ -1,0 +1,96 @@
+import { createContext, useContext, useState, useCallback, useLayoutEffect, useMemo } from 'react'
+import { IRecipe, IRecipeIngredient } from '../../types/recipe'
+import { getRecipes, addRecipe as addRecipeApi, updateRecipe as updateRecipeApi, deleteRecipe } from '../../api/recipes'
+import { IState, IRecipeProviderProps } from './types'
+import { useProjectContext } from '../ProjectProvider'
+
+const initialState: IState = {
+  recipes: [],
+  isLoading: false,
+  fetchRecipes: async () => {},
+  addRecipe: async () => {},
+  updateRecipe: async () => {},
+  removeRecipe: async () => {},
+}
+
+export const RecipeContext = createContext<IState>(initialState)
+
+export const useRecipeContext = () => useContext(RecipeContext)
+
+export const RecipeProvider = ({ children }: IRecipeProviderProps) => {
+  const { currentProject } = useProjectContext()
+  const [recipes, setRecipes] = useState<IRecipe[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  const fetchRecipes = useCallback(async () => {
+    if (!currentProject) return
+
+    try {
+      setIsLoading(true)
+      const items = await getRecipes(currentProject.id)
+      setRecipes(items)
+    } catch (error) {
+      console.error('Failed to fetch recipes:', error)
+      setRecipes([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [currentProject])
+
+  const addRecipe = useCallback(async (name: string, ingredients: IRecipeIngredient[]) => {
+    if (!currentProject) return
+
+    const result = await addRecipeApi({ name, ingredients }, currentProject.id)
+    const newRecipe: IRecipe = {
+      ...result,
+      name,
+      ingredients,
+      projectId: currentProject.id,
+    }
+    setRecipes((prev) => [...prev, newRecipe])
+  }, [currentProject])
+
+  const updateRecipe = useCallback(async (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[] }) => {
+    if (!currentProject) return
+
+    await updateRecipeApi(id, fields, currentProject.id)
+    setRecipes((prev) =>
+      prev.map((recipe) =>
+        recipe.id === id ? { ...recipe, ...fields } : recipe
+      )
+    )
+  }, [currentProject])
+
+  const removeRecipe = useCallback(async (id: string) => {
+    if (!currentProject) return
+
+    await deleteRecipe(id, currentProject.id)
+    setRecipes((prev) => prev.filter((recipe) => recipe.id !== id))
+  }, [currentProject])
+
+  useLayoutEffect(() => {
+    if (currentProject) {
+      fetchRecipes()
+    } else {
+      setRecipes([])
+    }
+  }, [currentProject, fetchRecipes])
+
+  const value = useMemo(
+    () => ({
+      recipes,
+      isLoading,
+      fetchRecipes,
+      addRecipe,
+      updateRecipe,
+      removeRecipe,
+    }),
+    [recipes, isLoading, fetchRecipes, addRecipe, updateRecipe, removeRecipe]
+  )
+
+  return (
+    <RecipeContext.Provider value={value}>
+      {children}
+    </RecipeContext.Provider>
+  )
+}

--- a/packages/web/src/providers/RecipeProvider/types.ts
+++ b/packages/web/src/providers/RecipeProvider/types.ts
@@ -1,0 +1,14 @@
+import { IRecipe, IRecipeIngredient } from '../../types/recipe'
+
+export interface IState {
+  recipes: IRecipe[]
+  isLoading: boolean
+  fetchRecipes: () => Promise<void>
+  addRecipe: (name: string, ingredients: IRecipeIngredient[]) => Promise<void>
+  updateRecipe: (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[] }) => Promise<void>
+  removeRecipe: (id: string) => Promise<void>
+}
+
+export interface IRecipeProviderProps {
+  children: React.ReactNode
+}

--- a/packages/web/src/routes/GroceryListRoute/index.tsx
+++ b/packages/web/src/routes/GroceryListRoute/index.tsx
@@ -10,8 +10,10 @@ import SortByAlphaIcon from '@mui/icons-material/SortByAlpha'
 import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore'
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess'
 import StorefrontIcon from '@mui/icons-material/Storefront'
+import MenuBookIcon from '@mui/icons-material/MenuBook'
 import { Container, ScrollableContainer } from './index.styled'
 import { useState, useCallback, useMemo } from 'react'
+import RecipeDrawer from '../../components/RecipeDrawer'
 import { useParams, useNavigate } from 'react-router'
 import { removeGroceryItems } from '../../api/groceryList'
 import { showAlert } from '../../utils/alert'
@@ -45,6 +47,7 @@ const GroceryListContent = () => {
   
   const [allExpanded, setAllExpanded] = useState<boolean>(true)
   const [expandKey, setExpandKey] = useState<number>(0)
+  const [recipeDrawerOpen, setRecipeDrawerOpen] = useState(false)
   const toggleAll = useCallback(() => {
     setAllExpanded((v) => !v)
     setExpandKey((k) => k + 1)
@@ -105,7 +108,14 @@ const GroceryListContent = () => {
           icon: <StorefrontIcon />,
           onClick: handleBackToShops,
           tooltip: "Back to Shops",
-          ariaLabel: "Navigate back to shops list"
+          ariaLabel: "Navigate back to shops list",
+          label: "Switch Shop",
+        }}
+        secondaryActionButton={{
+          icon: <MenuBookIcon />,
+          onClick: () => setRecipeDrawerOpen(true),
+          tooltip: "Browse recipes",
+          ariaLabel: "Open recipe book",
         }}
       />
       <Container>
@@ -136,6 +146,11 @@ const GroceryListContent = () => {
           <GroceryList allExpanded={allExpanded} expandKey={expandKey} shopId={shopId} />
         </ScrollableContainer>
       </Container>
+      <RecipeDrawer
+        open={recipeDrawerOpen}
+        onClose={() => setRecipeDrawerOpen(false)}
+        shopId={shopId}
+      />
     </StandardLayout>
   )
 }

--- a/packages/web/src/types/recipe.ts
+++ b/packages/web/src/types/recipe.ts
@@ -1,0 +1,16 @@
+import { GroceryItemUnit } from '../enums/groceryItem'
+
+export interface IRecipeIngredient {
+    name: string
+    quantity: number
+    unit: GroceryItemUnit
+}
+
+export interface IRecipe {
+    id: string
+    projectId: string
+    name: string
+    ingredients: IRecipeIngredient[]
+    createdAt: string
+    updatedAt: string
+}


### PR DESCRIPTION
Recipes allow users to save named ingredient lists and add them to the active grocery list in one tap. Accessible via a recipe-book icon in the grocery list page header, opening a bottom drawer UI.

Frontend:
- New IRecipe / IRecipeIngredient types
- RecipeProvider context for CRUD state management
- RecipeDrawer (bottom drawer, drag-to-close), RecipeList, RecipeItem, RecipeForm components
- api/recipes layer (add/get/update/delete)
- ModernPageHeader extended with secondaryActionButton + label prop (also fixes hardcoded "Switch Shop" text)
- GroceryListRoute integrates drawer with recipe-book icon button

Backend:
- 4 new Lambda sources: add_recipe, get_recipes, update_recipe, delete_recipe
- DynamoDB Recipes table with ProjectRecipesIndex GSI
- RECIPES enum added to DynamoDBTable + DynamoDBIndex
- OpenAPI spec for /recipes and /recipes/{id} endpoints
- IAM policies, lambda locals, and main.tf wired up for new resources

https://claude.ai/code/session_01H2JSmc7daRrTVbU6ffV5tT