### PR TITLE
Add Grocery Settings menu option to user avatar menu

### DIFF
--- a/packages/web/src/components/UserMenu/GrocerySettingsSubpage.tsx
+++ b/packages/web/src/components/UserMenu/GrocerySettingsSubpage.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react'
+import { Divider, CircularProgress } from '@mui/material'
+import { ArrowBack as ArrowBackIcon } from '@mui/icons-material'
+import * as Styled from './index.styled'
+import { retrieveGroceryListDefaults } from '../../api/groceryList'
+import { IDBGroceryItemDefault } from '../../api/groceryList/retrieve/types'
+
+interface GrocerySettingsSubpageProps {
+  onBack: () => void
+}
+
+const GrocerySettingsSubpage: React.FC<GrocerySettingsSubpageProps> = ({ onBack }) => {
+  const [defaults, setDefaults] = useState<Array<IDBGroceryItemDefault>>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    retrieveGroceryListDefaults()
+      .then(setDefaults)
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  const groupedByCategory = defaults.reduce<Record<string, Array<IDBGroceryItemDefault>>>((acc, item) => {
+    const category = item.category || 'Other'
+    if (!acc[category]) acc[category] = []
+    acc[category].push(item)
+    return acc
+  }, {})
+
+  const sortedCategories = Object.keys(groupedByCategory).sort()
+
+  return (
+    <>
+      <Styled.SubpageHeader>
+        <Styled.BackButton onClick={onBack}>
+          <ArrowBackIcon fontSize="small" />
+        </Styled.BackButton>
+        <Styled.SubpageTitle>Grocery Settings</Styled.SubpageTitle>
+      </Styled.SubpageHeader>
+
+      <Divider sx={{ my: 1 }} />
+
+      {isLoading && (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '24px 0' }}>
+          <CircularProgress size={24} />
+        </div>
+      )}
+
+      {!isLoading && defaults.length === 0 && (
+        <div style={{ fontSize: '13px', color: '#6b7280', textAlign: 'center', padding: '16px 0' }}>
+          No default items configured.
+        </div>
+      )}
+
+      {!isLoading && sortedCategories.map(category => (
+        <div key={category}>
+          <Styled.SectionTitle>{category}</Styled.SectionTitle>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', marginBottom: '4px' }}>
+            {groupedByCategory[category].map(item => (
+              <div
+                key={item.name}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  gap: '4px',
+                  width: '60px',
+                }}
+              >
+                <div
+                  style={{
+                    width: '44px',
+                    height: '44px',
+                    borderRadius: '10px',
+                    background: '#f3f4f6',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    overflow: 'hidden',
+                    flexShrink: 0,
+                  }}
+                >
+                  {item.icon ? (
+                    <img
+                      src={item.icon}
+                      alt={item.name}
+                      style={{ width: '32px', height: '32px', objectFit: 'contain' }}
+                    />
+                  ) : (
+                    <span style={{ fontSize: '20px' }}>🛒</span>
+                  )}
+                </div>
+                <span
+                  style={{
+                    fontSize: '10px',
+                    color: '#374151',
+                    textAlign: 'center',
+                    lineHeight: '1.2',
+                    wordBreak: 'break-word',
+                    width: '100%',
+                  }}
+                >
+                  {item.name}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  )
+}
+
+export default GrocerySettingsSubpage

--- a/packages/web/src/components/UserMenu/index.tsx
+++ b/packages/web/src/components/UserMenu/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { useAuth } from 'react-oidc-context'
 import { Divider, ListItemIcon, ListItemText } from '@mui/material'
-import { Settings as SettingsIcon, Notifications as NotificationsIcon } from '@mui/icons-material'
+import { Settings as SettingsIcon, Notifications as NotificationsIcon, ShoppingCart as ShoppingCartIcon } from '@mui/icons-material'
 import * as Styled from './index.styled'
 import { getPostLogoutRedirectUri, oidcConfig } from '../../config/oidc'
 import { useProjectContext } from '../../providers/ProjectProvider'
@@ -10,8 +10,9 @@ import CreateProjectDialog from '../CreateProjectDialog'
 import JoinProjectDialog from '../JoinProjectDialog'
 import ProjectSettingsSubpage from './ProjectSettingsSubpage'
 import NotificationSettingsSubpage from './NotificationSettingsSubpage'
+import GrocerySettingsSubpage from './GrocerySettingsSubpage'
 
-type SubpageView = 'main' | 'projects' | 'notifications'
+type SubpageView = 'main' | 'projects' | 'notifications' | 'grocery'
 
 const UserMenu: React.FC = () => {
   const auth = useAuth()
@@ -65,6 +66,10 @@ const UserMenu: React.FC = () => {
 
   const handleShowNotificationSettings = () => {
     setCurrentView('notifications')
+  }
+
+  const handleShowGrocerySettings = () => {
+    setCurrentView('grocery')
   }
 
   const handleBackToMain = () => {
@@ -168,6 +173,13 @@ const UserMenu: React.FC = () => {
                   <ListItemText primary="Notification Settings" />
                 </Styled.MainMenuItem>
 
+                <Styled.MainMenuItem onClick={handleShowGrocerySettings}>
+                  <ListItemIcon>
+                    <ShoppingCartIcon fontSize="small" />
+                  </ListItemIcon>
+                  <ListItemText primary="Grocery Settings" />
+                </Styled.MainMenuItem>
+
                 <Divider sx={{ my: 1 }} />
                 
                 <Styled.LogoutButton onClick={handleLogout}>
@@ -187,6 +199,12 @@ const UserMenu: React.FC = () => {
 
             {currentView === 'notifications' && (
               <NotificationSettingsSubpage
+                onBack={handleBackToMain}
+              />
+            )}
+
+            {currentView === 'grocery' && (
+              <GrocerySettingsSubpage
                 onBack={handleBackToMain}
               />
             )}


### PR DESCRIPTION
Adds a new "Grocery Settings" entry in the user menu that opens a subpage
displaying all default grocery items with their icons and names, grouped by
category. Data is fetched from the existing grocery defaults API endpoint.

https://claude.ai/code/session_015VEoBY73SnXKEXw3cVft7B