### PR TITLE
feat: add optional external link to recipes

### DIFF
--- a/packages/lambdas/libs/dynamodb/types/recipes/index.ts
+++ b/packages/lambdas/libs/dynamodb/types/recipes/index.ts
@@ -11,6 +11,7 @@ export interface IRecipe {
     projectId: string
     name: string
     imagePath?: string
+    externalLink?: string
     ingredients: string  // JSON-serialized IRecipeIngredient[]
     instructions?: string  // JSON-serialized string[]
     createdAt: string

--- a/packages/lambdas/sources/add_recipe/body/types.ts
+++ b/packages/lambdas/sources/add_recipe/body/types.ts
@@ -11,4 +11,5 @@ export interface IRequestBody {
     ingredients: IRecipeIngredientBody[];
     instructions?: string[];
     imagePath?: string;
+    externalLink?: string;
 }

--- a/packages/lambdas/sources/add_recipe/database/index.ts
+++ b/packages/lambdas/sources/add_recipe/database/index.ts
@@ -8,6 +8,7 @@ export const createRecipe = async (recipe: {
   ingredients: IRecipeIngredientBody[];
   instructions?: string[];
   imagePath?: string;
+  externalLink?: string;
 }): Promise<string> => {
   const id = randomUUID();
   const now = new Date().toISOString();
@@ -27,6 +28,10 @@ export const createRecipe = async (recipe: {
 
   if (recipe.imagePath) {
     item.imagePath = recipe.imagePath;
+  }
+
+  if (recipe.externalLink) {
+    item.externalLink = recipe.externalLink;
   }
 
   await putItem({

--- a/packages/lambdas/sources/add_recipe/index.ts
+++ b/packages/lambdas/sources/add_recipe/index.ts
@@ -23,9 +23,9 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
       });
     }
 
-    const { name, ingredients, instructions, imagePath } = body;
+    const { name, ingredients, instructions, imagePath, externalLink } = body;
 
-    const id = await createRecipe({ projectId, name, ingredients, instructions, imagePath });
+    const id = await createRecipe({ projectId, name, ingredients, instructions, imagePath, externalLink });
 
     return createResponse({
       statusCode: 201,

--- a/packages/lambdas/sources/update_recipe/body/types.ts
+++ b/packages/lambdas/sources/update_recipe/body/types.ts
@@ -12,4 +12,5 @@ export interface IRequestBody {
     ingredients?: IRecipeIngredientBody[];
     instructions?: string[];
     imagePath?: string;
+    externalLink?: string;
 }

--- a/packages/lambdas/sources/update_recipe/database/index.ts
+++ b/packages/lambdas/sources/update_recipe/database/index.ts
@@ -3,7 +3,7 @@ import { IRecipeIngredientBody } from "../body/types";
 
 export const updateRecipe = async (
   id: string,
-  fields: { name?: string; ingredients?: IRecipeIngredientBody[]; instructions?: string[]; imagePath?: string }
+  fields: { name?: string; ingredients?: IRecipeIngredientBody[]; instructions?: string[]; imagePath?: string; externalLink?: string }
 ): Promise<void> => {
   const updatedFields: Record<string, any> = {
     updatedAt: new Date().toISOString(),
@@ -25,6 +25,10 @@ export const updateRecipe = async (
 
   if (fields.imagePath !== undefined) {
     updatedFields.imagePath = fields.imagePath;
+  }
+
+  if (fields.externalLink !== undefined) {
+    updatedFields.externalLink = fields.externalLink || null;
   }
 
   await updateItem({

--- a/packages/lambdas/sources/update_recipe/index.ts
+++ b/packages/lambdas/sources/update_recipe/index.ts
@@ -23,9 +23,9 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
       });
     }
 
-    const { id, name, ingredients, instructions, imagePath } = body;
+    const { id, name, ingredients, instructions, imagePath, externalLink } = body;
 
-    await updateRecipe(id, { name, ingredients, instructions, imagePath });
+    await updateRecipe(id, { name, ingredients, instructions, imagePath, externalLink });
 
     return createResponse({
       statusCode: 200,

--- a/packages/web/src/api/recipes/add/index.ts
+++ b/packages/web/src/api/recipes/add/index.ts
@@ -3,7 +3,7 @@ import { API_BASE_URL } from '../../index'
 import { createFetchOptions } from '../../../utils/api'
 
 export const addRecipe = async (
-  recipe: { name: string; ingredients: IRecipeIngredient[]; instructions?: string[]; imagePath?: string },
+  recipe: { name: string; ingredients: IRecipeIngredient[]; instructions?: string[]; imagePath?: string; externalLink?: string },
   projectId?: string
 ): Promise<IRecipe> => {
   const response = await fetch(`${API_BASE_URL}/recipes`, createFetchOptions({

--- a/packages/web/src/api/recipes/update/index.ts
+++ b/packages/web/src/api/recipes/update/index.ts
@@ -4,7 +4,7 @@ import { createFetchOptions } from '../../../utils/api'
 
 export const updateRecipe = async (
   id: string,
-  fields: { name?: string; ingredients?: IRecipeIngredient[]; instructions?: string[]; imagePath?: string },
+  fields: { name?: string; ingredients?: IRecipeIngredient[]; instructions?: string[]; imagePath?: string; externalLink?: string },
   projectId?: string
 ): Promise<void> => {
   const response = await fetch(`${API_BASE_URL}/recipes/${id}`, createFetchOptions({

--- a/packages/web/src/components/RecipeForm/index.tsx
+++ b/packages/web/src/components/RecipeForm/index.tsx
@@ -41,6 +41,7 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
   const { currentProject } = useProjectContext()
   const { dispatch } = useAppState()
   const [name, setName] = useState(initialRecipe?.name ?? '')
+  const [externalLink, setExternalLink] = useState(initialRecipe?.externalLink ?? '')
   const [ingredients, setIngredients] = useState<IRecipeIngredient[]>(
     initialRecipe?.ingredients ?? [{ ...DEFAULT_INGREDIENT }]
   )
@@ -168,13 +169,14 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
     setIsSaving(true)
     try {
       const imagePathValue = imagePath || undefined
+      const externalLinkValue = externalLink.trim() || undefined
       const validInstructions = instructions.map((s) => s.trim()).filter((s) => s.length > 0)
       const instructionsValue = validInstructions.length > 0 ? validInstructions : undefined
       if (initialRecipe) {
-        await updateRecipe(initialRecipe.id, { name: trimmedName, ingredients: validIngredients, instructions: instructionsValue, imagePath: imagePathValue })
+        await updateRecipe(initialRecipe.id, { name: trimmedName, ingredients: validIngredients, instructions: instructionsValue, imagePath: imagePathValue, externalLink: externalLinkValue })
         showAlert({ description: 'Recipe updated', severity: 'success' }, dispatch)
       } else {
-        await addRecipe(trimmedName, validIngredients, imagePathValue, instructionsValue)
+        await addRecipe(trimmedName, validIngredients, imagePathValue, instructionsValue, externalLinkValue)
         showAlert({ description: 'Recipe added', severity: 'success' }, dispatch)
       }
       onDone()
@@ -224,6 +226,16 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
         fullWidth
         size="small"
         placeholder="e.g. Pasta Carbonara"
+      />
+
+      <TextField
+        label="Original recipe URL"
+        value={externalLink}
+        onChange={(e) => setExternalLink(e.target.value)}
+        fullWidth
+        size="small"
+        placeholder="https://..."
+        type="url"
       />
 
       <IngredientsSection>

--- a/packages/web/src/components/RecipeItem/index.tsx
+++ b/packages/web/src/components/RecipeItem/index.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback } from 'react'
-import { Typography, Button, Chip, Tooltip, Box, Checkbox } from '@mui/material'
+import { Typography, Button, Chip, Tooltip, Box, Checkbox, IconButton } from '@mui/material'
 import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import { IRecipe } from '../../types/recipe'
 import { IItemDefault } from '../../hooks/useItemDefaults/types'
 import { findItemIcon } from '../ItemForm/components/ItemImage/utils'
@@ -128,6 +129,21 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
             <Typography variant="body1" fontWeight={600}>
               {recipe.name}
             </Typography>
+            {recipe.externalLink && (
+              <Tooltip title="View original recipe">
+                <IconButton
+                  size="small"
+                  component="a"
+                  href={recipe.externalLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                  sx={{ color: '#667eea', padding: '2px' }}
+                >
+                  <OpenInNewIcon sx={{ fontSize: '1rem' }} />
+                </IconButton>
+              </Tooltip>
+            )}
           </RecipeCardHeader>
           <Box sx={{ display: 'flex', gap: '0.4rem', flexWrap: 'wrap' }}>
             <Chip

--- a/packages/web/src/providers/RecipeProvider/index.tsx
+++ b/packages/web/src/providers/RecipeProvider/index.tsx
@@ -8,7 +8,7 @@ const initialState: IState = {
   recipes: [],
   isLoading: false,
   fetchRecipes: async () => {},
-  addRecipe: async (_name, _ingredients, _imagePath?, _instructions?) => {},
+  addRecipe: async (_name, _ingredients, _imagePath?, _instructions?, _externalLink?) => {},
   updateRecipe: async (_id, _fields) => {},
   removeRecipe: async () => {},
 }
@@ -37,22 +37,23 @@ export const RecipeProvider = ({ children }: IRecipeProviderProps) => {
     }
   }, [currentProject])
 
-  const addRecipe = useCallback(async (name: string, ingredients: IRecipeIngredient[], imagePath?: string, instructions?: string[]) => {
+  const addRecipe = useCallback(async (name: string, ingredients: IRecipeIngredient[], imagePath?: string, instructions?: string[], externalLink?: string) => {
     if (!currentProject) return
 
-    const result = await addRecipeApi({ name, ingredients, imagePath, instructions }, currentProject.id)
+    const result = await addRecipeApi({ name, ingredients, imagePath, instructions, externalLink }, currentProject.id)
     const newRecipe: IRecipe = {
       ...result,
       name,
       ingredients,
       imagePath,
       instructions,
+      externalLink,
       projectId: currentProject.id,
     }
     setRecipes((prev) => [...prev, newRecipe])
   }, [currentProject])
 
-  const updateRecipe = useCallback(async (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[]; instructions?: string[]; imagePath?: string }) => {
+  const updateRecipe = useCallback(async (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[]; instructions?: string[]; imagePath?: string; externalLink?: string }) => {
     if (!currentProject) return
 
     await updateRecipeApi(id, fields, currentProject.id)

--- a/packages/web/src/providers/RecipeProvider/types.ts
+++ b/packages/web/src/providers/RecipeProvider/types.ts
@@ -4,8 +4,8 @@ export interface IState {
   recipes: IRecipe[]
   isLoading: boolean
   fetchRecipes: () => Promise<void>
-  addRecipe: (name: string, ingredients: IRecipeIngredient[], imagePath?: string, instructions?: string[]) => Promise<void>
-  updateRecipe: (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[]; instructions?: string[]; imagePath?: string }) => Promise<void>
+  addRecipe: (name: string, ingredients: IRecipeIngredient[], imagePath?: string, instructions?: string[], externalLink?: string) => Promise<void>
+  updateRecipe: (id: string, fields: { name?: string; ingredients?: IRecipeIngredient[]; instructions?: string[]; imagePath?: string; externalLink?: string }) => Promise<void>
   removeRecipe: (id: string) => Promise<void>
 }
 

--- a/packages/web/src/types/recipe.ts
+++ b/packages/web/src/types/recipe.ts
@@ -11,6 +11,7 @@ export interface IRecipe {
     projectId: string
     name: string
     imagePath?: string
+    externalLink?: string
     ingredients: IRecipeIngredient[]
     instructions?: string[]
     createdAt: string


### PR DESCRIPTION
Users can now save a URL pointing to the original recipe source. When set, a link icon appears next to the recipe name in the card, opening the external URL in a new tab. The field is optional and backward compatible with existing recipes.

https://claude.ai/code/session_01Ti73UdMkb8BPoFToNVF9ik