### PR TITLE
Add step-by-step instructions to recipes

### DIFF
--- a/packages/lambdas/libs/dynamodb/types/recipes/index.ts
+++ b/packages/lambdas/libs/dynamodb/types/recipes/index.ts
@@ -12,6 +12,7 @@ export interface IRecipe {
     name: string
     imagePath?: string
     ingredients: string  // JSON-serialized IRecipeIngredient[]
+    instructions?: string  // JSON-serialized string[]
     createdAt: string
     updatedAt: string
 }

--- a/packages/lambdas/sources/add_recipe/body/types.ts
+++ b/packages/lambdas/sources/add_recipe/body/types.ts
@@ -9,5 +9,6 @@ export interface IRecipeIngredientBody {
 export interface IRequestBody {
     name: string;
     ingredients: IRecipeIngredientBody[];
+    instructions?: string[];
     imagePath?: string;
 }

--- a/packages/lambdas/sources/add_recipe/database/index.ts
+++ b/packages/lambdas/sources/add_recipe/database/index.ts
@@ -6,6 +6,7 @@ export const createRecipe = async (recipe: {
   projectId: string;
   name: string;
   ingredients: IRecipeIngredientBody[];
+  instructions?: string[];
   imagePath?: string;
 }): Promise<string> => {
   const id = randomUUID();
@@ -19,6 +20,10 @@ export const createRecipe = async (recipe: {
     createdAt: now,
     updatedAt: now,
   };
+
+  if (recipe.instructions && recipe.instructions.length > 0) {
+    item.instructions = JSON.stringify(recipe.instructions);
+  }
 
   if (recipe.imagePath) {
     item.imagePath = recipe.imagePath;

--- a/packages/lambdas/sources/add_recipe/index.ts
+++ b/packages/lambdas/sources/add_recipe/index.ts
@@ -23,9 +23,9 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
       });
     }
 
-    const { name, ingredients, imagePath } = body;
+    const { name, ingredients, instructions, imagePath } = body;
 
-    const id = await createRecipe({ projectId, name, ingredients, imagePath });
+    const id = await createRecipe({ projectId, name, ingredients, instructions, imagePath });
 
     return createResponse({
       statusCode: 201,

--- a/packages/lambdas/sources/get_recipes/index.ts
+++ b/packages/lambdas/sources/get_recipes/index.ts
@@ -23,6 +23,7 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
     const recipes = items.map((item) => ({
       ...item,
       ingredients: JSON.parse(item.ingredients || "[]"),
+      instructions: item.instructions ? JSON.parse(item.instructions) : undefined,
     }));
 
     return createResponse({

--- a/packages/lambdas/sources/update_recipe/body/types.ts
+++ b/packages/lambdas/sources/update_recipe/body/types.ts
@@ -10,5 +10,6 @@ export interface IRequestBody {
     id: string;
     name?: string;
     ingredients?: IRecipeIngredientBody[];
+    instructions?: string[];
     imagePath?: string;
 }

--- a/packages/lambdas/sources/update_recipe/database/index.ts
+++ b/packages/lambdas/sources/update_recipe/database/index.ts
@@ -3,7 +3,7 @@ import { IRecipeIngredientBody } from "../body/types";
 
 export const updateRecipe = async (
   id: string,
-  fields: { name?: string; ingredients?: IRecipeIngredientBody[]; imagePath?: string }
+  fields: { name?: string; ingredients?: IRecipeIngredientBody[]; instructions?: string[]; imagePath?: string }
 ): Promise<void> => {
   const updatedFields: Record<string, any> = {
     updatedAt: new Date().toISOString(),
@@ -15,6 +15,12 @@ export const updateRecipe = async (
 
   if (fields.ingredients !== undefined) {
     updatedFields.ingredients = JSON.stringify(fields.ingredients);
+  }
+
+  if (fields.instructions !== undefined) {
+    updatedFields.instructions = fields.instructions.length > 0
+      ? JSON.stringify(fields.instructions)
+      : null;
   }
 
   if (fields.imagePath !== undefined) {

--- a/packages/lambdas/sources/update_recipe/index.ts
+++ b/packages/lambdas/sources/update_recipe/index.ts
@@ -23,9 +23,9 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
       });
     }
 
-    const { id, name, ingredients, imagePath } = body;
+    const { id, name, ingredients, instructions, imagePath } = body;
 
-    await updateRecipe(id, { name, ingredients, imagePath });
+    await updateRecipe(id, { name, ingredients, instructions, imagePath });
 
     return createResponse({
       statusCode: 200,

--- a/packages/web/src/api/recipes/add/index.ts
+++ b/packages/web/src/api/recipes/add/index.ts
@@ -3,7 +3,7 @@ import { API_BASE_URL } from '../../index'
 import { createFetchOptions } from '../../../utils/api'
 
 export const addRecipe = async (
-  recipe: { name: string; ingredients: IRecipeIngredient[]; imagePath?: string },
+  recipe: { name: string; ingredients: IRecipeIngredient[]; instructions?: string[]; imagePath?: string },
   projectId?: string
 ): Promise<IRecipe> => {
   const response = await fetch(`${API_BASE_URL}/recipes`, createFetchOptions({

--- a/packages/web/src/api/recipes/update/index.ts
+++ b/packages/web/src/api/recipes/update/index.ts
@@ -4,7 +4,7 @@ import { createFetchOptions } from '../../../utils/api'
 
 export const updateRecipe = async (
   id: string,
-  fields: { name?: string; ingredients?: IRecipeIngredient[]; imagePath?: string },
+  fields: { name?: string; ingredients?: IRecipeIngredient[]; instructions?: string[]; imagePath?: string },
   projectId?: string
 ): Promise<void> => {
   const response = await fetch(`${API_BASE_URL}/recipes/${id}`, createFetchOptions({

--- a/packages/web/src/components/RecipeForm/index.tsx
+++ b/packages/web/src/components/RecipeForm/index.tsx
@@ -41,6 +41,9 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
   const [ingredients, setIngredients] = useState<IRecipeIngredient[]>(
     initialRecipe?.ingredients ?? [{ ...DEFAULT_INGREDIENT }]
   )
+  const [instructions, setInstructions] = useState<string[]>(
+    initialRecipe?.instructions ?? ['']
+  )
   const [isSaving, setIsSaving] = useState(false)
   const [previewUrl, setPreviewUrl] = useState<string | null>(initialRecipe?.imagePath ?? null)
   const [imagePath, setImagePath] = useState<string>(initialRecipe?.imagePath ?? '')
@@ -64,6 +67,18 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
 
   const handleRemoveIngredient = useCallback((index: number) => {
     setIngredients((prev) => prev.filter((_, i) => i !== index))
+  }, [])
+
+  const handleInstructionChange = useCallback((index: number, value: string) => {
+    setInstructions((prev) => prev.map((step, i) => i === index ? value : step))
+  }, [])
+
+  const handleAddInstruction = useCallback(() => {
+    setInstructions((prev) => [...prev, ''])
+  }, [])
+
+  const handleRemoveInstruction = useCallback((index: number) => {
+    setInstructions((prev) => prev.filter((_, i) => i !== index))
   }, [])
 
   const handleImageClick = useCallback(() => {
@@ -111,11 +126,13 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
     setIsSaving(true)
     try {
       const imagePathValue = imagePath || undefined
+      const validInstructions = instructions.map((s) => s.trim()).filter((s) => s.length > 0)
+      const instructionsValue = validInstructions.length > 0 ? validInstructions : undefined
       if (initialRecipe) {
-        await updateRecipe(initialRecipe.id, { name: trimmedName, ingredients: validIngredients, imagePath: imagePathValue })
+        await updateRecipe(initialRecipe.id, { name: trimmedName, ingredients: validIngredients, instructions: instructionsValue, imagePath: imagePathValue })
         showAlert({ description: 'Recipe updated', severity: 'success' }, dispatch)
       } else {
-        await addRecipe(trimmedName, validIngredients, imagePathValue)
+        await addRecipe(trimmedName, validIngredients, imagePathValue, instructionsValue)
         showAlert({ description: 'Recipe added', severity: 'success' }, dispatch)
       }
       onDone()
@@ -124,7 +141,7 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
     } finally {
       setIsSaving(false)
     }
-  }, [name, ingredients, imagePath, initialRecipe, addRecipe, updateRecipe, dispatch, onDone])
+  }, [name, ingredients, instructions, imagePath, initialRecipe, addRecipe, updateRecipe, dispatch, onDone])
 
   return (
     <FormContainer>
@@ -214,6 +231,43 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
           sx={{ alignSelf: 'flex-start', borderRadius: '8px' }}
         >
           Add Ingredient
+        </Button>
+      </IngredientsSection>
+
+      <IngredientsSection>
+        <Typography variant="body2" fontWeight={600} color="text.secondary">
+          Instructions
+        </Typography>
+
+        {instructions.map((step, index) => (
+          <IngredientRow key={index} sx={{ gridTemplateColumns: '1fr 36px' }}>
+            <TextField
+              label={`Step ${index + 1}`}
+              value={step}
+              onChange={(e) => handleInstructionChange(index, e.target.value)}
+              size="small"
+              multiline
+              placeholder={`Describe step ${index + 1}...`}
+            />
+            <IconButton
+              size="small"
+              onClick={() => handleRemoveInstruction(index)}
+              disabled={instructions.length === 1}
+              aria-label={`Remove step ${index + 1}`}
+            >
+              <DeleteIcon fontSize="small" />
+            </IconButton>
+          </IngredientRow>
+        ))}
+
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={handleAddInstruction}
+          sx={{ alignSelf: 'flex-start', borderRadius: '8px' }}
+        >
+          Add Step
         </Button>
       </IngredientsSection>
 

--- a/packages/web/src/components/RecipeItem/index.tsx
+++ b/packages/web/src/components/RecipeItem/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import { Typography, IconButton, Button, Chip, Tooltip } from '@mui/material'
+import { Typography, IconButton, Button, Chip, Tooltip, Box } from '@mui/material'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
 import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart'
@@ -116,6 +116,38 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
             )
           })}
         </IngredientList>
+      )}
+
+      {recipe.instructions && recipe.instructions.length > 0 && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
+          <Typography variant="body2" fontWeight={600} color="text.secondary">
+            Instructions
+          </Typography>
+          {recipe.instructions.map((step, index) => (
+            <Box key={index} sx={{ display: 'flex', gap: '0.5rem', alignItems: 'flex-start' }}>
+              <Typography
+                variant="caption"
+                sx={{
+                  minWidth: '20px',
+                  height: '20px',
+                  borderRadius: '50%',
+                  background: 'rgba(102, 126, 234, 0.15)',
+                  color: '#667eea',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontWeight: 600,
+                  flexShrink: 0,
+                }}
+              >
+                {index + 1}
+              </Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ lineHeight: '1.4', paddingTop: '2px' }}>
+                {step}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
       )}
 
       <Tooltip title={canUseRecipe ? `Add all ingredients to current shop's list` : 'Open a specific shop to use this recipe'}>

--- a/packages/web/src/providers/RecipeProvider/index.tsx
+++ b/packages/web/src/providers/RecipeProvider/index.tsx
@@ -8,7 +8,7 @@ const initialState: IState = {
   recipes: [],
   isLoading: false,
   fetchRecipes: async () => {},
-  addRecipe: async (_name, _ingredients, _imagePath?) => {},
+  addRecipe: async (_name, _ingredients, _imagePath?, _instructions?) => {},
   updateRecipe: async (_id, _fields) => {},
   removeRecipe: async () => {},
 }
@@ -37,21 +37,22 @@ export const RecipeProvider = ({ children }: IRecipeProviderProps) => {
     }
   }, [currentProject])
 
-  const addRecipe = useCallback(async (name: string, ingredients: IRecipeIngredient[], imagePath?: string) => {
+  const addRecipe = useCallback(async (name: string, ingredients: IRecipeIngredient[], imagePath?: string, instructions?: string[]) => {
     if (!currentProject) return
 
-    const result = await addRecipeApi({ name, ingredients, imagePath }, currentProject.id)
+    const result = await addRecipeApi({ name, ingredients, imagePath, instructions }, currentProject.id)
     const newRecipe: IRecipe = {
       ...result,
       name,
       ingredients,
       imagePath,
+      instructions,
       projectId: currentProject.id,
     }
     setRecipes((prev) => [...prev, newRecipe])
   }, [currentProject])
 
-  const updateRecipe = useCallback(async (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[]; imagePath?: string }) => {
+  const updateRecipe = useCallback(async (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[]; instructions?: string[]; imagePath?: string }) => {
     if (!currentProject) return
 
     await updateRecipeApi(id, fields, currentProject.id)

--- a/packages/web/src/providers/RecipeProvider/types.ts
+++ b/packages/web/src/providers/RecipeProvider/types.ts
@@ -4,8 +4,8 @@ export interface IState {
   recipes: IRecipe[]
   isLoading: boolean
   fetchRecipes: () => Promise<void>
-  addRecipe: (name: string, ingredients: IRecipeIngredient[], imagePath?: string) => Promise<void>
-  updateRecipe: (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[]; imagePath?: string }) => Promise<void>
+  addRecipe: (name: string, ingredients: IRecipeIngredient[], imagePath?: string, instructions?: string[]) => Promise<void>
+  updateRecipe: (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[]; instructions?: string[]; imagePath?: string }) => Promise<void>
   removeRecipe: (id: string) => Promise<void>
 }
 

--- a/packages/web/src/types/recipe.ts
+++ b/packages/web/src/types/recipe.ts
@@ -12,6 +12,7 @@ export interface IRecipe {
     name: string
     imagePath?: string
     ingredients: IRecipeIngredient[]
+    instructions?: string[]
     createdAt: string
     updatedAt: string
 }


### PR DESCRIPTION
Adds an optional instructions field (array of strings) to recipes, allowing users to document step-by-step cooking guides alongside their ingredients.

- Frontend: new instructions field on IRecipe type, RecipeForm instructions section with add/remove steps UI, RecipeItem displays numbered steps
- Backend: add_recipe and update_recipe lambdas accept and store instructions as JSON in DynamoDB, get_recipes deserializes instructions on read

https://claude.ai/code/session_01AwtiYywQRqJcTEicvA5KTC