### PR TITLE
Add shop selector to edit grocery item form for moving items between shops

### DIFF
--- a/packages/web/src/api/groceryList/types.ts
+++ b/packages/web/src/api/groceryList/types.ts
@@ -5,4 +5,5 @@ export type GroceryItemUpdateFields = {
   quantity?: number
   unit?: GroceryItemUnit
   imagePath?: string
+  shopId?: string
 }

--- a/packages/web/src/routes/EditGroceryItemRoute/index.test.tsx
+++ b/packages/web/src/routes/EditGroceryItemRoute/index.test.tsx
@@ -30,6 +30,7 @@ const mockGroceryItem = {
   name: 'Test Item',
   quantity: 2,
   unit: GroceryItemUnit.KILOGRAM,
+  shopId: 'test-shop-1',
   imagePath: '/test.png',
   toBeRemoved: false,
 }
@@ -90,19 +91,22 @@ describe('Given the EditGroceryItemRoute component', () => {
     const [firstCall] = jest.mocked(ItemForm).mock.calls
     const props = firstCall[0]
     
-    expect(props.fields).toHaveLength(3)
-    
+    expect(props.fields).toHaveLength(4)
+
     const nameField = props.fields.find((field: any) => field.name === 'name')
     const quantityField = props.fields.find((field: any) => field.name === 'quantity')
     const unitField = props.fields.find((field: any) => field.name === 'unit')
-    
+    const shopField = props.fields.find((field: any) => field.name === 'shopId')
+
     expect(nameField).toBeDefined()
     expect(quantityField).toBeDefined()
     expect(unitField).toBeDefined()
-    
+    expect(shopField).toBeDefined()
+
     expect(nameField!.value).toBe('Test Item')
     expect(quantityField!.value).toBe(2)
     expect(unitField!.value).toBe(GroceryItemUnit.KILOGRAM)
+    expect(shopField!.value).toBe('test-shop-1')
   })
 
 
@@ -138,6 +142,12 @@ describe('Given the EditGroceryItemRoute component', () => {
                 required: true,
                 value: GroceryItemUnit.UNIT,
               },
+              {
+                name: 'shopId',
+                type: FormFieldType.SELECT,
+                required: true,
+                value: 'test-shop-1',
+              },
             ])
           })
 
@@ -146,6 +156,7 @@ describe('Given the EditGroceryItemRoute component', () => {
             quantity: 3,
             unit: GroceryItemUnit.UNIT,
             imagePath: '/test.png',
+            shopId: 'test-shop-1',
           })
 
           expect(mockNavigate).toHaveBeenCalledWith('/groceries/test-shop-1')

--- a/packages/web/src/routes/EditGroceryItemRoute/index.tsx
+++ b/packages/web/src/routes/EditGroceryItemRoute/index.tsx
@@ -28,7 +28,7 @@ const EditGroceryItemContent = () => {
   const { defaults } = useItemDefaults({
     fetchMethod: retrieveGroceryListDefaults
   })
-  
+
   const currentShop = shops.find(shop => shop.id === shopId)
 
   const groceryItem = useMemo(() => {
@@ -80,7 +80,18 @@ const EditGroceryItemContent = () => {
         value: key,
       })),
     },
-  ], [currentItem])
+    {
+      name: 'shopId',
+      label: 'Shop',
+      type: FormFieldType.SELECT,
+      required: true,
+      value: currentItem?.shopId || shopId || '',
+      options: shops.map((shop) => ({
+        label: shop.name,
+        value: shop.id,
+      })),
+    },
+  ], [currentItem, shops, shopId])
 
   const createAlert = useCallback((description: string, severity: AlertColor) => {
     showAlert({ description, severity }, dispatch)
@@ -88,19 +99,20 @@ const EditGroceryItemContent = () => {
 
   const onSubmit = useCallback(async (fields: Array<IFormField>, imagePath?: string) => {
     try {
-      const [name, quantity, unit] = validateFields(fields)
+      const [name, quantity, unit, shopField] = validateFields(fields)
 
       const updatedFields = {
         name: name.value,
         quantity: quantity.value,
         unit: unit.value as GroceryItemUnit,
         imagePath: imagePath || currentItem?.imagePath,
+        shopId: shopField.value,
       }
 
       await updateGroceryItemFields(id!, updatedFields)
 
       createAlert(`${name.value} has been updated`, 'success')
-      navigate(Route.GroceryList.replace(':shopId', shopId || ''))
+      navigate(Route.GroceryList.replace(':shopId', shopField.value || shopId || ''))
     } catch (error) {
       console.error(error)
       createAlert('Error updating grocery item', 'error')
@@ -136,7 +148,7 @@ const EditGroceryItemContent = () => {
 
 export const EditGroceryItemRoute = () => {
   const { shopId } = useParams<{ shopId: string }>()
-  
+
   return (
     <GroceryListProvider shopId={shopId}>
       <EditGroceryItemContent />

--- a/packages/web/src/routes/EditGroceryItemRoute/utils.test.ts
+++ b/packages/web/src/routes/EditGroceryItemRoute/utils.test.ts
@@ -25,6 +25,13 @@ describe('validateFields', () => {
         required: true,
         value: 'kg',
       },
+      {
+        name: 'shopId',
+        label: 'Shop',
+        type: FormFieldType.SELECT,
+        required: true,
+        value: 'shop-1',
+      },
     ]
 
     const result = validateFields(fields)
@@ -33,6 +40,7 @@ describe('validateFields', () => {
       expect.objectContaining({ name: 'name', value: 'Test Item' }),
       expect.objectContaining({ name: 'quantity', value: 2 }),
       expect.objectContaining({ name: 'unit', value: 'kg' }),
+      expect.objectContaining({ name: 'shopId', value: 'shop-1' }),
     ])
   })
 
@@ -73,6 +81,13 @@ describe('validateFields', () => {
         required: true,
         value: 'kg',
       },
+      {
+        name: 'shopId',
+        label: 'Shop',
+        type: FormFieldType.SELECT,
+        required: true,
+        value: 'shop-1',
+      },
     ]
 
     expect(() => validateFields(fields)).toThrow('Fields cannot be empty')
@@ -100,6 +115,13 @@ describe('validateFields', () => {
         type: FormFieldType.SELECT,
         required: true,
         value: 'kg',
+      },
+      {
+        name: 'shopId',
+        label: 'Shop',
+        type: FormFieldType.SELECT,
+        required: true,
+        value: 'shop-1',
       },
     ]
 

--- a/packages/web/src/routes/EditGroceryItemRoute/utils.ts
+++ b/packages/web/src/routes/EditGroceryItemRoute/utils.ts
@@ -3,17 +3,18 @@ import { IFormField } from "../../components/ItemForm/types"
 export type IValidatedFields = [
     IFormField<string>,
     IFormField<number>,
+    IFormField<string>,
     IFormField<string>
 ]
 
 export const validateFields = (fields: Array<IFormField>): IValidatedFields => {
-  if (fields.length !== 3) {
+  if (fields.length !== 4) {
     throw new Error('Invalid number of fields')
   }
 
-  const [name, quantity, unit] = fields
+  const [name, quantity, unit, shopField] = fields
 
-  if (!name.value || !quantity.value || !unit.value) {
+  if (!name.value || !quantity.value || !unit.value || !shopField.value) {
     throw new Error('Fields cannot be empty')
   }
 
@@ -29,9 +30,14 @@ export const validateFields = (fields: Array<IFormField>): IValidatedFields => {
     throw new Error('Invalid unit field type')
   }
 
+  if (typeof shopField.value !== 'string') {
+    throw new Error('Invalid shop field type')
+  }
+
   return [
     { ...name, value: name.value },
     { ...quantity, value: quantity.value },
-    { ...unit, value: unit.value }
+    { ...unit, value: unit.value },
+    { ...shopField, value: shopField.value }
   ];
 }


### PR DESCRIPTION
Users can now change the shop of a grocery item directly from the edit form.
After saving, they are navigated to the destination shop's grocery list.

https://claude.ai/code/session_01JBYg1BELMeDBcKtQPKZAV4