### PR TITLE
Add meal planning feature

### DIFF
--- a/packages/infra/main.tf
+++ b/packages/infra/main.tf
@@ -70,6 +70,7 @@ module "policies" {
   dynamodb_shops_arn                  = module.dynamodb.shops_arn
   dynamodb_recipes_arn                = module.dynamodb.recipes_arn
   dynamodb_birthdays_arn              = module.dynamodb.birthdays_arn
+  dynamodb_meal_plans_arn             = module.dynamodb.meal_plans_arn
   sns_todo_notifications_arn          = module.sns.todo_notifications_topic_arn
   s3_kairos_web_arn                   = module.s3.kairos_web_arn
   s3_kairos_lambdas_arn               = module.s3.kairos_lambdas_arn

--- a/packages/infra/modules/api_gateway/openapi/meal_plans.yml
+++ b/packages/infra/modules/api_gateway/openapi/meal_plans.yml
@@ -1,0 +1,268 @@
+openapi: 3.0.1
+info:
+  title: Meal Plans
+  description: |
+    API for Meal Plan Management
+  version: "1.0"
+paths:
+  /meal-plans:
+    get:
+      security:
+        - CognitoAuthorizer: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectIDHeader"
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: AWS_PROXY
+        uri: ${lambda_functions["get_meal_plans"].invoke_arn}
+        passthroughBehavior: when_no_match
+        contentHandling: CONVERT_TO_TEXT
+      responses:
+        200:
+          description: Meal plans retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/mealPlan"
+    put:
+      security:
+        - CognitoAuthorizer: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectIDHeader"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/createMealPlanRequest"
+        required: true
+      x-amazon-apigateway-request-validator: Validate body
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: AWS_PROXY
+        uri: ${lambda_functions["add_meal_plan"].invoke_arn}
+        passthroughBehavior: "when_no_match"
+        contentHandling: "CONVERT_TO_TEXT"
+      responses:
+        201:
+          description: Meal plan created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    example: "meal-plan-123"
+        400:
+          description: Incorrect meal plan details
+    options:
+      responses:
+        200:
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Access-Control-Allow-Methods: "'GET, PUT'"
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Project-ID'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestTemplates:
+          application/json: '{"statusCode": 200}'
+        passthroughBehavior: "when_no_match"
+        type: "mock"
+  /meal-plans/{id}:
+    post:
+      security:
+        - CognitoAuthorizer: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectIDHeader"
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Identifier of the meal plan to be updated
+          example: "meal-plan-123"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/updateMealPlanRequest"
+        required: true
+      x-amazon-apigateway-request-validator: Validate body
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: AWS_PROXY
+        uri: ${lambda_functions["update_meal_plan"].invoke_arn}
+        passthroughBehavior: when_no_match
+        contentHandling: CONVERT_TO_TEXT
+      responses:
+        200:
+          description: Meal plan updated successfully
+        400:
+          description: Incorrect meal plan details
+    delete:
+      security:
+        - CognitoAuthorizer: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectIDHeader"
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Identifier of the meal plan to be removed
+          example: "meal-plan-123"
+      x-amazon-apigateway-integration:
+        httpMethod: POST
+        type: AWS_PROXY
+        uri: ${lambda_functions["delete_meal_plan"].invoke_arn}
+        passthroughBehavior: when_no_match
+        contentHandling: CONVERT_TO_TEXT
+      responses:
+        200:
+          description: Meal plan removed
+        400:
+          description: Invalid meal plan ID
+        404:
+          description: Meal plan does not exist
+    options:
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Identifier of the meal plan
+          example: "meal-plan-123"
+      responses:
+        200:
+          description: "200 response"
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: "string"
+            Access-Control-Allow-Methods:
+              schema:
+                type: "string"
+            Access-Control-Allow-Headers:
+              schema:
+                type: "string"
+      x-amazon-apigateway-integration:
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Access-Control-Allow-Methods: "'POST, DELETE'"
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Project-ID'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestTemplates:
+          application/json: '{"statusCode": 200}'
+        passthroughBehavior: "when_no_match"
+        type: "mock"
+components:
+  parameters:
+    ProjectIDHeader:
+      name: X-Project-ID
+      in: header
+      required: true
+      schema:
+        type: string
+      description: Project ID for multi-tenancy data isolation
+  schemas:
+    mealPlan:
+      title: Meal Plan
+      type: object
+      required:
+        - id
+        - projectId
+        - date
+        - recipeName
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          example: "meal-plan-123"
+        projectId:
+          type: string
+          example: "project-456"
+        date:
+          type: string
+          example: "2025-08-21"
+        recipeName:
+          type: string
+          example: "Pasta Carbonara"
+        recipeId:
+          type: string
+          example: "recipe-789"
+        createdAt:
+          type: string
+          format: date-time
+          example: "2024-01-01T00:00:00Z"
+        updatedAt:
+          type: string
+          format: date-time
+          example: "2024-01-01T00:00:00Z"
+    createMealPlanRequest:
+      title: Create Meal Plan Request
+      type: object
+      required:
+        - date
+        - recipeName
+      properties:
+        date:
+          type: string
+          example: "2025-08-21"
+        recipeName:
+          type: string
+          example: "Pasta Carbonara"
+        recipeId:
+          type: string
+          example: "recipe-789"
+    updateMealPlanRequest:
+      title: Update Meal Plan Request
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: "meal-plan-123"
+        date:
+          type: string
+          example: "2025-08-22"
+        recipeName:
+          type: string
+          example: "Updated Meal Name"
+        recipeId:
+          type: string
+          nullable: true
+          example: "recipe-789"
+  securitySchemes:
+    CognitoAuthorizer:
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: cognito_user_pools
+      x-amazon-apigateway-authorizer:
+        type: cognito_user_pools
+        providerARNs:
+          - ${cognito_user_pool_arn}
+x-amazon-apigateway-request-validators:
+  Validate body:
+    validateRequestParameters: false
+    validateRequestBody: true

--- a/packages/infra/modules/dynamodb/main.meal_plans.tf
+++ b/packages/infra/modules/dynamodb/main.meal_plans.tf
@@ -1,0 +1,25 @@
+resource "aws_dynamodb_table" "meal_plans" {
+  name           = "MealPlans"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 1
+  write_capacity = 1
+  hash_key       = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "projectId"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "ProjectMealPlansIndex"
+    hash_key        = "projectId"
+    write_capacity  = 1
+    read_capacity   = 1
+    projection_type = "ALL"
+  }
+}

--- a/packages/infra/modules/dynamodb/outputs.tf
+++ b/packages/infra/modules/dynamodb/outputs.tf
@@ -45,3 +45,7 @@ output "recipes_arn" {
 output "birthdays_arn" {
   value = aws_dynamodb_table.birthdays.arn
 }
+
+output "meal_plans_arn" {
+  value = aws_dynamodb_table.meal_plans.arn
+}

--- a/packages/infra/modules/lambda/locals.tf
+++ b/packages/infra/modules/lambda/locals.tf
@@ -518,6 +518,54 @@ locals {
           todo_notifications = "none"
         }
       }
+    },
+    "add_meal_plan" = {
+      environment_variables = {}
+      permissions = {
+        database = {
+          meal_plans         = "read-write"
+          push_subscriptions = "none"
+        }
+        sns = {
+          todo_notifications = "none"
+        }
+      }
+    },
+    "get_meal_plans" = {
+      environment_variables = {}
+      permissions = {
+        database = {
+          meal_plans         = "read-only"
+          push_subscriptions = "none"
+        }
+        sns = {
+          todo_notifications = "none"
+        }
+      }
+    },
+    "update_meal_plan" = {
+      environment_variables = {}
+      permissions = {
+        database = {
+          meal_plans         = "read-write"
+          push_subscriptions = "none"
+        }
+        sns = {
+          todo_notifications = "none"
+        }
+      }
+    },
+    "delete_meal_plan" = {
+      environment_variables = {}
+      permissions = {
+        database = {
+          meal_plans         = "read-write"
+          push_subscriptions = "none"
+        }
+        sns = {
+          todo_notifications = "none"
+        }
+      }
     }
   }
 }

--- a/packages/infra/modules/policies/data.lambda.tf
+++ b/packages/infra/modules/policies/data.lambda.tf
@@ -353,6 +353,34 @@ data "aws_iam_policy_document" "lambda_policies" {
   }
 
   dynamic "statement" {
+    for_each = each.value.permissions.database.meal_plans == local.permissions.read_only ? [each.key] : []
+
+    content {
+      sid     = "DatabaseReadOnlyMealPlans"
+      actions = local.database_read_only_actions
+      effect  = "Allow"
+      resources = [
+        var.dynamodb_meal_plans_arn,
+        "${var.dynamodb_meal_plans_arn}/index/*",
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = each.value.permissions.database.meal_plans == local.permissions.read_write ? [each.key] : []
+
+    content {
+      sid     = "DatabaseReadWriteMealPlans"
+      actions = local.database_read_write_actions
+      effect  = "Allow"
+      resources = [
+        var.dynamodb_meal_plans_arn,
+        "${var.dynamodb_meal_plans_arn}/index/*",
+      ]
+    }
+  }
+
+  dynamic "statement" {
     for_each = try(each.value.permissions.s3.recipe_uploads, "none") == "put-only" ? [each.key] : []
 
     content {

--- a/packages/infra/modules/policies/variables.tf
+++ b/packages/infra/modules/policies/variables.tf
@@ -26,6 +26,7 @@ variable "lambda_functions" {
         shops                  = optional(string, "none")
         recipes                = optional(string, "none")
         birthdays              = optional(string, "none")
+        meal_plans             = optional(string, "none")
       })
       sns = object({
         todo_notifications = optional(string, "none")
@@ -87,6 +88,10 @@ variable "dynamodb_recipes_arn" {
 }
 
 variable "dynamodb_birthdays_arn" {
+  type = string
+}
+
+variable "dynamodb_meal_plans_arn" {
   type = string
 }
 

--- a/packages/lambdas/libs/dynamodb/enums/index.ts
+++ b/packages/lambdas/libs/dynamodb/enums/index.ts
@@ -11,6 +11,7 @@ export enum DynamoDBTable {
   SHOPS = "Shops",
   RECIPES = "Recipes",
   BIRTHDAYS = "Birthdays",
+  MEAL_PLANS = "MealPlans",
 }
 
 export enum DynamoDBIndex {
@@ -26,6 +27,7 @@ export enum DynamoDBIndex {
   SHOPS_PROJECT = "ProjectShopsIndex",
   RECIPES_PROJECT = "ProjectRecipesIndex",
   BIRTHDAYS_PROJECT = "ProjectBirthdaysIndex",
+  MEAL_PLANS_PROJECT = "ProjectMealPlansIndex",
 }
 
 export enum GroceryItemUnit {

--- a/packages/lambdas/sources/add_meal_plan/body/index.ts
+++ b/packages/lambdas/sources/add_meal_plan/body/index.ts
@@ -1,0 +1,34 @@
+import { IRequestBody } from "./types";
+
+const validateBody = (body: any): body is IRequestBody => {
+  if (!body.date || typeof body.date !== 'string' || body.date.trim().length === 0) {
+    return false;
+  }
+
+  if (!body.recipeName || typeof body.recipeName !== 'string' || body.recipeName.trim().length === 0) {
+    return false;
+  }
+
+  if (body.recipeId !== undefined && typeof body.recipeId !== 'string') {
+    return false;
+  }
+
+  return true;
+};
+
+export const getBody = (body: string | null): IRequestBody | null => {
+  if (!body) {
+    return null;
+  }
+
+  try {
+    const parsedBody = JSON.parse(body);
+    if (validateBody(parsedBody)) {
+      return parsedBody;
+    }
+  } catch (error) {
+    console.error('Failed to parse body:', error);
+  }
+
+  return null;
+};

--- a/packages/lambdas/sources/add_meal_plan/body/types.ts
+++ b/packages/lambdas/sources/add_meal_plan/body/types.ts
@@ -1,0 +1,5 @@
+export interface IRequestBody {
+    date: string;
+    recipeName: string;
+    recipeId?: string;
+}

--- a/packages/lambdas/sources/add_meal_plan/database/index.ts
+++ b/packages/lambdas/sources/add_meal_plan/database/index.ts
@@ -1,0 +1,32 @@
+import { DynamoDBTable, putItem } from "@kairos-lambdas-libs/dynamodb";
+import { randomUUID } from "node:crypto";
+
+export const createMealPlan = async (mealPlan: {
+  projectId: string;
+  date: string;
+  recipeName: string;
+  recipeId?: string;
+}): Promise<string> => {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+
+  const item: Record<string, any> = {
+    id,
+    projectId: mealPlan.projectId,
+    date: mealPlan.date.trim(),
+    recipeName: mealPlan.recipeName.trim(),
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  if (mealPlan.recipeId) {
+    item.recipeId = mealPlan.recipeId;
+  }
+
+  await putItem({
+    tableName: DynamoDBTable.MEAL_PLANS,
+    item,
+  });
+
+  return id;
+};

--- a/packages/lambdas/sources/add_meal_plan/index.ts
+++ b/packages/lambdas/sources/add_meal_plan/index.ts
@@ -1,0 +1,35 @@
+import { APIGatewayProxyEvent, Handler } from "aws-lambda";
+import { middleware, AuthenticatedEvent } from "@kairos-lambdas-libs/middleware";
+import { createResponse } from "@kairos-lambdas-libs/response";
+import { getBody } from "./body";
+import { createMealPlan } from "./database";
+
+export const handler: Handler<APIGatewayProxyEvent> = middleware(
+  async (event: AuthenticatedEvent) => {
+    const { projectId } = event;
+
+    if (!projectId) {
+      return createResponse({
+        statusCode: 400,
+        message: "Project ID is required",
+      });
+    }
+
+    const body = getBody(event.body);
+
+    if (!body) {
+      return createResponse({
+        statusCode: 400,
+      });
+    }
+
+    const { date, recipeName, recipeId } = body;
+
+    const id = await createMealPlan({ projectId, date, recipeName, recipeId });
+
+    return createResponse({
+      statusCode: 201,
+      message: { id },
+    });
+  },
+);

--- a/packages/lambdas/sources/add_meal_plan/package.json
+++ b/packages/lambdas/sources/add_meal_plan/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "add_meal_plan",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@kairos-lambdas-libs/dynamodb": "1.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0"
+  }
+}

--- a/packages/lambdas/sources/delete_meal_plan/index.ts
+++ b/packages/lambdas/sources/delete_meal_plan/index.ts
@@ -1,0 +1,34 @@
+import { APIGatewayProxyEvent, Handler } from "aws-lambda";
+import { middleware, AuthenticatedEvent } from "@kairos-lambdas-libs/middleware";
+import { createResponse } from "@kairos-lambdas-libs/response";
+import { DynamoDBTable, deleteItem } from "@kairos-lambdas-libs/dynamodb";
+
+export const handler: Handler<APIGatewayProxyEvent> = middleware(
+  async (event: AuthenticatedEvent) => {
+    const { projectId } = event;
+
+    if (!projectId) {
+      return createResponse({
+        statusCode: 400,
+        message: "Project ID is required",
+      });
+    }
+
+    const { id } = event.pathParameters ?? {};
+
+    if (!id || typeof id !== "string") {
+      return createResponse({
+        statusCode: 400,
+      });
+    }
+
+    await deleteItem({
+      key: { id },
+      tableName: DynamoDBTable.MEAL_PLANS,
+    });
+
+    return createResponse({
+      statusCode: 200,
+    });
+  },
+);

--- a/packages/lambdas/sources/delete_meal_plan/package.json
+++ b/packages/lambdas/sources/delete_meal_plan/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "delete_meal_plan",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@kairos-lambdas-libs/dynamodb": "1.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0"
+  }
+}

--- a/packages/lambdas/sources/get_meal_plans/index.ts
+++ b/packages/lambdas/sources/get_meal_plans/index.ts
@@ -1,0 +1,28 @@
+import { APIGatewayProxyEvent, Handler } from "aws-lambda";
+import { middleware, AuthenticatedEvent } from "@kairos-lambdas-libs/middleware";
+import { createResponse } from "@kairos-lambdas-libs/response";
+import { DynamoDBTable, DynamoDBIndex, query } from "@kairos-lambdas-libs/dynamodb";
+
+export const handler: Handler<APIGatewayProxyEvent> = middleware(
+  async (event: AuthenticatedEvent) => {
+    const { projectId } = event;
+
+    if (!projectId) {
+      return createResponse({
+        statusCode: 400,
+        message: "Project ID is required",
+      });
+    }
+
+    const items = await query({
+      tableName: DynamoDBTable.MEAL_PLANS,
+      indexName: DynamoDBIndex.MEAL_PLANS_PROJECT,
+      attributes: { projectId },
+    });
+
+    return createResponse({
+      statusCode: 200,
+      message: items,
+    });
+  },
+);

--- a/packages/lambdas/sources/get_meal_plans/package.json
+++ b/packages/lambdas/sources/get_meal_plans/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "get_meal_plans",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@kairos-lambdas-libs/dynamodb": "1.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0"
+  }
+}

--- a/packages/lambdas/sources/update_meal_plan/body/index.ts
+++ b/packages/lambdas/sources/update_meal_plan/body/index.ts
@@ -1,0 +1,34 @@
+import { IRequestBody } from "./types";
+
+const validateBody = (body: any): body is IRequestBody => {
+  if (!body.id || typeof body.id !== 'string') {
+    return false;
+  }
+
+  if (body.date !== undefined && (typeof body.date !== 'string' || body.date.trim().length === 0)) {
+    return false;
+  }
+
+  if (body.recipeName !== undefined && (typeof body.recipeName !== 'string' || body.recipeName.trim().length === 0)) {
+    return false;
+  }
+
+  return true;
+};
+
+export const getBody = (body: string | null): IRequestBody | null => {
+  if (!body) {
+    return null;
+  }
+
+  try {
+    const parsedBody = JSON.parse(body);
+    if (validateBody(parsedBody)) {
+      return parsedBody;
+    }
+  } catch (error) {
+    console.error('Failed to parse body:', error);
+  }
+
+  return null;
+};

--- a/packages/lambdas/sources/update_meal_plan/body/types.ts
+++ b/packages/lambdas/sources/update_meal_plan/body/types.ts
@@ -1,0 +1,6 @@
+export interface IRequestBody {
+    id: string;
+    date?: string;
+    recipeName?: string;
+    recipeId?: string | null;
+}

--- a/packages/lambdas/sources/update_meal_plan/database/index.ts
+++ b/packages/lambdas/sources/update_meal_plan/database/index.ts
@@ -1,0 +1,28 @@
+import { DynamoDBTable, updateItem } from "@kairos-lambdas-libs/dynamodb";
+
+export const updateMealPlan = async (
+  id: string,
+  fields: { date?: string; recipeName?: string; recipeId?: string | null }
+): Promise<void> => {
+  const updatedFields: Record<string, any> = {
+    updatedAt: new Date().toISOString(),
+  };
+
+  if (fields.date !== undefined) {
+    updatedFields.date = fields.date.trim();
+  }
+
+  if (fields.recipeName !== undefined) {
+    updatedFields.recipeName = fields.recipeName.trim();
+  }
+
+  if (fields.recipeId !== undefined) {
+    updatedFields.recipeId = fields.recipeId || null;
+  }
+
+  await updateItem({
+    tableName: DynamoDBTable.MEAL_PLANS,
+    key: { id },
+    updatedFields,
+  });
+};

--- a/packages/lambdas/sources/update_meal_plan/index.ts
+++ b/packages/lambdas/sources/update_meal_plan/index.ts
@@ -1,0 +1,35 @@
+import { APIGatewayProxyEvent, Handler } from "aws-lambda";
+import { middleware, AuthenticatedEvent } from "@kairos-lambdas-libs/middleware";
+import { createResponse } from "@kairos-lambdas-libs/response";
+import { getBody } from "./body";
+import { updateMealPlan } from "./database";
+
+export const handler: Handler<APIGatewayProxyEvent> = middleware(
+  async (event: AuthenticatedEvent) => {
+    const { projectId } = event;
+
+    if (!projectId) {
+      return createResponse({
+        statusCode: 400,
+        message: "Project ID is required",
+      });
+    }
+
+    const body = getBody(event.body);
+
+    if (!body) {
+      return createResponse({
+        statusCode: 400,
+      });
+    }
+
+    const { id, date, recipeName, recipeId } = body;
+
+    await updateMealPlan(id, { date, recipeName, recipeId });
+
+    return createResponse({
+      statusCode: 200,
+      message: { id },
+    });
+  },
+);

--- a/packages/lambdas/sources/update_meal_plan/package.json
+++ b/packages/lambdas/sources/update_meal_plan/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "update_meal_plan",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@kairos-lambdas-libs/dynamodb": "1.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0"
+  }
+}

--- a/packages/web/src/api/mealPlans/add/index.ts
+++ b/packages/web/src/api/mealPlans/add/index.ts
@@ -1,0 +1,25 @@
+import { IMealPlan } from '../../../types/mealPlan'
+import { API_BASE_URL } from '../../index'
+import { createFetchOptions } from '../../../utils/api'
+
+export const addMealPlan = async (
+  mealPlan: { date: string; recipeName: string; recipeId?: string },
+  projectId?: string
+): Promise<IMealPlan> => {
+  const response = await fetch(`${API_BASE_URL}/meal-plans`, createFetchOptions({
+    method: 'PUT',
+    body: JSON.stringify(mealPlan),
+  }, projectId))
+
+  if (response.ok) {
+    const data = await response.json()
+
+    if (data.id) {
+      return data
+    }
+
+    throw new Error('Unexpected response from API')
+  }
+
+  throw new Error('Failed to add meal plan')
+}

--- a/packages/web/src/api/mealPlans/delete/index.ts
+++ b/packages/web/src/api/mealPlans/delete/index.ts
@@ -1,0 +1,12 @@
+import { API_BASE_URL } from '../../index'
+import { createFetchOptions } from '../../../utils/api'
+
+export const deleteMealPlan = async (id: string, projectId?: string): Promise<void> => {
+  const response = await fetch(`${API_BASE_URL}/meal-plans/${id}`, createFetchOptions({
+    method: 'DELETE',
+  }, projectId))
+
+  if (!response.ok) {
+    throw new Error('Failed to delete meal plan')
+  }
+}

--- a/packages/web/src/api/mealPlans/get/index.ts
+++ b/packages/web/src/api/mealPlans/get/index.ts
@@ -1,0 +1,13 @@
+import { IMealPlan } from '../../../types/mealPlan'
+import { API_BASE_URL } from '../../index'
+import { createFetchOptions } from '../../../utils/api'
+
+export const getMealPlans = async (projectId?: string): Promise<IMealPlan[]> => {
+  const response = await fetch(`${API_BASE_URL}/meal-plans`, createFetchOptions({}, projectId))
+
+  if (response.ok) {
+    return await response.json()
+  }
+
+  return []
+}

--- a/packages/web/src/api/mealPlans/index.ts
+++ b/packages/web/src/api/mealPlans/index.ts
@@ -1,0 +1,4 @@
+export { addMealPlan } from './add'
+export { getMealPlans } from './get'
+export { updateMealPlan } from './update'
+export { deleteMealPlan } from './delete'

--- a/packages/web/src/api/mealPlans/update/index.ts
+++ b/packages/web/src/api/mealPlans/update/index.ts
@@ -1,0 +1,17 @@
+import { API_BASE_URL } from '../../index'
+import { createFetchOptions } from '../../../utils/api'
+
+export const updateMealPlan = async (
+  id: string,
+  fields: { date?: string; recipeName?: string; recipeId?: string | null },
+  projectId?: string
+): Promise<void> => {
+  const response = await fetch(`${API_BASE_URL}/meal-plans/${id}`, createFetchOptions({
+    method: 'POST',
+    body: JSON.stringify({ id, ...fields }),
+  }, projectId))
+
+  if (!response.ok) {
+    throw new Error('Failed to update meal plan')
+  }
+}

--- a/packages/web/src/components/MealPlanDrawer/index.styled.tsx
+++ b/packages/web/src/components/MealPlanDrawer/index.styled.tsx
@@ -1,0 +1,84 @@
+import { styled } from '@mui/material/styles'
+import { Box, Typography, TextField, Button, ToggleButtonGroup } from '@mui/material'
+
+export const DrawerContent = styled(Box)({
+  padding: '1.25em',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1em',
+})
+
+export const DrawerHeader = styled(Typography)({
+  fontWeight: 700,
+  fontSize: '1.1rem',
+  color: '#1d4ed8',
+})
+
+export const DateLabel = styled(Typography)({
+  fontSize: '0.9rem',
+  color: '#6b7280',
+  fontWeight: 500,
+})
+
+export const StyledTextField = styled(TextField)({
+  '& .MuiOutlinedInput-root': {
+    borderRadius: '8px',
+  },
+})
+
+export const ModeToggle = styled(ToggleButtonGroup)({
+  width: '100%',
+  '& .MuiToggleButton-root': {
+    flex: 1,
+    textTransform: 'none',
+    fontSize: '0.85rem',
+  },
+})
+
+export const RecipeList = styled(Box)({
+  maxHeight: '200px',
+  overflowY: 'auto',
+  border: '1px solid #e5e7eb',
+  borderRadius: '8px',
+})
+
+export const RecipeItem = styled(Box)<{ selected?: boolean }>(({ selected }) => ({
+  padding: '10px 14px',
+  cursor: 'pointer',
+  fontSize: '0.9rem',
+  color: selected ? '#1d4ed8' : '#374151',
+  backgroundColor: selected ? '#eff6ff' : 'transparent',
+  borderBottom: '1px solid #f3f4f6',
+  '&:last-child': {
+    borderBottom: 'none',
+  },
+  '&:hover': {
+    backgroundColor: selected ? '#dbeafe' : '#f9fafb',
+  },
+}))
+
+export const SaveButton = styled(Button)({
+  borderRadius: '8px',
+  textTransform: 'none',
+  fontWeight: 600,
+  padding: '10px',
+})
+
+export const DeleteButton = styled(Button)({
+  borderRadius: '8px',
+  textTransform: 'none',
+  fontWeight: 600,
+  padding: '10px',
+  color: '#dc2626',
+  borderColor: '#dc2626',
+  '&:hover': {
+    borderColor: '#b91c1c',
+    backgroundColor: '#fef2f2',
+  },
+})
+
+export const SearchField = styled(TextField)({
+  '& .MuiOutlinedInput-root': {
+    borderRadius: '8px',
+  },
+})

--- a/packages/web/src/components/MealPlanDrawer/index.tsx
+++ b/packages/web/src/components/MealPlanDrawer/index.tsx
@@ -1,0 +1,179 @@
+import { useState, useEffect, useMemo } from 'react'
+import { Drawer, ToggleButton, InputAdornment } from '@mui/material'
+import RestaurantIcon from '@mui/icons-material/Restaurant'
+import SearchIcon from '@mui/icons-material/Search'
+import dayjs from 'dayjs'
+import { IMealPlan } from '../../types/mealPlan'
+import { useRecipeContext } from '../../providers/RecipeProvider'
+import {
+  DrawerContent,
+  DrawerHeader,
+  DateLabel,
+  StyledTextField,
+  ModeToggle,
+  RecipeList,
+  RecipeItem,
+  SaveButton,
+  DeleteButton,
+  SearchField,
+} from './index.styled'
+
+type Mode = 'recipe' | 'custom'
+
+interface IMealPlanDrawerProps {
+  open: boolean
+  date: string | null
+  mealPlan?: IMealPlan
+  onClose: () => void
+  onSave: (date: string, recipeName: string, recipeId?: string) => void
+  onDelete?: (id: string) => void
+}
+
+const MealPlanDrawer = ({ open, date, mealPlan, onClose, onSave, onDelete }: IMealPlanDrawerProps) => {
+  const { recipes } = useRecipeContext()
+  const [mode, setMode] = useState<Mode>('recipe')
+  const [customName, setCustomName] = useState('')
+  const [selectedRecipeId, setSelectedRecipeId] = useState<string | undefined>(undefined)
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    if (open) {
+      if (mealPlan) {
+        if (mealPlan.recipeId) {
+          setMode('recipe')
+          setSelectedRecipeId(mealPlan.recipeId)
+          setCustomName('')
+        } else {
+          setMode('custom')
+          setCustomName(mealPlan.recipeName)
+          setSelectedRecipeId(undefined)
+        }
+      } else {
+        setMode('recipe')
+        setCustomName('')
+        setSelectedRecipeId(undefined)
+      }
+      setSearch('')
+    }
+  }, [open, mealPlan])
+
+  const filteredRecipes = useMemo(
+    () => recipes.filter(r => r.name.toLowerCase().includes(search.toLowerCase())),
+    [recipes, search]
+  )
+
+  const selectedRecipe = useMemo(
+    () => recipes.find(r => r.id === selectedRecipeId),
+    [recipes, selectedRecipeId]
+  )
+
+  const canSave = mode === 'recipe'
+    ? selectedRecipeId !== undefined
+    : customName.trim().length > 0
+
+  const handleSave = () => {
+    if (!date) return
+
+    if (mode === 'recipe' && selectedRecipe) {
+      onSave(date, selectedRecipe.name, selectedRecipe.id)
+    } else if (mode === 'custom' && customName.trim()) {
+      onSave(date, customName.trim(), undefined)
+    }
+  }
+
+  const displayDate = date ? dayjs(date).format('dddd, D MMMM YYYY') : ''
+
+  return (
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { borderRadius: '16px 16px 0 0', maxHeight: '85vh' } }}
+    >
+      <DrawerContent>
+        <DrawerHeader>
+          <RestaurantIcon sx={{ fontSize: '1.1rem', verticalAlign: 'middle', marginRight: '6px' }} />
+          {mealPlan ? 'Edit Meal' : 'Add Meal'}
+        </DrawerHeader>
+
+        <DateLabel>{displayDate}</DateLabel>
+
+        <ModeToggle
+          value={mode}
+          exclusive
+          onChange={(_, value) => { if (value) setMode(value) }}
+        >
+          <ToggleButton value="recipe">From Recipe</ToggleButton>
+          <ToggleButton value="custom">Custom Name</ToggleButton>
+        </ModeToggle>
+
+        {mode === 'recipe' ? (
+          <>
+            <SearchField
+              size="small"
+              placeholder="Search recipes..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon fontSize="small" />
+                  </InputAdornment>
+                ),
+              }}
+              fullWidth
+            />
+            <RecipeList>
+              {filteredRecipes.length === 0 ? (
+                <RecipeItem sx={{ color: '#9ca3af', fontStyle: 'italic' }}>
+                  {search ? 'No recipes found' : 'No recipes yet'}
+                </RecipeItem>
+              ) : (
+                filteredRecipes.map(recipe => (
+                  <RecipeItem
+                    key={recipe.id}
+                    selected={selectedRecipeId === recipe.id}
+                    onClick={() => setSelectedRecipeId(recipe.id)}
+                  >
+                    {recipe.name}
+                  </RecipeItem>
+                ))
+              )}
+            </RecipeList>
+          </>
+        ) : (
+          <StyledTextField
+            size="small"
+            label="Meal name"
+            value={customName}
+            onChange={(e) => setCustomName(e.target.value)}
+            fullWidth
+            autoFocus
+            onKeyDown={(e) => { if (e.key === 'Enter' && canSave) handleSave() }}
+          />
+        )}
+
+        <SaveButton
+          variant="contained"
+          fullWidth
+          disabled={!canSave}
+          onClick={handleSave}
+        >
+          Save
+        </SaveButton>
+
+        {mealPlan && onDelete && (
+          <DeleteButton
+            variant="outlined"
+            fullWidth
+            onClick={() => onDelete(mealPlan.id)}
+          >
+            Delete
+          </DeleteButton>
+        )}
+      </DrawerContent>
+    </Drawer>
+  )
+}
+
+export default MealPlanDrawer

--- a/packages/web/src/components/Planner/CalendarView/index.styled.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.styled.tsx
@@ -1,6 +1,7 @@
 import { styled } from '@mui/material/styles'
 import { Box, Typography } from '@mui/material'
 import CakeIcon from '@mui/icons-material/Cake'
+import RestaurantIcon from '@mui/icons-material/Restaurant'
 
 export const Container = styled('div')({
   display: 'flex',
@@ -265,4 +266,52 @@ export const BirthdayDayDetailItem = styled('div')({
   '&:hover': {
     backgroundColor: '#fce7f3',
   },
+})
+
+export const MealPlanIcon = styled(RestaurantIcon)({
+  fontSize: '0.85rem',
+  color: '#d97706',
+})
+
+export const MealDayDetailItem = styled('div')({
+  fontSize: '0.9rem',
+  color: '#92400e',
+  padding: '8px 10px',
+  borderBottom: '1px solid #fde68a',
+  cursor: 'pointer',
+  borderRadius: '4px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  '&:last-child': {
+    borderBottom: 'none',
+  },
+  '&:hover': {
+    backgroundColor: '#fef3c7',
+  },
+})
+
+export const AddMealButton = styled('div')({
+  fontSize: '0.85rem',
+  color: '#d97706',
+  padding: '8px 10px',
+  cursor: 'pointer',
+  borderRadius: '4px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  fontWeight: 500,
+  '&:hover': {
+    backgroundColor: '#fef3c7',
+  },
+})
+
+export const MealsSectionHeader = styled(Typography)({
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  color: '#d97706',
+  marginTop: '0.5em',
+  marginBottom: '0.25em',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
 })

--- a/packages/web/src/components/Planner/CalendarView/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.tsx
@@ -3,9 +3,12 @@ import { IconButton } from '@mui/material'
 import CakeIcon from '@mui/icons-material/Cake'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import AddIcon from '@mui/icons-material/Add'
+import LinkIcon from '@mui/icons-material/Link'
 import dayjs, { Dayjs } from 'dayjs'
 import { ITodoItem } from '../../../api/toDoList/retrieve/types'
 import { IBirthdayItem } from '../../../api/birthdays/retrieve/types'
+import { IMealPlan } from '../../../types/mealPlan'
 import {
   Container,
   CalendarHeader,
@@ -29,6 +32,10 @@ import {
   CompletedNoDueDateItem,
   BirthdayCakeIcon,
   BirthdayDayDetailItem,
+  MealPlanIcon,
+  MealDayDetailItem,
+  AddMealButton,
+  MealsSectionHeader,
 } from './index.styled'
 
 const WEEK_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -38,9 +45,20 @@ interface ICalendarViewProps {
   onItemClick: (id: string) => void
   birthdayItems?: IBirthdayItem[]
   onBirthdayClick?: (id: string) => void
+  mealPlans?: IMealPlan[]
+  onAddMealPlan?: (date: string) => void
+  onMealPlanClick?: (mealPlan: IMealPlan) => void
 }
 
-const CalendarView = ({ visibleToDoItems, onItemClick, birthdayItems = [], onBirthdayClick }: ICalendarViewProps) => {
+const CalendarView = ({
+  visibleToDoItems,
+  onItemClick,
+  birthdayItems = [],
+  onBirthdayClick,
+  mealPlans = [],
+  onAddMealPlan,
+  onMealPlanClick,
+}: ICalendarViewProps) => {
   const [currentMonth, setCurrentMonth] = useState<Dayjs>(() => dayjs().startOf('month'))
   const [selectedDay, setSelectedDay] = useState<string | null>(null)
   const today = dayjs()
@@ -130,6 +148,25 @@ const CalendarView = ({ visibleToDoItems, onItemClick, birthdayItems = [], onBir
     return birthdaysByDay.get(key) ?? []
   }, [selectedDay, birthdaysByDay])
 
+  // Map from "YYYY-MM-DD" -> IMealPlan[]
+  const mealPlansByDay = useMemo(() => {
+    const map = new Map<string, IMealPlan[]>()
+    for (const plan of mealPlans) {
+      const existing = map.get(plan.date)
+      if (existing) {
+        existing.push(plan)
+      } else {
+        map.set(plan.date, [plan])
+      }
+    }
+    return map
+  }, [mealPlans])
+
+  const selectedDayMealPlans = useMemo(
+    () => (selectedDay ? (mealPlansByDay.get(selectedDay) ?? []) : []),
+    [selectedDay, mealPlansByDay]
+  )
+
   // Build the grid: pad the start with days from the previous month
   const calendarDays = useMemo(() => {
     const startOfMonth = currentMonth.startOf('month')
@@ -184,6 +221,7 @@ const CalendarView = ({ visibleToDoItems, onItemClick, birthdayItems = [], onBir
           const completedCount = completedTodosByDay.get(key)?.length ?? 0
           const birthdayKey = `${day.month() + 1}-${day.date()}`
           const hasBirthday = isCurrentMonth && (birthdaysByDay.get(birthdayKey)?.length ?? 0) > 0
+          const hasMealPlan = isCurrentMonth && (mealPlansByDay.get(key)?.length ?? 0) > 0
 
           return (
             <DayCell
@@ -197,6 +235,7 @@ const CalendarView = ({ visibleToDoItems, onItemClick, birthdayItems = [], onBir
               <TodoDot count={pendingCount} isOverdue={isCurrentMonth && day.isBefore(today, 'day')}>{pendingCount > 0 ? pendingCount : ''}</TodoDot>
               <CompletedTodoDot count={completedCount}>{completedCount > 0 ? completedCount : ''}</CompletedTodoDot>
               {hasBirthday && <BirthdayCakeIcon />}
+              {hasMealPlan && <MealPlanIcon />}
             </DayCell>
           )
         })}
@@ -229,16 +268,28 @@ const CalendarView = ({ visibleToDoItems, onItemClick, birthdayItems = [], onBir
               ))}
             </>
           )}
-        {selectedDayBirthdays.length > 0 && (
-          <>
-            {selectedDayBirthdays.map(birthday => (
-              <BirthdayDayDetailItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
-                <CakeIcon sx={{ fontSize: '0.9rem', color: '#db2777', flexShrink: 0 }} />
-                {birthday.name}
-              </BirthdayDayDetailItem>
-            ))}
-          </>
-        )}
+          {selectedDayBirthdays.length > 0 && (
+            <>
+              {selectedDayBirthdays.map(birthday => (
+                <BirthdayDayDetailItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
+                  <CakeIcon sx={{ fontSize: '0.9rem', color: '#db2777', flexShrink: 0 }} />
+                  {birthday.name}
+                </BirthdayDayDetailItem>
+              ))}
+            </>
+          )}
+          <MealsSectionHeader>Meals</MealsSectionHeader>
+          {selectedDayMealPlans.map(plan => (
+            <MealDayDetailItem key={plan.id} onClick={() => onMealPlanClick?.(plan)}>
+              <MealPlanIcon sx={{ fontSize: '0.9rem', flexShrink: 0 }} />
+              {plan.recipeName}
+              {plan.recipeId && <LinkIcon sx={{ fontSize: '0.75rem', color: '#d97706', marginLeft: 'auto', flexShrink: 0 }} />}
+            </MealDayDetailItem>
+          ))}
+          <AddMealButton onClick={() => onAddMealPlan?.(selectedDay)}>
+            <AddIcon sx={{ fontSize: '0.9rem' }} />
+            Add meal
+          </AddMealButton>
         </DayDetailPanel>
       )}
 

--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -25,7 +25,10 @@ import { IToDoListProps } from './types';
 export const Planner = ({
   allExpanded = true,
   expandKey = 0,
-  viewMode = PlannerViewMode.CALENDAR
+  viewMode = PlannerViewMode.CALENDAR,
+  mealPlans = [],
+  onAddMealPlan,
+  onMealPlanClick,
 }: IToDoListProps = {}) => {
   const { dispatch } = useAppState();
   const { user } = useAuth();
@@ -117,6 +120,9 @@ export const Planner = ({
             onItemClick={handlePreview}
             birthdayItems={birthdays}
             onBirthdayClick={handleBirthdayPreview}
+            mealPlans={mealPlans}
+            onAddMealPlan={onAddMealPlan}
+            onMealPlanClick={onMealPlanClick}
           />
         )}
         <ToDoItemPreviewDrawer

--- a/packages/web/src/components/Planner/types.ts
+++ b/packages/web/src/components/Planner/types.ts
@@ -1,7 +1,11 @@
 import { PlannerViewMode } from '../../enums/plannerViewMode';
+import { IMealPlan } from '../../types/mealPlan';
 
 export interface IToDoListProps {
   allExpanded?: boolean;
   expandKey?: string | number;
   viewMode?: PlannerViewMode;
+  mealPlans?: IMealPlan[];
+  onAddMealPlan?: (date: string) => void;
+  onMealPlanClick?: (mealPlan: IMealPlan) => void;
 };

--- a/packages/web/src/providers/MealPlanProvider/index.tsx
+++ b/packages/web/src/providers/MealPlanProvider/index.tsx
@@ -1,0 +1,100 @@
+import { createContext, useContext, useState, useCallback, useLayoutEffect, useMemo } from 'react'
+import { IMealPlan } from '../../types/mealPlan'
+import { getMealPlans, addMealPlan as addMealPlanApi, updateMealPlan as updateMealPlanApi, deleteMealPlan } from '../../api/mealPlans'
+import { IState, IMealPlanProviderProps } from './types'
+import { useProjectContext } from '../ProjectProvider'
+
+const initialState: IState = {
+  mealPlans: [],
+  isLoading: false,
+  fetchMealPlans: async () => {},
+  addMealPlan: async () => {},
+  updateMealPlan: async () => {},
+  removeMealPlan: async () => {},
+}
+
+export const MealPlanContext = createContext<IState>(initialState)
+
+export const useMealPlanContext = () => useContext(MealPlanContext)
+
+export const MealPlanProvider = ({ children }: IMealPlanProviderProps) => {
+  const { currentProject } = useProjectContext()
+  const [mealPlans, setMealPlans] = useState<IMealPlan[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  const fetchMealPlans = useCallback(async () => {
+    if (!currentProject) return
+
+    try {
+      setIsLoading(true)
+      const items = await getMealPlans(currentProject.id)
+      setMealPlans(items)
+    } catch (error) {
+      console.error('Failed to fetch meal plans:', error)
+      setMealPlans([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [currentProject])
+
+  const addMealPlan = useCallback(async (date: string, recipeName: string, recipeId?: string) => {
+    if (!currentProject) return
+
+    const result = await addMealPlanApi({ date, recipeName, recipeId }, currentProject.id)
+    const newMealPlan: IMealPlan = {
+      ...result,
+      date,
+      recipeName,
+      recipeId,
+      projectId: currentProject.id,
+    }
+    setMealPlans((prev) => [...prev, newMealPlan])
+  }, [currentProject])
+
+  const updateMealPlan = useCallback(async (id: string, fields: { date?: string; recipeName?: string; recipeId?: string | null }) => {
+    if (!currentProject) return
+
+    await updateMealPlanApi(id, fields, currentProject.id)
+    const definedFields = Object.fromEntries(
+      Object.entries(fields).filter(([, v]) => v !== undefined)
+    ) as Partial<IMealPlan>
+    setMealPlans((prev) =>
+      prev.map((plan) =>
+        plan.id === id ? { ...plan, ...definedFields } : plan
+      )
+    )
+  }, [currentProject])
+
+  const removeMealPlan = useCallback(async (id: string) => {
+    if (!currentProject) return
+
+    await deleteMealPlan(id, currentProject.id)
+    setMealPlans((prev) => prev.filter((plan) => plan.id !== id))
+  }, [currentProject])
+
+  useLayoutEffect(() => {
+    if (currentProject) {
+      fetchMealPlans()
+    } else {
+      setMealPlans([])
+    }
+  }, [currentProject, fetchMealPlans])
+
+  const value = useMemo(
+    () => ({
+      mealPlans,
+      isLoading,
+      fetchMealPlans,
+      addMealPlan,
+      updateMealPlan,
+      removeMealPlan,
+    }),
+    [mealPlans, isLoading, fetchMealPlans, addMealPlan, updateMealPlan, removeMealPlan]
+  )
+
+  return (
+    <MealPlanContext.Provider value={value}>
+      {children}
+    </MealPlanContext.Provider>
+  )
+}

--- a/packages/web/src/providers/MealPlanProvider/types.ts
+++ b/packages/web/src/providers/MealPlanProvider/types.ts
@@ -1,0 +1,14 @@
+import { IMealPlan } from '../../types/mealPlan'
+
+export interface IState {
+  mealPlans: IMealPlan[]
+  isLoading: boolean
+  fetchMealPlans: () => Promise<void>
+  addMealPlan: (date: string, recipeName: string, recipeId?: string) => Promise<void>
+  updateMealPlan: (id: string, fields: { date?: string; recipeName?: string; recipeId?: string | null }) => Promise<void>
+  removeMealPlan: (id: string) => Promise<void>
+}
+
+export interface IMealPlanProviderProps {
+  children: React.ReactNode
+}

--- a/packages/web/src/routes/PlannerRoute/index.tsx
+++ b/packages/web/src/routes/PlannerRoute/index.tsx
@@ -1,9 +1,12 @@
 import StandardLayout from '../../layout/standardLayout'
 import { PlannerProvider, usePlannerContext } from '../../providers/PlannerProvider'
 import { BirthdayProvider } from '../../providers/BirthdayProvider'
+import { RecipeProvider } from '../../providers/RecipeProvider'
+import { MealPlanProvider, useMealPlanContext } from '../../providers/MealPlanProvider'
 import Planner from '../../components/Planner'
 import ActionButtonsBar from '../../components/ActionButtonsBar'
 import ModernPageHeader from '../../components/ModernPageHeader'
+import MealPlanDrawer from '../../components/MealPlanDrawer'
 import ChecklistIcon from '@mui/icons-material/Checklist'
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 import ViewModuleIcon from '@mui/icons-material/ViewModule'
@@ -15,6 +18,7 @@ import { ActionName } from '../../providers/AppStateProvider/enums'
 import { useProjectContext } from '../../providers/ProjectProvider'
 import { updateToDoItems } from '../../api/toDoList'
 import { PlannerViewMode } from '../../enums/plannerViewMode'
+import { IMealPlan } from '../../types/mealPlan'
 import dayjs from 'dayjs'
 
 const PlannerContent = () => {
@@ -24,7 +28,12 @@ const PlannerContent = () => {
   const [allExpanded, setAllExpanded] = useState(true)
   const [expandKey, setExpandKey] = useState(0)
   const [viewMode, setViewMode] = useState<PlannerViewMode>(PlannerViewMode.CALENDAR)
-  
+  const { mealPlans, addMealPlan, updateMealPlan, removeMealPlan } = useMealPlanContext()
+
+  const [mealDrawerOpen, setMealDrawerOpen] = useState(false)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [editingMealPlan, setEditingMealPlan] = useState<IMealPlan | undefined>(undefined)
+
   const pendingItems = toDoList.filter(item => !item.isDone)
   const completedItems = toDoList.filter(item => item.isDone)
 
@@ -63,22 +72,22 @@ const PlannerContent = () => {
   const statusText = useMemo(() => {
     const totalItems = toDoList.length
     const selectedCount = selectedTodoItems.size
-    
+
     if (totalItems === 0) {
       return "Your planner is empty"
     }
-    
+
     if (selectedCount === 0) {
       return "Tap items to mark as done"
     }
-    
+
     return `${selectedCount} of ${totalItems} item${totalItems === 1 ? '' : 's'} selected`
   }, [toDoList.length, selectedTodoItems.size])
 
   const clearSelectedTodoItems = useCallback((selectedTodoItems: Set<string>) => {
-    dispatch({ 
-      type: ActionName.CLEAR_SELECTED_TODO_ITEMS, 
-      payload: Array.from(selectedTodoItems) 
+    dispatch({
+      type: ActionName.CLEAR_SELECTED_TODO_ITEMS,
+      payload: Array.from(selectedTodoItems)
     })
   }, [dispatch])
 
@@ -107,10 +116,46 @@ const PlannerContent = () => {
     )
   }, [])
 
+  const handleAddMealPlan = useCallback((date: string) => {
+    setSelectedDate(date)
+    setEditingMealPlan(undefined)
+    setMealDrawerOpen(true)
+  }, [])
+
+  const handleMealPlanClick = useCallback((mealPlan: IMealPlan) => {
+    setSelectedDate(mealPlan.date)
+    setEditingMealPlan(mealPlan)
+    setMealDrawerOpen(true)
+  }, [])
+
+  const handleMealPlanSave = useCallback(async (date: string, recipeName: string, recipeId?: string) => {
+    try {
+      if (editingMealPlan) {
+        await updateMealPlan(editingMealPlan.id, { date, recipeName, recipeId: recipeId ?? null })
+      } else {
+        await addMealPlan(date, recipeName, recipeId)
+      }
+      setMealDrawerOpen(false)
+    } catch (error) {
+      console.error('Failed to save meal plan:', error)
+      showAlert({ description: 'Failed to save meal plan', severity: 'error' }, dispatch)
+    }
+  }, [editingMealPlan, addMealPlan, updateMealPlan, dispatch])
+
+  const handleMealPlanDelete = useCallback(async (id: string) => {
+    try {
+      await removeMealPlan(id)
+      setMealDrawerOpen(false)
+    } catch (error) {
+      console.error('Failed to delete meal plan:', error)
+      showAlert({ description: 'Failed to delete meal plan', severity: 'error' }, dispatch)
+    }
+  }, [removeMealPlan, dispatch])
+
   const viewToggleIcon = viewMode === PlannerViewMode.CALENDAR
     ? <CalendarMonthIcon />
     : <ViewModuleIcon />
-  
+
   return (
     <StandardLayout>
       <ModernPageHeader
@@ -137,9 +182,24 @@ const PlannerContent = () => {
           }}
         />
         <ScrollableContainer>
-          <Planner allExpanded={allExpanded} expandKey={expandKey} viewMode={viewMode} />
+          <Planner
+            allExpanded={allExpanded}
+            expandKey={expandKey}
+            viewMode={viewMode}
+            mealPlans={mealPlans}
+            onAddMealPlan={handleAddMealPlan}
+            onMealPlanClick={handleMealPlanClick}
+          />
         </ScrollableContainer>
       </Container>
+      <MealPlanDrawer
+        open={mealDrawerOpen}
+        date={selectedDate}
+        mealPlan={editingMealPlan}
+        onClose={() => setMealDrawerOpen(false)}
+        onSave={handleMealPlanSave}
+        onDelete={handleMealPlanDelete}
+      />
     </StandardLayout>
   )
 }
@@ -148,7 +208,11 @@ export const PlannerRoute = () => {
   return (
     <PlannerProvider>
       <BirthdayProvider>
-        <PlannerContent />
+        <RecipeProvider>
+          <MealPlanProvider>
+            <PlannerContent />
+          </MealPlanProvider>
+        </RecipeProvider>
       </BirthdayProvider>
     </PlannerProvider>
   )

--- a/packages/web/src/types/mealPlan.ts
+++ b/packages/web/src/types/mealPlan.ts
@@ -1,0 +1,9 @@
+export interface IMealPlan {
+    id: string
+    projectId: string
+    date: string          // YYYY-MM-DD
+    recipeName: string    // display name (custom or from linked recipe)
+    recipeId?: string     // optional link to existing IRecipe
+    createdAt: string
+    updatedAt: string
+}


### PR DESCRIPTION
Allow users to plan what to cook on specific days via the Planner calendar view. Users can link an existing recipe or enter a custom meal name.

Changes:
- Backend: 4 new Lambda functions (add/get/update/delete meal plans), new DynamoDB MealPlans table, OpenAPI routes for /meal-plans
- Infrastructure: Terraform resources for DynamoDB table, Lambda IAM policies, API Gateway routes
- Frontend: IMealPlan type, API client, MealPlanProvider, MealPlanDrawer bottom sheet, CalendarView extended with meal plan indicators and day detail section, PlannerRoute wired up with providers and drawer state

https://claude.ai/code/session_01A8iZhvVK9rGZN5G8v1cA8M