### PR TITLE
fix: refresh grocery list after using a recipe

### DIFF
--- a/packages/web/src/components/RecipeDrawer/index.tsx
+++ b/packages/web/src/components/RecipeDrawer/index.tsx
@@ -19,10 +19,11 @@ const DRAG_CLOSE_THRESHOLD = 100
 interface RecipeDrawerProps {
   open: boolean
   onClose: () => void
+  onUseRecipe?: () => void
   shopId?: string
 }
 
-const RecipeDrawer = ({ open, onClose, shopId }: RecipeDrawerProps) => {
+const RecipeDrawer = ({ open, onClose, onUseRecipe, shopId }: RecipeDrawerProps) => {
   const [view, setView] = useState<'list' | 'form'>('list')
   const [editingRecipe, setEditingRecipe] = useState<IRecipe | null>(null)
   const [dragOffset, setDragOffset] = useState(0)
@@ -49,6 +50,11 @@ const RecipeDrawer = ({ open, onClose, shopId }: RecipeDrawerProps) => {
     setEditingRecipe(null)
     onClose()
   }, [onClose])
+
+  const handleUseRecipe = useCallback(() => {
+    handleClose()
+    onUseRecipe?.()
+  }, [handleClose, onUseRecipe])
 
   const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     isDragging.current = true
@@ -159,7 +165,7 @@ const RecipeDrawer = ({ open, onClose, shopId }: RecipeDrawerProps) => {
           {view === 'list' ? (
             <RecipeList
               onEditRecipe={handleEditRecipe}
-              onUseRecipe={handleClose}
+              onUseRecipe={handleUseRecipe}
               shopId={shopId}
             />
           ) : (

--- a/packages/web/src/routes/GroceryListRoute/index.tsx
+++ b/packages/web/src/routes/GroceryListRoute/index.tsx
@@ -149,6 +149,7 @@ const GroceryListContent = () => {
       <RecipeDrawer
         open={recipeDrawerOpen}
         onClose={() => setRecipeDrawerOpen(false)}
+        onUseRecipe={refetchGroceryList}
         shopId={shopId}
       />
     </StandardLayout>


### PR DESCRIPTION
When 'Use Recipe' is selected, call refetchGroceryList so the grocery list updates immediately without requiring a manual navigation away and back.

https://claude.ai/code/session_01MhXNRqsVjus3GuPwzDPRiA