### PR TITLE
Auto-focus first input field across all add flows

### DIFF
--- a/packages/web/src/components/AddShopForm/index.tsx
+++ b/packages/web/src/components/AddShopForm/index.tsx
@@ -152,6 +152,7 @@ const AddShopForm = ({ onSubmit, onCancel, isSubmitting = false }: IAddShopFormP
           <form onSubmit={handleSubmit} noValidate>
             <FormFieldsContainer>
               <StyledTextField
+                autoFocus
                 fullWidth
                 label="Shop Name"
                 value={name}

--- a/packages/web/src/components/ItemForm/components/TextField/index.tsx
+++ b/packages/web/src/components/ItemForm/components/TextField/index.tsx
@@ -15,10 +15,10 @@ export const TextField = ({
     errors,
     isSubmitting
 }: ITextFieldProps) => {
-    const { name, label, type, required } = field
+    const { name, label, type, required, autoFocus } = field
 
     return (
-        <StyledTextField 
+        <StyledTextField
             key={name}
             fullWidth
             label={label}
@@ -27,6 +27,7 @@ export const TextField = ({
             error={!!errors[name]}
             helperText={errors[name]}
             required={required}
+            autoFocus={autoFocus}
             disabled={isSubmitting}
             aria-label={label}
             aria-required={required}

--- a/packages/web/src/components/ItemForm/types.ts
+++ b/packages/web/src/components/ItemForm/types.ts
@@ -8,6 +8,7 @@ export interface IFormField<T extends string | number | undefined = string | num
     label: string;
     value: T;
     required?: boolean;
+    autoFocus?: boolean;
     validate?: (value: T) => string | undefined;
     options?: Array<{ label: string; value: string }>;
 }

--- a/packages/web/src/components/RecipeForm/index.tsx
+++ b/packages/web/src/components/RecipeForm/index.tsx
@@ -335,6 +335,7 @@ const RecipeForm = ({ initialRecipe, onDone }: RecipeFormProps) => {
         fullWidth
         size="small"
         placeholder="e.g. Pasta Carbonara"
+        autoFocus={!initialRecipe}
       />
 
       <TextField

--- a/packages/web/src/routes/AddGroceryItemRoute/index.tsx
+++ b/packages/web/src/routes/AddGroceryItemRoute/index.tsx
@@ -24,6 +24,7 @@ const FIELDS: Array<IFormField> = [
     label: 'Name',
     type: FormFieldType.TEXT,
     required: true,
+    autoFocus: true,
     value: '',
   },
   {

--- a/packages/web/src/routes/AddPlannerItemRoute/index.tsx
+++ b/packages/web/src/routes/AddPlannerItemRoute/index.tsx
@@ -32,6 +32,7 @@ const TASK_FIELDS: Array<IFormField> = [
     label: 'Name',
     type: FormFieldType.TEXT,
     required: true,
+    autoFocus: true,
     value: '',
   },
   {


### PR DESCRIPTION
Extends the auto-focus behaviour (already present on birthday and project
creation) to grocery items, to-do/planner tasks, add shop, and add recipe.

- Add `autoFocus?: boolean` to `IFormField` interface
- Thread `autoFocus` through `ItemForm`'s internal `TextField` component
- Set `autoFocus: true` on the name field in AddGroceryItemRoute and AddPlannerItemRoute
- Add `autoFocus` to Shop Name input in AddShopForm
- Add `autoFocus` (add-mode only) to Recipe name input in RecipeForm

https://claude.ai/code/session_01HCPvj3qH3P9vgKidDYu5YS