### PR TITLE
fix: resolve 9 failing unit tests across 5 test suites

### DIFF
--- a/packages/web/src/hooks/useHomeInteractions/index.ts
+++ b/packages/web/src/hooks/useHomeInteractions/index.ts
@@ -10,6 +10,7 @@ export const useHomeInteractions = (): IUseHomeInteractions => {
   const [isToDoItemsExpanded, setIsToDoItemsExpanded] = useState(false)
   const [noiseView, setNoiseView] = useState<NoiseView>('overview')
   const [selectedToDoItem, setSelectedToDoItem] = useState<ITodoItem | null>(null)
+  const [expandedToDoItems, setExpandedToDoItems] = useState<Set<string>>(new Set())
 
   const calculatePopupPosition = useCallback((
     item: IGroceryItem, 
@@ -67,6 +68,18 @@ export const useHomeInteractions = (): IUseHomeInteractions => {
     setSelectedToDoItem(null)
   }, [])
 
+  const handleToDoItemToggle = useCallback((id: string) => {
+    setExpandedToDoItems(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }, [])
+
   return {
     selectedGroceryItem,
     isPopupOpen,
@@ -74,12 +87,14 @@ export const useHomeInteractions = (): IUseHomeInteractions => {
     isToDoItemsExpanded,
     noiseView,
     selectedToDoItem,
+    expandedToDoItems,
     handleGroceryItemClick,
     handlePopupClose,
     handleToggleToDoItems,
     handleNoiseViewChange,
     handleToDoItemSelect,
-    handleToDoItemDeselect
+    handleToDoItemDeselect,
+    handleToDoItemToggle,
   }
 }
 

--- a/packages/web/src/hooks/useHomeInteractions/types.ts
+++ b/packages/web/src/hooks/useHomeInteractions/types.ts
@@ -16,6 +16,7 @@ export interface IHomeInteractionState {
   isToDoItemsExpanded: boolean
   noiseView: NoiseView
   selectedToDoItem: ITodoItem | null
+  expandedToDoItems: Set<string>
 }
 
 export interface IHomeInteractionHandlers {
@@ -25,6 +26,7 @@ export interface IHomeInteractionHandlers {
   handleNoiseViewChange: (view: NoiseView) => void
   handleToDoItemSelect: (item: ITodoItem) => void
   handleToDoItemDeselect: () => void
+  handleToDoItemToggle: (id: string) => void
 }
 
 export interface IUseHomeInteractions extends IHomeInteractionState, IHomeInteractionHandlers {}

--- a/packages/web/src/routes/EditPlannerItemRoute/index.test.tsx
+++ b/packages/web/src/routes/EditPlannerItemRoute/index.test.tsx
@@ -131,7 +131,8 @@ describe('Given the EditPlannerItemRoute component', () => {
       expect(mockToDoListContext.updateToDoItemFields).toHaveBeenCalledWith('1', {
         name: 'Updated Todo',
         description: 'Updated description',
-        dueDate: expect.any(Number)
+        dueDate: expect.any(Number),
+        steps: [],
       })
       
       expect(mockNavigate).toHaveBeenCalledWith('/planner')
@@ -160,19 +161,20 @@ describe('Given the EditPlannerItemRoute component', () => {
         },
         {
           name: 'dueDate',
-          value: expect.any(String),
+          value: '2023-01-01T00:00:00.000Z',
           type: FormFieldType.DATE,
           required: true,
           label: 'Due Date'
         }
       ]
-      
+
       await props.onSubmit(mockFields)
-      
+
       expect(mockToDoListContext.updateToDoItemFields).toHaveBeenCalledWith('1', {
         name: 'Just Name',
         description: '',
-        dueDate: expect.any(Number)
+        dueDate: expect.any(Number),
+        steps: [],
       })
     })
 

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/ToDoItemCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/ToDoItemCard/index.tsx
@@ -7,20 +7,35 @@ import {
   CompactItemMeta,
   CompactDescription,
   DueDateText,
+  ExpandedToDoContent,
+  ExpandedDescription,
+  ExpandedMetadata,
+  MetadataRow,
+  MetadataContent,
+  MetadataLabel,
+  MetadataValue,
 } from './index.styled'
+
+const formatFullDate = (dueDate: number): string => {
+  const date = new Date(dueDate)
+  const datePart = date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })
+  const timePart = date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })
+  return `${datePart} at ${timePart}`
+}
 
 export const ToDoItemCard: React.FC<IToDoItemCardProps> = ({
   item,
   dueDateText,
   dueDateClass,
+  isExpanded,
   onClick
 }) => {
   return (
-    <CompactItemText onClick={onClick}>
+    <CompactItemText $isExpanded={isExpanded} onClick={onClick}>
       <CompactItemHeader>
         <CompactItemContent>
           {item.name}
-          {item.description && (
+          {!isExpanded && item.description && (
             <CompactDescription>
               {item.description.length > 50
                 ? `${item.description.substring(0, 50)}...`
@@ -36,6 +51,25 @@ export const ToDoItemCard: React.FC<IToDoItemCardProps> = ({
           </CompactItemMeta>
         )}
       </CompactItemHeader>
+      {isExpanded && (item.description || item.dueDate) && (
+        <ExpandedToDoContent>
+          {item.description && (
+            <ExpandedDescription>
+              {item.description}
+            </ExpandedDescription>
+          )}
+          {item.dueDate && (
+            <ExpandedMetadata>
+              <MetadataRow>
+                <MetadataContent>
+                  <MetadataLabel>Due Date</MetadataLabel>
+                  <MetadataValue>{formatFullDate(item.dueDate)}</MetadataValue>
+                </MetadataContent>
+              </MetadataRow>
+            </ExpandedMetadata>
+          )}
+        </ExpandedToDoContent>
+      )}
     </CompactItemText>
   )
 }

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/ToDoItemCard/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/ToDoItemCard/types.ts
@@ -5,5 +5,6 @@ export interface IToDoItemCardProps {
   item: ITodoItem
   dueDateText: string
   dueDateClass: DueDateClass
+  isExpanded: boolean
   onClick: () => void
 }

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -13,7 +13,8 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
   isLoading,
   isExpanded,
   onToggleExpansion,
-  onItemSelect
+  onItemToggle,
+  expandedItems,
 }) => {
   const renderContent = () => {
     if (isLoading) {
@@ -42,7 +43,8 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
               item={item}
               dueDateText={dueDateText}
               dueDateClass={dueDateClass}
-              onClick={() => onItemSelect(item)}
+              isExpanded={expandedItems.has(item.id)}
+              onClick={() => onItemToggle(item.id)}
             />
           )
         })}

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
@@ -6,5 +6,6 @@ export interface IToDoSectionProps {
   isLoading: boolean
   isExpanded: boolean
   onToggleExpansion: () => void
-  onItemSelect: (item: ITodoItem) => void
+  onItemToggle: (id: string) => void
+  expandedItems: Set<string>
 }

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -92,7 +92,8 @@ const HomeDataContent = () => {
           isLoading={isToDoLoading}
           isExpanded={interactions.isToDoItemsExpanded}
           onToggleExpansion={interactions.handleToggleToDoItems}
-          onItemSelect={interactions.handleToDoItemSelect}
+          onItemToggle={interactions.handleToDoItemToggle}
+          expandedItems={interactions.expandedToDoItems}
         />
 
         <AgentMessageButton />

--- a/packages/web/src/routes/PlannerRoute/index.tsx
+++ b/packages/web/src/routes/PlannerRoute/index.tsx
@@ -24,7 +24,7 @@ const PlannerContent = () => {
   const { currentProject } = useProjectContext()
   const [allExpanded, setAllExpanded] = useState(true)
   const [expandKey, setExpandKey] = useState(0)
-  const [viewMode, setViewMode] = useState<PlannerViewMode>(PlannerViewMode.CALENDAR)
+  const [viewMode, setViewMode] = useState<PlannerViewMode>(PlannerViewMode.GROUPED)
   
   const pendingItems = toDoList.filter(item => !item.isDone)
   const completedItems = toDoList.filter(item => item.isDone)


### PR DESCRIPTION
- Add expandedToDoItems state and handleToDoItemToggle handler to
  useHomeInteractions to support inline todo item expansion
- Update IToDoSectionProps to replace onItemSelect with onItemToggle
  and add expandedItems prop
- Update PlannerSection to pass expansion state to ToDoItemCard
- Update ToDoItemCard to render full description and due date details
  when expanded (using pre-existing styled components)
- Wire HomeRoute to use expandedToDoItems/handleToDoItemToggle
- Change PlannerRoute default viewMode from CALENDAR to GROUPED so
  header stats show Pending/Today/Day/Month/Year as tests expect
- Fix EditPlannerItemRoute tests to include steps:[] in expected call
  and use a real ISO date string instead of expect.any(String)

https://claude.ai/code/session_015dduNAwaoeuqBqnTPfZtBh