### PR TITLE
Redesign todo form layout: move sub-steps inside the form card

### DIFF
--- a/packages/web/src/components/ItemForm/index.tsx
+++ b/packages/web/src/components/ItemForm/index.tsx
@@ -1,4 +1,4 @@
-import { Stack, CircularProgress, Alert } from "@mui/material";
+import { Stack, CircularProgress, Alert, Divider } from "@mui/material";
 import { useCallback, useMemo, useState } from "react";
 import { IItemFormProps, IFormField } from "./types";
 import { useForm } from "./hooks/useForm";
@@ -6,7 +6,7 @@ import ItemImage from "./components/ItemImage";
 import FormField from "./components/FormField";
 import { FormContainer, FormCard, FormContent, FormFieldsContainer, SubmitButton, ImageContainer } from "./index.styled";
 
-const ItemForm = ({ defaults, fields, hideImage, initialImagePath, onSubmit, submitButtonText = 'Add Item', submittingButtonText = 'Adding Item...' }: IItemFormProps) => {
+const ItemForm = ({ defaults, fields, hideImage, initialImagePath, onSubmit, submitButtonText = 'Add Item', submittingButtonText = 'Adding Item...', children }: IItemFormProps) => {
     const [itemName, setItemName] = useState<string | undefined>();
     const [imagePath, setImagePath] = useState<string | undefined>();
 
@@ -64,7 +64,13 @@ const ItemForm = ({ defaults, fields, hideImage, initialImagePath, onSubmit, sub
                             <FormFieldsContainer>
                                 {formFieldsComponents}
                             </FormFieldsContainer>
-                            <SubmitButton 
+                            {children && (
+                                <>
+                                    <Divider sx={{ borderColor: 'rgba(102, 126, 234, 0.15)' }} />
+                                    {children}
+                                </>
+                            )}
+                            <SubmitButton
                                 type="submit" 
                                 variant="contained" 
                                 disabled={isSubmitting}

--- a/packages/web/src/components/ItemForm/types.ts
+++ b/packages/web/src/components/ItemForm/types.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { FormFieldType } from "./enums";
 import { IItemDefault } from "../../hooks/useItemDefaults/types";
 
@@ -19,6 +20,7 @@ export interface IItemFormProps {
     onSubmit: (fields: Array<IFormField>, icon?: string) => Promise<void>;
     submitButtonText?: string;
     submittingButtonText?: string;
+    children?: React.ReactNode;
 }
 
 export interface IHandleChangeParams {

--- a/packages/web/src/components/StepsEditor/index.tsx
+++ b/packages/web/src/components/StepsEditor/index.tsx
@@ -7,9 +7,10 @@ import { IStep } from '../../api/toDoList/retrieve/types'
 interface StepsEditorProps {
   steps: IStep[]
   onChange: (steps: IStep[]) => void
+  embedded?: boolean
 }
 
-const StepsEditor = ({ steps, onChange }: StepsEditorProps) => {
+const StepsEditor = ({ steps, onChange, embedded = false }: StepsEditorProps) => {
   const addStep = useCallback(() => {
     onChange([...steps, { id: crypto.randomUUID(), name: '', isDone: false }])
   }, [steps, onChange])
@@ -21,6 +22,74 @@ const StepsEditor = ({ steps, onChange }: StepsEditorProps) => {
   const updateStepName = useCallback((id: string, name: string) => {
     onChange(steps.map(s => s.id === id ? { ...s, name } : s))
   }, [steps, onChange])
+
+  if (embedded) {
+    return (
+      <Box>
+        <Typography
+          variant="subtitle2"
+          sx={{ fontWeight: 600, mb: 1.5, color: 'text.secondary', letterSpacing: 0.5, textTransform: 'uppercase', fontSize: '0.75rem' }}
+        >
+          Sub-steps
+        </Typography>
+
+        {steps.map((step, index) => (
+          <Box
+            key={step.id}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              mb: 1,
+              borderRadius: '10px',
+              border: '1.5px solid',
+              borderColor: 'rgba(102, 126, 234, 0.25)',
+              px: 1.5,
+              py: 0.5,
+              background: 'rgba(102, 126, 234, 0.04)',
+            }}
+          >
+            <Typography sx={{ color: 'text.disabled', fontSize: '0.85rem', minWidth: 20, textAlign: 'center' }}>
+              {index + 1}.
+            </Typography>
+            <InputBase
+              value={step.name}
+              onChange={e => updateStepName(step.id, e.target.value)}
+              placeholder="Step name"
+              fullWidth
+              inputProps={{ 'aria-label': `Sub-step ${index + 1} name` }}
+              sx={{ fontSize: '0.9375rem' }}
+            />
+            <IconButton
+              size="small"
+              onClick={() => removeStep(step.id)}
+              aria-label={`Remove step ${index + 1}`}
+              sx={{ color: 'text.disabled', '&:hover': { color: 'error.main' } }}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </Box>
+        ))}
+
+        <Button
+          startIcon={<AddIcon />}
+          onClick={addStep}
+          size="small"
+          sx={{
+            mt: steps.length > 0 ? 1 : 0,
+            textTransform: 'none',
+            fontWeight: 600,
+            color: '#667eea',
+            borderRadius: '8px',
+            px: 1.5,
+            '&:hover': { background: 'rgba(102, 126, 234, 0.08)' },
+          }}
+        >
+          Add step
+        </Button>
+      </Box>
+    )
+  }
 
   return (
     <Box

--- a/packages/web/src/routes/AddPlannerItemRoute/index.tsx
+++ b/packages/web/src/routes/AddPlannerItemRoute/index.tsx
@@ -184,16 +184,13 @@ export const AddPlannerItemContent = () => {
         </SegmentedControl>
       </Box>
       {itemType === 'task' ? (
-        <>
-          <ItemForm
-            fields={TASK_FIELDS}
-            onSubmit={onSubmit}
-            hideImage={true}
-          />
-          <Box sx={{ px: 2, width: '100%', boxSizing: 'border-box' }}>
-            <StepsEditor steps={steps} onChange={setSteps} />
-          </Box>
-        </>
+        <ItemForm
+          fields={TASK_FIELDS}
+          onSubmit={onSubmit}
+          hideImage={true}
+        >
+          <StepsEditor steps={steps} onChange={setSteps} embedded />
+        </ItemForm>
       ) : (
         <BirthdayForm />
       )}

--- a/packages/web/src/routes/EditPlannerItemRoute/index.tsx
+++ b/packages/web/src/routes/EditPlannerItemRoute/index.tsx
@@ -5,7 +5,7 @@ import { validateFields } from './utils'
 import { useNavigate, useParams } from 'react-router'
 import { useAppState } from '../../providers/AppStateProvider'
 import { useCallback, useEffect, useState, useMemo } from 'react'
-import { AlertColor, Box } from '@mui/material'
+import { AlertColor } from '@mui/material'
 import { Route } from '../../enums/route'
 import { showAlert } from '../../utils/alert'
 import StandardLayout from '../../layout/standardLayout'
@@ -126,10 +126,9 @@ const EditPlannerItemContent = () => {
         hideImage={true}
         submitButtonText="Update Item"
         submittingButtonText="Updating Item..."
-      />
-      <Box sx={{ px: 2, width: '100%', boxSizing: 'border-box' }}>
-        <StepsEditor steps={steps} onChange={setSteps} />
-      </Box>
+      >
+        <StepsEditor steps={steps} onChange={setSteps} embedded />
+      </ItemForm>
     </StandardLayout>
   )
 }


### PR DESCRIPTION
Sub-steps were previously rendered below the submit button, making them
easy to miss. This change integrates them into the form card above the
submit button, creating a clear top-to-bottom flow: details → sub-steps → submit.

- Add `embedded` prop to StepsEditor for card-integrated styling (no outer shadow/border-radius)
- Add `children` prop to ItemForm, rendered between form fields and submit button with a subtle divider
- Update AddPlannerItemRoute and EditPlannerItemRoute to pass StepsEditor as children to ItemForm
- Remove now-redundant standalone StepsEditor boxes from both route files

https://claude.ai/code/session_01MD2C5dCBuqTQJBaaLC4ySR