### PR TITLE
feat: add multi-checkbox sub-steps to todo items

### DIFF
--- a/packages/lambdas/sources/add_todo_item/types.ts
+++ b/packages/lambdas/sources/add_todo_item/types.ts
@@ -1,3 +1,9 @@
+export interface IStep {
+  id: string;
+  name: string;
+  isDone: boolean;
+}
+
 export interface TodoItem {
   id: string;
   projectId: string;
@@ -5,7 +11,7 @@ export interface TodoItem {
   description?: string;
   dueDate?: number;
   isDone: boolean;
-  [key: string]: string | number | boolean | undefined;
+  steps?: IStep[];
 }
 
 export interface TodoItemForNotification {

--- a/packages/lambdas/sources/update_todo_item/body/types.ts
+++ b/packages/lambdas/sources/update_todo_item/body/types.ts
@@ -1,7 +1,14 @@
+export interface IStep {
+    id: string;
+    name: string;
+    isDone: boolean;
+}
+
 export interface IRequestBody {
     id: string;
     name?: string;
     description?: string;
     dueDate?: number;
     isDone?: boolean;
+    steps?: IStep[];
 }

--- a/packages/web/src/api/toDoList/retrieve/types.ts
+++ b/packages/web/src/api/toDoList/retrieve/types.ts
@@ -1,8 +1,15 @@
 
+export interface IStep {
+  id: string
+  name: string
+  isDone: boolean
+}
+
 export interface ITodoItem {
   id: string
   name: string
   description?: string
   isDone: boolean
   dueDate?: number
+  steps?: IStep[]
 }

--- a/packages/web/src/api/toDoList/update/updateSingle.ts
+++ b/packages/web/src/api/toDoList/update/updateSingle.ts
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from '../../index'
-import { ITodoItem } from '../retrieve/types'
+import { IStep } from '../retrieve/types'
 import { createFetchOptions } from '../../../utils/api'
 
 export type ToDoItemUpdateFields = {
@@ -7,6 +7,7 @@ export type ToDoItemUpdateFields = {
   description?: string
   dueDate?: number
   isDone?: boolean
+  steps?: IStep[]
 }
 
 export const updateToDoItemFields = async (id: string, fields: ToDoItemUpdateFields, projectId?: string): Promise<void> => {

--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -28,7 +28,7 @@ export const Planner = ({
   viewMode = PlannerViewMode.GROUPED
 }: IToDoListProps = {}) => {
   const { dispatch } = useAppState();
-  const { toDoList, isLoading, removeFromToDoList } = usePlannerContext();
+  const { toDoList, isLoading, removeFromToDoList, updateToDoItemFields } = usePlannerContext();
   const { currentProject } = useProjectContext();
   const navigate = useNavigate();
   const [previewItem, setPreviewItem] = useState<ITodoItem | null>(null);
@@ -84,6 +84,18 @@ export const Planner = ({
     await removeBirthdayItem(id);
   }, [removeBirthdayItem]);
 
+  const handleStepToggle = useCallback(async (todoId: string, stepId: string, isDone: boolean) => {
+    const item = toDoList.find(t => t.id === todoId)
+    if (!item?.steps) return
+    const updatedSteps = item.steps.map(s => s.id === stepId ? { ...s, isDone } : s)
+    setPreviewItem({ ...item, steps: updatedSteps })
+    try {
+      await updateToDoItemFields(todoId, { steps: updatedSteps })
+    } catch (error) {
+      console.error('Failed to update step:', error)
+    }
+  }, [toDoList, updateToDoItemFields])
+
   if (viewMode === PlannerViewMode.CALENDAR) {
     return (
       <>
@@ -100,6 +112,7 @@ export const Planner = ({
           onClose={() => setPreviewItem(null)}
           onEdit={handleEdit}
           onMarkDone={markToDoItemAsDone}
+          onStepToggle={handleStepToggle}
         />
         <BirthdayPreviewDrawer
           item={previewBirthday}

--- a/packages/web/src/components/StepsEditor/index.tsx
+++ b/packages/web/src/components/StepsEditor/index.tsx
@@ -1,0 +1,117 @@
+import { useCallback } from 'react'
+import { Box, IconButton, InputBase, Typography, Button } from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import CloseIcon from '@mui/icons-material/Close'
+import { IStep } from '../../api/toDoList/retrieve/types'
+
+interface StepsEditorProps {
+  steps: IStep[]
+  onChange: (steps: IStep[]) => void
+}
+
+const StepsEditor = ({ steps, onChange }: StepsEditorProps) => {
+  const addStep = useCallback(() => {
+    onChange([...steps, { id: crypto.randomUUID(), name: '', isDone: false }])
+  }, [steps, onChange])
+
+  const removeStep = useCallback((id: string) => {
+    onChange(steps.filter(s => s.id !== id))
+  }, [steps, onChange])
+
+  const updateStepName = useCallback((id: string, name: string) => {
+    onChange(steps.map(s => s.id === id ? { ...s, name } : s))
+  }, [steps, onChange])
+
+  return (
+    <Box
+      sx={{
+        borderRadius: '20px',
+        boxShadow: '0 8px 32px rgba(0, 0, 0, 0.12)',
+        background: 'linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,0.98) 100%)',
+        backdropFilter: 'blur(20px)',
+        position: 'relative',
+        overflow: 'hidden',
+        margin: '0 0 2rem 0',
+        padding: '2rem 1.25rem',
+        boxSizing: 'border-box',
+        '&:before': {
+          content: '""',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: '4px',
+          background: 'linear-gradient(90deg, #667eea 0%, #764ba2 50%, #f093fb 100%)',
+          opacity: 0.8,
+        },
+        '@media (max-width: 600px)': {
+          padding: '1.5rem 1rem',
+        },
+      }}
+    >
+      <Typography
+        variant="subtitle2"
+        sx={{ fontWeight: 600, mb: 1.5, color: 'text.secondary', letterSpacing: 0.5, textTransform: 'uppercase', fontSize: '0.75rem' }}
+      >
+        Sub-steps
+      </Typography>
+
+      {steps.map((step, index) => (
+        <Box
+          key={step.id}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            mb: 1,
+            borderRadius: '10px',
+            border: '1.5px solid',
+            borderColor: 'rgba(102, 126, 234, 0.25)',
+            px: 1.5,
+            py: 0.5,
+            background: 'rgba(102, 126, 234, 0.04)',
+          }}
+        >
+          <Typography sx={{ color: 'text.disabled', fontSize: '0.85rem', minWidth: 20, textAlign: 'center' }}>
+            {index + 1}.
+          </Typography>
+          <InputBase
+            value={step.name}
+            onChange={e => updateStepName(step.id, e.target.value)}
+            placeholder="Step name"
+            fullWidth
+            inputProps={{ 'aria-label': `Sub-step ${index + 1} name` }}
+            sx={{ fontSize: '0.9375rem' }}
+          />
+          <IconButton
+            size="small"
+            onClick={() => removeStep(step.id)}
+            aria-label={`Remove step ${index + 1}`}
+            sx={{ color: 'text.disabled', '&:hover': { color: 'error.main' } }}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      ))}
+
+      <Button
+        startIcon={<AddIcon />}
+        onClick={addStep}
+        size="small"
+        sx={{
+          mt: steps.length > 0 ? 1 : 0,
+          textTransform: 'none',
+          fontWeight: 600,
+          color: '#667eea',
+          borderRadius: '8px',
+          px: 1.5,
+          '&:hover': { background: 'rgba(102, 126, 234, 0.08)' },
+        }}
+      >
+        Add step
+      </Button>
+    </Box>
+  )
+}
+
+export default StepsEditor

--- a/packages/web/src/components/ToDoItem/index.tsx
+++ b/packages/web/src/components/ToDoItem/index.tsx
@@ -3,8 +3,9 @@ import { ITodoItemProps } from './types'
 import { useAppState } from '../../providers/AppStateProvider';
 import { ActionName } from '../../providers/AppStateProvider/enums';
 import { useMemo, useCallback, memo } from 'react';
+import { Chip } from '@mui/material';
 
-const ToDoItem = memo(({ id, name, description, dueDate }: ITodoItemProps) => {
+const ToDoItem = memo(({ id, name, description, dueDate, steps }: ITodoItemProps) => {
   const { state: { selectedTodoItems }, dispatch } = useAppState()
   const isSelected = useMemo(() => selectedTodoItems.has(id), [selectedTodoItems, id])
 
@@ -38,24 +39,46 @@ const ToDoItem = memo(({ id, name, description, dueDate }: ITodoItemProps) => {
     if (dueDate) {
       const date = new Date(dueDate)
       const dayName = date.toLocaleDateString('en-US', { weekday: 'short' })
-      const dateString = date.toLocaleDateString('en-GB', { 
-        day: '2-digit', 
-        month: 'short', 
-        year: 'numeric' 
+      const dateString = date.toLocaleDateString('en-GB', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric'
       })
       return `${dayName}, ${dateString}`
     }
   }, [dueDate])
 
+  const stepProgress = useMemo(() => {
+    if (!steps || steps.length === 0) return null
+    const done = steps.filter(s => s.isDone).length
+    return `${done} / ${steps.length}`
+  }, [steps])
+
   return (
     <Container isSelected={isSelected}>
       <ActionArea
         onClick={handleClick}
-      >  
+      >
         <Content>
           <Name>{name}</Name>
           { description?.trim() && <Description>{description}</Description> }
           <DueDate>{formattedDueDate}</DueDate>
+          {stepProgress && (
+            <Chip
+              label={`${stepProgress} steps`}
+              size="small"
+              sx={{
+                mt: 0.5,
+                height: 20,
+                fontSize: '0.7rem',
+                fontWeight: 600,
+                alignSelf: 'flex-start',
+                background: 'rgba(102, 126, 234, 0.12)',
+                color: '#667eea',
+                border: 'none',
+              }}
+            />
+          )}
         </Content>
       </ActionArea>
     </Container>

--- a/packages/web/src/components/ToDoItem/types.ts
+++ b/packages/web/src/components/ToDoItem/types.ts
@@ -1,7 +1,10 @@
+import { IStep } from '../../api/toDoList/retrieve/types'
+
 export interface ITodoItemProps {
     id: string;
     name: string;
     description?: string;
     isDone: boolean;
     dueDate?: number;
+    steps?: IStep[];
 }

--- a/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
+++ b/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react'
-import { Box, Button, Chip, Drawer } from '@mui/material'
+import { Box, Button, Checkbox, Chip, Drawer, FormControlLabel, Typography } from '@mui/material'
 import AssignmentIcon from '@mui/icons-material/Assignment'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
@@ -26,9 +26,10 @@ interface ToDoItemPreviewDrawerProps {
   onClose: () => void
   onEdit: (id: string) => void
   onMarkDone?: (id: string) => void
+  onStepToggle?: (todoId: string, stepId: string, isDone: boolean) => void
 }
 
-const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone }: ToDoItemPreviewDrawerProps) => {
+const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle }: ToDoItemPreviewDrawerProps) => {
   const [dragOffset, setDragOffset] = useState(0)
   const isDragging = useRef(false)
   const dragStartY = useRef(0)
@@ -67,6 +68,8 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone }: ToDoItemPr
     isDragging.current = false
     setDragOffset(0)
   }, [onClose])
+
+  const steps = item?.steps ?? []
 
   return (
     <Drawer
@@ -160,6 +163,52 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone }: ToDoItemPr
             <DescriptionText>{item.description}</DescriptionText>
           ) : (
             <NoDescriptionText>No description</NoDescriptionText>
+          )}
+
+          {steps.length > 0 && (
+            <Box sx={{ mt: 2 }}>
+              <Typography
+                variant="subtitle2"
+                sx={{ fontWeight: 600, mb: 1, color: 'text.secondary', letterSpacing: 0.5, textTransform: 'uppercase', fontSize: '0.75rem' }}
+              >
+                Sub-steps
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                {steps.map(step => (
+                  <FormControlLabel
+                    key={step.id}
+                    control={
+                      <Checkbox
+                        checked={step.isDone}
+                        onChange={() => onStepToggle?.(item!.id, step.id, !step.isDone)}
+                        size="small"
+                        sx={{
+                          color: 'rgba(102, 126, 234, 0.5)',
+                          '&.Mui-checked': { color: '#667eea' },
+                        }}
+                      />
+                    }
+                    label={
+                      <Typography
+                        variant="body2"
+                        sx={{
+                          textDecoration: step.isDone ? 'line-through' : 'none',
+                          color: step.isDone ? 'text.disabled' : 'text.primary',
+                        }}
+                      >
+                        {step.name}
+                      </Typography>
+                    }
+                    sx={{
+                      mx: 0,
+                      borderRadius: '8px',
+                      px: 1,
+                      '&:hover': { background: 'rgba(102, 126, 234, 0.05)' },
+                    }}
+                  />
+                ))}
+              </Box>
+            </Box>
           )}
         </ContentContainer>
 

--- a/packages/web/src/routes/AddPlannerItemRoute/index.tsx
+++ b/packages/web/src/routes/AddPlannerItemRoute/index.tsx
@@ -21,6 +21,8 @@ import { PlannerProvider, usePlannerContext } from '../../providers/PlannerProvi
 import { BirthdayProvider } from '../../providers/BirthdayProvider'
 import dayjs from 'dayjs'
 import BirthdayForm from './BirthdayForm'
+import StepsEditor from '../../components/StepsEditor'
+import { IStep } from '../../api/toDoList/retrieve/types'
 
 type ItemType = 'task' | 'birthday'
 
@@ -104,6 +106,7 @@ export const AddPlannerItemContent = () => {
   const { toDoList } = usePlannerContext()
   const { user } = useAuth()
   const [itemType, setItemType] = useState<ItemType>('task')
+  const [steps, setSteps] = useState<IStep[]>([])
 
   const createAlert = useCallback((description: string, severity: AlertColor) => {
     showAlert({ description, severity }, dispatch)
@@ -120,10 +123,13 @@ export const AddPlannerItemContent = () => {
 
       const utcTimestamp = dueDate ? dayjs(dueDate.value).valueOf() : undefined
 
+      const filteredSteps = steps.filter(s => s.name.trim() !== '')
+
       await addTodoItem({
         name: name.value,
         description: description.value,
         dueDate: utcTimestamp,
+        steps: filteredSteps.length > 0 ? filteredSteps : undefined,
       }, currentProject.id, user?.access_token)
 
       createAlert(`${name.value} has been added to your planner`, 'success')
@@ -132,7 +138,7 @@ export const AddPlannerItemContent = () => {
       console.error(error)
       createAlert('Error creating task', 'error')
     }
-  }, [createAlert, navigate, currentProject])
+  }, [createAlert, navigate, currentProject, steps])
 
   const today = new Date()
   const currentDay = today.toLocaleDateString('en-US', { weekday: 'short' })
@@ -178,11 +184,16 @@ export const AddPlannerItemContent = () => {
         </SegmentedControl>
       </Box>
       {itemType === 'task' ? (
-        <ItemForm
-          fields={TASK_FIELDS}
-          onSubmit={onSubmit}
-          hideImage={true}
-        />
+        <>
+          <ItemForm
+            fields={TASK_FIELDS}
+            onSubmit={onSubmit}
+            hideImage={true}
+          />
+          <Box sx={{ px: 2, width: '100%', boxSizing: 'border-box' }}>
+            <StepsEditor steps={steps} onChange={setSteps} />
+          </Box>
+        </>
       ) : (
         <BirthdayForm />
       )}

--- a/packages/web/src/routes/EditPlannerItemRoute/index.tsx
+++ b/packages/web/src/routes/EditPlannerItemRoute/index.tsx
@@ -5,15 +5,16 @@ import { validateFields } from './utils'
 import { useNavigate, useParams } from 'react-router'
 import { useAppState } from '../../providers/AppStateProvider'
 import { useCallback, useEffect, useState, useMemo } from 'react'
-import { AlertColor } from '@mui/material'
+import { AlertColor, Box } from '@mui/material'
 import { Route } from '../../enums/route'
 import { showAlert } from '../../utils/alert'
 import StandardLayout from '../../layout/standardLayout'
 import ModernPageHeader from '../../components/ModernPageHeader'
 import { PlannerProvider, usePlannerContext } from '../../providers/PlannerProvider'
-import { ITodoItem } from '../../api/toDoList/retrieve/types'
+import { IStep, ITodoItem } from '../../api/toDoList/retrieve/types'
 import ChecklistIcon from '@mui/icons-material/Checklist'
 import dayjs from 'dayjs'
+import StepsEditor from '../../components/StepsEditor'
 
 const EditPlannerItemContent = () => {
   const { dispatch } = useAppState()
@@ -21,6 +22,7 @@ const EditPlannerItemContent = () => {
   const navigate = useNavigate()
   const { id } = useParams()
   const [currentItem, setCurrentItem] = useState<ITodoItem | null>(null)
+  const [steps, setSteps] = useState<IStep[]>([])
 
   const todoItem = useMemo(() => {
     return toDoList.find(item => item.id === id) || null
@@ -43,6 +45,7 @@ const EditPlannerItemContent = () => {
   useEffect(() => {
     if (todoItem) {
       setCurrentItem(todoItem)
+      setSteps(todoItem.steps ?? [])
     } else if (!todoItem && toDoList.length > 0) {
       createAlert('Todo item not found', 'error')
       navigate(Route.Planner)
@@ -83,10 +86,13 @@ const EditPlannerItemContent = () => {
 
       const utcTimestamp = dueDate ? dayjs(dueDate.value).valueOf() : undefined
 
+      const filteredSteps = steps.filter(s => s.name.trim() !== '')
+
       const updatedFields: any = {
         name: name.value,
         description: description.value,
         dueDate: utcTimestamp,
+        steps: filteredSteps.length > 0 ? filteredSteps : [],
       }
 
       await updateToDoItemFields(id!, updatedFields)
@@ -97,7 +103,7 @@ const EditPlannerItemContent = () => {
       console.error(error)
       createAlert('Error updating todo item', 'error')
     }
-  }, [createAlert, navigate, id, updateToDoItemFields])
+  }, [createAlert, navigate, id, updateToDoItemFields, steps])
 
   if (!currentItem) {
     return (
@@ -121,6 +127,9 @@ const EditPlannerItemContent = () => {
         submitButtonText="Update Item"
         submittingButtonText="Updating Item..."
       />
+      <Box sx={{ px: 2, width: '100%', boxSizing: 'border-box' }}>
+        <StepsEditor steps={steps} onChange={setSteps} />
+      </Box>
     </StandardLayout>
   )
 }

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -26,7 +26,7 @@ import { Container } from './index.styled'
 
 const HomeDataContent = () => {
   const { groceryList, isLoading: isGroceryLoading } = useGroceryListContext()
-  const { toDoList, isLoading: isToDoLoading, removeFromToDoList } = usePlannerContext()
+  const { toDoList, isLoading: isToDoLoading, removeFromToDoList, updateToDoItemFields } = usePlannerContext()
   const { noiseTrackingItems, isLoading: isNoiseLoading } = useNoiseTrackingContext()
   const { state: { purchasedItems }, dispatch } = useAppState()
   const { currentProject } = useProjectContext()
@@ -56,6 +56,19 @@ const HomeDataContent = () => {
   const handleEditTask = useCallback((id: string) => {
     navigate(Route.EditPlannerItem.replace(':id', id))
   }, [navigate])
+
+  const handleStepToggle = useCallback(async (todoId: string, stepId: string, isDone: boolean) => {
+    const item = toDoList.find(t => t.id === todoId)
+    if (!item?.steps) return
+    const updatedSteps = item.steps.map(s => s.id === stepId ? { ...s, isDone } : s)
+    interactions.handleToDoItemSelect({ ...item, steps: updatedSteps })
+    try {
+      await updateToDoItemFields(todoId, { steps: updatedSteps })
+    } catch (error) {
+      console.error('Failed to update step:', error)
+      showAlert({ description: 'Failed to update step', severity: 'error' }, dispatch)
+    }
+  }, [toDoList, updateToDoItemFields, interactions.handleToDoItemSelect, dispatch])
 
   return (
     <>
@@ -97,6 +110,7 @@ const HomeDataContent = () => {
         onClose={interactions.handleToDoItemDeselect}
         onEdit={handleEditTask}
         onMarkDone={handleMarkDone}
+        onStepToggle={handleStepToggle}
       />
     </>
   )
@@ -127,4 +141,4 @@ export const HomeRoute = () => {
   return <HomeContent />
 }
 
-export default HomeRoute 
+export default HomeRoute


### PR DESCRIPTION
Users can now add named sub-steps to any todo item, each with their
own independent checkbox. This allows breaking down complex tasks into
smaller trackable steps without creating separate todo items.

Changes:
- Add IStep type (id, name, isDone) and steps field to ITodoItem
- New StepsEditor component for adding/removing/naming steps in forms
- AddPlannerItemRoute and EditPlannerItemRoute include StepsEditor
- ToDoItemPreviewDrawer renders steps as checkboxes; checking persists to API
- ToDoItem card shows a progress chip (e.g. "2 / 3 steps") when steps exist
- Planner and HomeRoute wire up onStepToggle for optimistic UI updates
- Backend Lambda types updated to support steps array in add/update endpoints

https://claude.ai/code/session_01Vdmb8ReVw2D1tVEDv8er7c