### PR TITLE
Add delete task button to ToDoItemPreviewDrawer

### DIFF
--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -4,7 +4,7 @@ import { usePlannerContext } from '../../providers/PlannerProvider';
 import { useProjectContext } from '../../providers/ProjectProvider';
 import { useAppState } from '../../providers/AppStateProvider';
 import { ActionName } from '../../providers/AppStateProvider/enums';
-import { updateToDoItems } from '../../api/toDoList';
+import { removeTodoItems, updateToDoItems } from '../../api/toDoList';
 import { showAlert } from '../../utils/alert';
 import { Route } from '../../enums/route';
 import { groupTodosByTime } from './utils/timeGrouping';
@@ -80,6 +80,17 @@ export const Planner = ({
     setBirthdayDialogOpen(true);
   }, []);
 
+  const handleDeleteTodo = useCallback(async (id: string) => {
+    try {
+      await removeTodoItems([id], currentProject!.id);
+      clearSelectedTodoItems(id);
+      removeFromToDoList(id);
+    } catch (error) {
+      console.error('Failed to delete todo item:', error);
+      showAlert({ description: 'Failed to delete task', severity: 'error' }, dispatch);
+    }
+  }, [currentProject, dispatch, clearSelectedTodoItems, removeFromToDoList]);
+
   const handleBirthdayDelete = useCallback(async (id: string) => {
     await removeBirthdayItem(id);
   }, [removeBirthdayItem]);
@@ -113,6 +124,7 @@ export const Planner = ({
           onEdit={handleEdit}
           onMarkDone={markToDoItemAsDone}
           onStepToggle={handleStepToggle}
+          onDelete={handleDeleteTodo}
         />
         <BirthdayPreviewDrawer
           item={previewBirthday}

--- a/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
+++ b/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Checkbox, Chip, Drawer, FormControlLabel, Typography } fro
 import AssignmentIcon from '@mui/icons-material/Assignment'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
 import dayjs from 'dayjs'
 import { ITodoItem } from '../../api/toDoList/retrieve/types'
@@ -27,9 +28,10 @@ interface ToDoItemPreviewDrawerProps {
   onEdit: (id: string) => void
   onMarkDone?: (id: string) => void
   onStepToggle?: (todoId: string, stepId: string, isDone: boolean) => void
+  onDelete?: (id: string) => void
 }
 
-const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle }: ToDoItemPreviewDrawerProps) => {
+const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle, onDelete }: ToDoItemPreviewDrawerProps) => {
   const [dragOffset, setDragOffset] = useState(0)
   const isDragging = useRef(false)
   const dragStartY = useRef(0)
@@ -45,6 +47,12 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
     onMarkDone?.(item.id)
     onClose()
   }, [item, onMarkDone, onClose])
+
+  const handleDelete = useCallback(() => {
+    if (!item) return
+    onDelete?.(item.id)
+    onClose()
+  }, [item, onDelete, onClose])
 
   const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     isDragging.current = true
@@ -249,6 +257,22 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
             }}
           >
             Edit Task
+          </Button>
+          <Button
+            variant="outlined"
+            fullWidth
+            startIcon={<DeleteIcon />}
+            onClick={handleDelete}
+            color="error"
+            sx={{
+              borderRadius: '10px',
+              textTransform: 'none',
+              fontWeight: 600,
+              py: 1.25,
+              mt: 1,
+            }}
+          >
+            Delete Task
           </Button>
         </Footer>
       </Box>


### PR DESCRIPTION
Users can now permanently delete a task from the preview drawer (calendar view),
providing an alternative to marking tasks as complete for items added by mistake.

https://claude.ai/code/session_01L8zVQfoM5jfnS9LBWYDK3R