### PR TITLE
Add weekly view to planner for focused week overview

### DIFF
--- a/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
@@ -1,0 +1,204 @@
+import { styled } from '@mui/material/styles'
+import { Box, Typography, Button } from '@mui/material'
+import CakeIcon from '@mui/icons-material/Cake'
+import RestaurantIcon from '@mui/icons-material/Restaurant'
+
+export const WeeklyContainer = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  padding: '0 0.5em',
+  boxSizing: 'border-box',
+})
+
+export const WeekHeader = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: '0.5em',
+})
+
+export const WeekRangeLabel = styled(Typography)({
+  fontWeight: 600,
+  fontSize: '1rem',
+  flex: 1,
+  textAlign: 'center',
+})
+
+export const TodayButton = styled(Button)({
+  fontSize: '0.75rem',
+  minWidth: 'auto',
+  padding: '2px 8px',
+  textTransform: 'none',
+  color: '#059669',
+  borderColor: '#059669',
+  '&:hover': {
+    backgroundColor: '#d1fae5',
+    borderColor: '#059669',
+  },
+})
+
+export const WeekGrid = styled('div')({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(7, 1fr)',
+  gap: '4px',
+  overflowX: 'auto',
+})
+
+interface IDayColumnProps {
+  isToday?: boolean
+}
+
+export const DayColumn = styled('div')<IDayColumnProps>(({ isToday }) => ({
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: 0,
+  borderRadius: '8px',
+  border: isToday ? '1.5px solid #059669' : '1px solid #e5e7eb',
+  backgroundColor: isToday ? '#ecfdf5' : '#ffffff',
+  overflow: 'hidden',
+}))
+
+export const DayColumnHeader = styled('div')<IDayColumnProps>(({ isToday }) => ({
+  textAlign: 'center',
+  padding: '6px 4px',
+  backgroundColor: isToday ? '#d1fae5' : '#f9fafb',
+  borderBottom: isToday ? '1px solid #a7f3d0' : '1px solid #e5e7eb',
+}))
+
+export const DayName = styled(Typography)<IDayColumnProps>(({ isToday }) => ({
+  fontSize: '0.65rem',
+  fontWeight: 600,
+  color: isToday ? '#059669' : '#6b7280',
+  textTransform: 'uppercase',
+  lineHeight: 1.2,
+}))
+
+export const DayNumber = styled(Typography)<IDayColumnProps>(({ isToday }) => ({
+  fontSize: '0.9rem',
+  fontWeight: isToday ? 700 : 500,
+  color: isToday ? '#059669' : '#374151',
+  lineHeight: 1.2,
+}))
+
+export const DayColumnBody = styled('div')({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '4px',
+  gap: '2px',
+  minHeight: '80px',
+})
+
+export const DayItem = styled('div')({
+  fontSize: '0.75rem',
+  color: '#374151',
+  padding: '4px 6px',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  wordBreak: 'break-word',
+  lineHeight: 1.3,
+  '&:hover': {
+    backgroundColor: '#dbeafe',
+  },
+})
+
+export const OverdueDayItem = styled('div')({
+  fontSize: '0.75rem',
+  color: '#dc2626',
+  padding: '4px 6px',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  wordBreak: 'break-word',
+  lineHeight: 1.3,
+  '&:hover': {
+    backgroundColor: '#fee2e2',
+  },
+})
+
+export const CompletedDayItem = styled('div')({
+  fontSize: '0.75rem',
+  color: '#9ca3af',
+  textDecoration: 'line-through',
+  padding: '4px 6px',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  wordBreak: 'break-word',
+  lineHeight: 1.3,
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '3px',
+  '&::before': {
+    content: '"✓"',
+    color: '#059669',
+    fontWeight: 700,
+    textDecoration: 'none',
+    flexShrink: 0,
+    fontSize: '0.65rem',
+  },
+  '&:hover': {
+    backgroundColor: '#f3f4f6',
+  },
+})
+
+export const BirthdayItem = styled('div')({
+  fontSize: '0.75rem',
+  color: '#9d174d',
+  padding: '4px 6px',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  wordBreak: 'break-word',
+  lineHeight: 1.3,
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '3px',
+  '&:hover': {
+    backgroundColor: '#fce7f3',
+  },
+})
+
+export const BirthdayIconStyled = styled(CakeIcon)({
+  fontSize: '0.75rem',
+  color: '#db2777',
+  flexShrink: 0,
+  marginTop: '1px',
+})
+
+export const MealItem = styled('div')({
+  fontSize: '0.75rem',
+  color: '#92400e',
+  padding: '4px 6px',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  wordBreak: 'break-word',
+  lineHeight: 1.3,
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '3px',
+  '&:hover': {
+    backgroundColor: '#fef3c7',
+  },
+})
+
+export const MealIconStyled = styled(RestaurantIcon)({
+  fontSize: '0.75rem',
+  color: '#d97706',
+  flexShrink: 0,
+  marginTop: '1px',
+})
+
+export const AddMealButton = styled('div')({
+  fontSize: '0.7rem',
+  color: '#d97706',
+  padding: '3px 6px',
+  cursor: 'pointer',
+  borderRadius: '4px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '2px',
+  fontWeight: 500,
+  marginTop: 'auto',
+  '&:hover': {
+    backgroundColor: '#fef3c7',
+  },
+})

--- a/packages/web/src/components/Planner/WeeklyView/index.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.tsx
@@ -1,0 +1,217 @@
+import { useState, useMemo } from 'react'
+import { IconButton } from '@mui/material'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import AddIcon from '@mui/icons-material/Add'
+import dayjs, { Dayjs } from 'dayjs'
+import { ITodoItem } from '../../../api/toDoList/retrieve/types'
+import { IBirthdayItem } from '../../../api/birthdays/retrieve/types'
+import { IMealPlan } from '../../../types/mealPlan'
+import {
+  WeeklyContainer,
+  WeekHeader,
+  WeekRangeLabel,
+  TodayButton,
+  WeekGrid,
+  DayColumn,
+  DayColumnHeader,
+  DayName,
+  DayNumber,
+  DayColumnBody,
+  DayItem,
+  OverdueDayItem,
+  CompletedDayItem,
+  BirthdayItem,
+  BirthdayIconStyled,
+  MealItem,
+  MealIconStyled,
+  AddMealButton,
+} from './index.styled'
+
+interface IWeeklyViewProps {
+  visibleToDoItems: ITodoItem[]
+  onItemClick: (id: string) => void
+  birthdayItems?: IBirthdayItem[]
+  onBirthdayClick?: (id: string) => void
+  mealPlans?: IMealPlan[]
+  onAddMealPlan?: (date: string) => void
+  onMealPlanClick?: (mealPlan: IMealPlan) => void
+}
+
+const WeeklyView = ({
+  visibleToDoItems,
+  onItemClick,
+  birthdayItems = [],
+  onBirthdayClick,
+  mealPlans = [],
+  onAddMealPlan,
+  onMealPlanClick,
+}: IWeeklyViewProps) => {
+  const [currentWeek, setCurrentWeek] = useState<Dayjs>(() => dayjs().startOf('week'))
+  const today = dayjs()
+
+  const weekDays = useMemo(
+    () => Array.from({ length: 7 }, (_, i) => currentWeek.add(i, 'day')),
+    [currentWeek]
+  )
+
+  const goToPrevWeek = () => setCurrentWeek(prev => prev.subtract(1, 'week'))
+  const goToNextWeek = () => setCurrentWeek(prev => prev.add(1, 'week'))
+  const goToToday = () => setCurrentWeek(dayjs().startOf('week'))
+
+  const weekRangeLabel = useMemo(() => {
+    const start = weekDays[0]
+    const end = weekDays[6]
+    if (start.month() === end.month()) {
+      return `${start.format('MMM D')} – ${end.format('D, YYYY')}`
+    }
+    if (start.year() === end.year()) {
+      return `${start.format('MMM D')} – ${end.format('MMM D, YYYY')}`
+    }
+    return `${start.format('MMM D, YYYY')} – ${end.format('MMM D, YYYY')}`
+  }, [weekDays])
+
+  const itemsWithDueDate = useMemo(
+    () => visibleToDoItems.filter(item => item.dueDate != null),
+    [visibleToDoItems]
+  )
+
+  const pendingTodosByDay = useMemo(() => {
+    const map = new Map<string, ITodoItem[]>()
+    for (const item of itemsWithDueDate.filter(i => !i.isDone)) {
+      const key = dayjs(item.dueDate!).format('YYYY-MM-DD')
+      const existing = map.get(key)
+      if (existing) {
+        existing.push(item)
+      } else {
+        map.set(key, [item])
+      }
+    }
+    return map
+  }, [itemsWithDueDate])
+
+  const completedTodosByDay = useMemo(() => {
+    const map = new Map<string, ITodoItem[]>()
+    for (const item of itemsWithDueDate.filter(i => i.isDone)) {
+      const key = dayjs(item.dueDate!).format('YYYY-MM-DD')
+      const existing = map.get(key)
+      if (existing) {
+        existing.push(item)
+      } else {
+        map.set(key, [item])
+      }
+    }
+    return map
+  }, [itemsWithDueDate])
+
+  const birthdaysByDay = useMemo(() => {
+    const map = new Map<string, IBirthdayItem[]>()
+    for (const item of birthdayItems) {
+      const key = `${item.month}-${item.day}`
+      const existing = map.get(key)
+      if (existing) {
+        existing.push(item)
+      } else {
+        map.set(key, [item])
+      }
+    }
+    return map
+  }, [birthdayItems])
+
+  const mealPlansByDay = useMemo(() => {
+    const map = new Map<string, IMealPlan[]>()
+    for (const plan of mealPlans) {
+      const existing = map.get(plan.date)
+      if (existing) {
+        existing.push(plan)
+      } else {
+        map.set(plan.date, [plan])
+      }
+    }
+    return map
+  }, [mealPlans])
+
+  const isCurrentWeek = today.isSame(currentWeek, 'week')
+
+  return (
+    <WeeklyContainer>
+      <WeekHeader>
+        <IconButton size="small" onClick={goToPrevWeek} aria-label="Previous week">
+          <ChevronLeftIcon />
+        </IconButton>
+        <WeekRangeLabel>{weekRangeLabel}</WeekRangeLabel>
+        {!isCurrentWeek && (
+          <TodayButton variant="outlined" size="small" onClick={goToToday}>
+            Today
+          </TodayButton>
+        )}
+        <IconButton size="small" onClick={goToNextWeek} aria-label="Next week">
+          <ChevronRightIcon />
+        </IconButton>
+      </WeekHeader>
+
+      <WeekGrid>
+        {weekDays.map(day => {
+          const key = day.format('YYYY-MM-DD')
+          const isToday = day.isSame(today, 'day')
+          const isOverdue = day.isBefore(today, 'day')
+          const pendingTodos = pendingTodosByDay.get(key) ?? []
+          const completedTodos = completedTodosByDay.get(key) ?? []
+          const birthdayKey = `${day.month() + 1}-${day.date()}`
+          const dayBirthdays = birthdaysByDay.get(birthdayKey) ?? []
+          const dayMeals = mealPlansByDay.get(key) ?? []
+
+          return (
+            <DayColumn key={key} isToday={isToday}>
+              <DayColumnHeader isToday={isToday}>
+                <DayName isToday={isToday}>{day.format('ddd')}</DayName>
+                <DayNumber isToday={isToday}>{day.date()}</DayNumber>
+              </DayColumnHeader>
+
+              <DayColumnBody>
+                {pendingTodos.map(todo => (
+                  isOverdue ? (
+                    <OverdueDayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                      {todo.name}
+                    </OverdueDayItem>
+                  ) : (
+                    <DayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                      {todo.name}
+                    </DayItem>
+                  )
+                ))}
+
+                {completedTodos.map(todo => (
+                  <CompletedDayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                    {todo.name}
+                  </CompletedDayItem>
+                ))}
+
+                {dayBirthdays.map(birthday => (
+                  <BirthdayItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
+                    <BirthdayIconStyled />
+                    {birthday.name}
+                  </BirthdayItem>
+                ))}
+
+                {dayMeals.map(plan => (
+                  <MealItem key={plan.id} onClick={() => onMealPlanClick?.(plan)}>
+                    <MealIconStyled />
+                    {plan.recipeName}
+                  </MealItem>
+                ))}
+
+                <AddMealButton onClick={() => onAddMealPlan?.(key)}>
+                  <AddIcon sx={{ fontSize: '0.7rem' }} />
+                  Meal
+                </AddMealButton>
+              </DayColumnBody>
+            </DayColumn>
+          )
+        })}
+      </WeekGrid>
+    </WeeklyContainer>
+  )
+}
+
+export default WeeklyView

--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -17,6 +17,7 @@ import BirthdayPreviewDrawer from '../BirthdayPreviewDrawer';
 import BirthdayFormDialog from '../BirthdayFormDialog';
 import GroupedView from './GroupedView';
 import CalendarView from './CalendarView';
+import WeeklyView from './WeeklyView';
 import Placeholder from './Placeholder';
 import EmptyPlanner from './EmptyPlanner';
 import ToDoItemPreviewDrawer from '../ToDoItemPreviewDrawer';
@@ -111,6 +112,30 @@ export const Planner = ({
     }
   }, [toDoList, updateToDoItemFields])
 
+  const drawers = (
+    <>
+      <ToDoItemPreviewDrawer
+        item={previewItem}
+        onClose={() => setPreviewItem(null)}
+        onEdit={handleEdit}
+        onMarkDone={markToDoItemAsDone}
+        onStepToggle={handleStepToggle}
+        onDelete={handleDeleteTodo}
+      />
+      <BirthdayPreviewDrawer
+        item={previewBirthday}
+        onClose={() => setPreviewBirthday(null)}
+        onEdit={handleBirthdayEdit}
+        onDelete={handleBirthdayDelete}
+      />
+      <BirthdayFormDialog
+        open={birthdayDialogOpen}
+        onClose={() => { setBirthdayDialogOpen(false); setEditingBirthday(null); }}
+        initialBirthday={editingBirthday}
+      />
+    </>
+  );
+
   if (viewMode === PlannerViewMode.CALENDAR) {
     return (
       <>
@@ -125,25 +150,26 @@ export const Planner = ({
             onMealPlanClick={onMealPlanClick}
           />
         )}
-        <ToDoItemPreviewDrawer
-          item={previewItem}
-          onClose={() => setPreviewItem(null)}
-          onEdit={handleEdit}
-          onMarkDone={markToDoItemAsDone}
-          onStepToggle={handleStepToggle}
-          onDelete={handleDeleteTodo}
-        />
-        <BirthdayPreviewDrawer
-          item={previewBirthday}
-          onClose={() => setPreviewBirthday(null)}
-          onEdit={handleBirthdayEdit}
-          onDelete={handleBirthdayDelete}
-        />
-        <BirthdayFormDialog
-          open={birthdayDialogOpen}
-          onClose={() => { setBirthdayDialogOpen(false); setEditingBirthday(null); }}
-          initialBirthday={editingBirthday}
-        />
+        {drawers}
+      </>
+    );
+  }
+
+  if (viewMode === PlannerViewMode.WEEKLY) {
+    return (
+      <>
+        {isLoading ? <Placeholder /> : (
+          <WeeklyView
+            visibleToDoItems={toDoList}
+            onItemClick={handlePreview}
+            birthdayItems={birthdays}
+            onBirthdayClick={handleBirthdayPreview}
+            mealPlans={mealPlans}
+            onAddMealPlan={onAddMealPlan}
+            onMealPlanClick={onMealPlanClick}
+          />
+        )}
+        {drawers}
       </>
     );
   }

--- a/packages/web/src/enums/plannerViewMode.ts
+++ b/packages/web/src/enums/plannerViewMode.ts
@@ -1,9 +1,11 @@
 export enum PlannerViewMode {
   CALENDAR = "calendar",
+  WEEKLY = "weekly",
   GROUPED = "grouped",
 }
 
 export const PlannerViewModeLabelMap = {
   [PlannerViewMode.CALENDAR]: "Calendar View",
+  [PlannerViewMode.WEEKLY]: "Weekly View",
   [PlannerViewMode.GROUPED]: "Grouped by Time",
 }

--- a/packages/web/src/routes/PlannerRoute/index.tsx
+++ b/packages/web/src/routes/PlannerRoute/index.tsx
@@ -9,6 +9,7 @@ import ModernPageHeader from '../../components/ModernPageHeader'
 import MealPlanDrawer from '../../components/MealPlanDrawer'
 import ChecklistIcon from '@mui/icons-material/Checklist'
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
+import ViewWeekIcon from '@mui/icons-material/ViewWeek'
 import ViewModuleIcon from '@mui/icons-material/ViewModule'
 import { Container, ScrollableContainer } from './index.styled'
 import { useAppState } from '../../providers/AppStateProvider'
@@ -67,7 +68,7 @@ const PlannerContent = () => {
     { value: noDateItems.length, label: 'No Date' },
   ]
 
-  const stats = viewMode === PlannerViewMode.CALENDAR ? calendarStats : defaultStats
+  const stats = viewMode === PlannerViewMode.GROUPED ? defaultStats : calendarStats
 
   const statusText = useMemo(() => {
     const totalItems = toDoList.length
@@ -111,9 +112,11 @@ const PlannerContent = () => {
   }, [allExpanded])
 
   const toggleViewMode = useCallback(() => {
-    setViewMode(prev =>
-      prev === PlannerViewMode.CALENDAR ? PlannerViewMode.GROUPED : PlannerViewMode.CALENDAR
-    )
+    setViewMode(prev => {
+      if (prev === PlannerViewMode.CALENDAR) return PlannerViewMode.WEEKLY
+      if (prev === PlannerViewMode.WEEKLY) return PlannerViewMode.GROUPED
+      return PlannerViewMode.CALENDAR
+    })
   }, [])
 
   const handleAddMealPlan = useCallback((date: string) => {
@@ -152,9 +155,10 @@ const PlannerContent = () => {
     }
   }, [removeMealPlan, dispatch])
 
-  const viewToggleIcon = viewMode === PlannerViewMode.CALENDAR
-    ? <CalendarMonthIcon />
-    : <ViewModuleIcon />
+  const viewToggleIcon =
+    viewMode === PlannerViewMode.CALENDAR ? <CalendarMonthIcon /> :
+    viewMode === PlannerViewMode.WEEKLY ? <ViewWeekIcon /> :
+    <ViewModuleIcon />
 
   return (
     <StandardLayout>
@@ -168,7 +172,7 @@ const PlannerContent = () => {
           expandCollapseButton={{
             isExpanded: allExpanded,
             onToggle: toggleAll,
-            disabled: pendingItems.length === 0 || viewMode === PlannerViewMode.CALENDAR,
+            disabled: pendingItems.length === 0 || viewMode !== PlannerViewMode.GROUPED,
           }}
           actionButton={{
             isEnabled: selectedTodoItems.size > 0,


### PR DESCRIPTION
Adds a new Weekly view mode that displays 7 day columns (Sun–Sat) with
full item text visible inline — todos, birthdays, and meal plans — making
it easy to see the current week at a glance without the overwhelming
monthly grid. Navigation cycles: Monthly → Weekly → Grouped → Monthly.

https://claude.ai/code/session_01SkYGGwA6XUR1njQNAwZxxn