### PR TITLE
fix: add externalLink to handleSave dependency array in RecipeForm

### DIFF
--- a/packages/web/src/components/RecipeForm/index.tsx
+++ b/packages/web/src/components/RecipeForm/index.tsx
@@ -185,7 +185,7 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
     } finally {
       setIsSaving(false)
     }
-  }, [name, ingredients, instructions, imagePath, initialRecipe, addRecipe, updateRecipe, dispatch, onDone])
+  }, [name, externalLink, ingredients, instructions, imagePath, initialRecipe, addRecipe, updateRecipe, dispatch, onDone])
 
   return (
     <FormContainer>


### PR DESCRIPTION
The externalLink state was missing from the useCallback deps, so the save handler always captured the initial empty string value, causing the URL to never be persisted on save.

https://claude.ai/code/session_01Ti73UdMkb8BPoFToNVF9ik