### PR TITLE
Redesign planner widget as three mini-cards on home page

### DIFF
--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
@@ -1,0 +1,18 @@
+import { styled } from '@mui/material/styles'
+
+export const MealName = styled('div')(({ theme }) => ({
+  fontSize: '0.78rem',
+  fontWeight: 600,
+  color: theme.palette.text.primary,
+  lineHeight: '1.3',
+  overflow: 'hidden',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+}))
+
+export const AdditionalMeals = styled('div')(({ theme }) => ({
+  fontSize: '0.7rem',
+  color: theme.palette.text.secondary,
+  fontWeight: 500,
+}))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { IMealPlan } from '../../../../../../types/mealPlan'
+import { MealName, AdditionalMeals } from './index.styled'
+
+interface ITodayMealCardProps {
+  todayMeals: IMealPlan[]
+}
+
+export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals }) => {
+  if (todayMeals.length === 0) {
+    return <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>No meal planned</span>
+  }
+
+  const [first, ...rest] = todayMeals
+
+  return (
+    <>
+      <MealName>{first.recipeName}</MealName>
+      {rest.length > 0 && (
+        <AdditionalMeals>+{rest.length} more</AdditionalMeals>
+      )}
+    </>
+  )
+}
+
+export default TodayMealCard

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.styled.tsx
@@ -1,0 +1,50 @@
+import { styled } from '@mui/material/styles'
+import { Box } from '@mui/material'
+
+export const TaskRow = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '0.4rem',
+  fontSize: '0.75rem',
+  color: theme.palette.text.primary,
+  lineHeight: '1.3',
+}))
+
+export const TaskDot = styled('div')<{ $class?: string }>(({ theme, $class }) => ({
+  width: '5px',
+  height: '5px',
+  borderRadius: '50%',
+  flexShrink: 0,
+  marginTop: '0.3rem',
+  backgroundColor:
+    $class === 'overdue'
+      ? theme.palette.error.main
+      : $class === 'today'
+      ? '#667eea'
+      : theme.palette.text.disabled,
+}))
+
+export const TaskName = styled('span')({
+  flex: 1,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+export const OverdueBadge = styled(Box)(({ theme }) => ({
+  display: 'inline-flex',
+  alignItems: 'center',
+  fontSize: '0.65rem',
+  fontWeight: 700,
+  color: theme.palette.error.main,
+  background: `${theme.palette.error.main}18`,
+  borderRadius: '8px',
+  padding: '0.1rem 0.4rem',
+  marginBottom: '0.35rem',
+}))
+
+export const MoreCount = styled('div')(({ theme }) => ({
+  fontSize: '0.7rem',
+  color: theme.palette.text.secondary,
+  fontWeight: 600,
+}))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { ITodoItem } from '../../../../../../api/toDoList/retrieve/types'
+import { getDueDateClass } from '../../../../../../utils/dateTime'
+import { TaskRow, TaskDot, TaskName, OverdueBadge, MoreCount } from './index.styled'
+
+interface ITodayTasksCardProps {
+  sortedItems: ITodoItem[]
+}
+
+const getTodayBounds = () => {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+  const end = start + 24 * 60 * 60 * 1000
+  return { start, end }
+}
+
+export const TodayTasksCard: React.FC<ITodayTasksCardProps> = ({ sortedItems }) => {
+  const { start, end } = getTodayBounds()
+
+  const overdueItems = sortedItems.filter(item => item.dueDate && item.dueDate < start)
+  const todayItems = sortedItems.filter(item => item.dueDate && item.dueDate >= start && item.dueDate < end)
+  const displayItems = todayItems.slice(0, 3)
+  const moreCount = todayItems.length - displayItems.length
+
+  if (todayItems.length === 0 && overdueItems.length === 0) {
+    return <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>No tasks for today</span>
+  }
+
+  return (
+    <>
+      {overdueItems.length > 0 && (
+        <OverdueBadge>{overdueItems.length} overdue</OverdueBadge>
+      )}
+      {displayItems.map(item => (
+        <TaskRow key={item.id}>
+          <TaskDot $class={getDueDateClass(item.dueDate)} />
+          <TaskName>{item.name}</TaskName>
+        </TaskRow>
+      ))}
+      {moreCount > 0 && <MoreCount>+{moreCount} more</MoreCount>}
+      {todayItems.length === 0 && overdueItems.length > 0 && (
+        <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>No tasks due today</span>
+      )}
+    </>
+  )
+}
+
+export default TodayTasksCard

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.styled.tsx
@@ -1,0 +1,26 @@
+import { styled } from '@mui/material/styles'
+
+export const BirthdayRow = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '0.3rem',
+  fontSize: '0.75rem',
+}))
+
+export const BirthdayName = styled('span')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontWeight: 500,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  flex: 1,
+}))
+
+export const DaysUntil = styled('span')<{ $isToday?: boolean }>(({ theme, $isToday }) => ({
+  flexShrink: 0,
+  fontSize: '0.68rem',
+  fontWeight: 700,
+  color: $isToday ? '#f093fb' : theme.palette.text.secondary,
+  whiteSpace: 'nowrap',
+}))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { IBirthdayItem } from '../../../../../../api/birthdays/retrieve/types'
+import { BirthdayRow, BirthdayName, DaysUntil } from './index.styled'
+
+interface IUpcomingBirthdaysCardProps {
+  birthdays: IBirthdayItem[]
+}
+
+const getNextBirthdayDate = (birthday: IBirthdayItem): Date => {
+  const today = new Date()
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+  const thisYear = today.getFullYear()
+  const candidate = new Date(thisYear, birthday.month - 1, birthday.day)
+  if (candidate.getTime() < todayMidnight.getTime()) {
+    return new Date(thisYear + 1, birthday.month - 1, birthday.day)
+  }
+  return candidate
+}
+
+const getDaysUntilLabel = (nextDate: Date): { label: string; isToday: boolean } => {
+  const today = new Date()
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+  const diffDays = Math.round((nextDate.getTime() - todayMidnight.getTime()) / (1000 * 60 * 60 * 24))
+
+  if (diffDays === 0) return { label: 'Today!', isToday: true }
+  if (diffDays === 1) return { label: 'Tomorrow', isToday: false }
+  return { label: `in ${diffDays}d`, isToday: false }
+}
+
+export const UpcomingBirthdaysCard: React.FC<IUpcomingBirthdaysCardProps> = ({ birthdays }) => {
+  if (birthdays.length === 0) {
+    return <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>No birthdays saved</span>
+  }
+
+  const sorted = [...birthdays]
+    .map(b => ({ ...b, nextDate: getNextBirthdayDate(b) }))
+    .sort((a, b) => a.nextDate.getTime() - b.nextDate.getTime())
+    .slice(0, 3)
+
+  return (
+    <>
+      {sorted.map(b => {
+        const { label, isToday } = getDaysUntilLabel(b.nextDate)
+        return (
+          <BirthdayRow key={b.id}>
+            <BirthdayName>{b.name}</BirthdayName>
+            <DaysUntil $isToday={isToday}>{label}</DaysUntil>
+          </BirthdayRow>
+        )
+      })}
+    </>
+  )
+}
+
+export default UpcomingBirthdaysCard

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.styled.tsx
@@ -1,5 +1,92 @@
 import { styled } from '@mui/material/styles'
+import { Box, Card, CardContent } from '@mui/material'
 
+export const MiniCardsGrid = styled(Box)({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gap: '0.6rem',
+  width: '100%',
+})
+
+export const MiniCard = styled(Card)({
+  borderRadius: '16px',
+  boxShadow: '0 2px 12px rgba(0, 0, 0, 0.06)',
+  border: 'none',
+  background: 'linear-gradient(135deg, rgba(255,255,255,0.9) 0%, rgba(248,250,252,0.95) 100%)',
+  backdropFilter: 'blur(10px)',
+  WebkitBackdropFilter: 'blur(10px)',
+  transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+  position: 'relative',
+  overflow: 'hidden',
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: '110px',
+  '&:before': {
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: '3px',
+    background: 'linear-gradient(90deg, #667eea 0%, #764ba2 50%, #f093fb 100%)',
+    opacity: 0,
+    transition: 'opacity 0.3s ease',
+  },
+  '&:hover': {
+    boxShadow: '0 8px 32px rgba(0, 0, 0, 0.12)',
+    transform: 'translateY(-2px)',
+    '&:before': {
+      opacity: 1,
+    },
+  },
+})
+
+export const MiniCardContent = styled(CardContent)({
+  padding: '0.875rem',
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.35rem',
+  '&:last-child': {
+    paddingBottom: '0.875rem',
+  },
+})
+
+export const MiniCardHeader = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.35rem',
+  marginBottom: '0.25rem',
+})
+
+export const MiniCardIcon = styled('div')({
+  '& .MuiSvgIcon-root': {
+    fontSize: '0.85rem',
+    padding: '0.2rem',
+    borderRadius: '5px',
+    background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+    color: 'white',
+    display: 'block',
+  },
+})
+
+export const MiniCardTitle = styled('div')(({ theme }) => ({
+  fontSize: '0.7rem',
+  fontWeight: 700,
+  color: theme.palette.text.secondary,
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}))
+
+export const MiniCardBody = styled('div')({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.25rem',
+  overflow: 'hidden',
+})
+
+// Kept for backward compatibility with existing tests
 export const CompactItemList = styled('ul')({
   listStyle: 'none',
   padding: 0,

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.test.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { ThemeProvider } from '@mui/material/styles'
 import theme from '../../../../theme'
 import { PlannerSection } from './index'
 import { ITodoItem } from '../../../../api/toDoList/retrieve/types'
 import { IToDoStats } from '../../../../hooks/useHomeData/types'
+import { IBirthdayItem } from '../../../../api/birthdays/retrieve/types'
+import { IMealPlan } from '../../../../types/mealPlan'
 
 const createMockTodoItem = (overrides: Partial<ITodoItem> = {}): ITodoItem => ({
   id: 'todo-1',
@@ -23,6 +25,24 @@ const createMockToDoStats = (overrides: Partial<IToDoStats> = {}): IToDoStats =>
   ...overrides
 })
 
+const createMockBirthday = (overrides: Partial<IBirthdayItem> = {}): IBirthdayItem => ({
+  id: 'birthday-1',
+  name: 'Alice',
+  month: 6,
+  day: 15,
+  ...overrides
+})
+
+const createMockMealPlan = (overrides: Partial<IMealPlan> = {}): IMealPlan => ({
+  id: 'meal-1',
+  projectId: 'project-1',
+  date: '2024-01-15',
+  recipeName: 'Pasta',
+  createdAt: '',
+  updatedAt: '',
+  ...overrides
+})
+
 const renderWithTheme = (component: React.ReactElement) => {
   return render(
     <ThemeProvider theme={theme}>
@@ -31,13 +51,19 @@ const renderWithTheme = (component: React.ReactElement) => {
   )
 }
 
-describe('PlannerSection component', () => {
-  const mockOnToggleExpansion = jest.fn()
-  const mockOnItemToggle = jest.fn()
+const defaultProps = {
+  toDoStats: createMockToDoStats(),
+  birthdays: [],
+  todayMeals: [],
+  isLoading: false,
+  isExpanded: false,
+  expandedItems: new Set<string>(),
+  onToggleExpansion: jest.fn(),
+  onItemToggle: jest.fn(),
+}
 
+describe('PlannerSection component', () => {
   beforeEach(() => {
-    mockOnToggleExpansion.mockClear()
-    mockOnItemToggle.mockClear()
     jest.useFakeTimers()
     jest.setSystemTime(new Date('2024-01-15T12:00:00Z'))
   })
@@ -46,360 +72,152 @@ describe('PlannerSection component', () => {
     jest.useRealTimers()
   })
 
-  describe('when loading', () => {
-    it('should show loading placeholders', () => {
-      const toDoStats = createMockToDoStats()
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={true}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      expect(screen.getByText('Planner')).toBeInTheDocument()
-      expect(screen.getByText('0')).toBeInTheDocument()
+  describe('card titles', () => {
+    it('should render three section cards', () => {
+      renderWithTheme(<PlannerSection {...defaultProps} />)
+
+      expect(screen.getByText("Today's Tasks")).toBeInTheDocument()
+      expect(screen.getByText('Dinner Tonight')).toBeInTheDocument()
+      expect(screen.getByText('Birthdays')).toBeInTheDocument()
     })
   })
 
-  describe('when no todo items exist', () => {
-    it('should show empty state message', () => {
-      const toDoStats = createMockToDoStats()
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
+  describe('Today\'s Tasks card', () => {
+    it('should show empty state when no tasks for today', () => {
+      renderWithTheme(<PlannerSection {...defaultProps} />)
+
+      expect(screen.getByText('No tasks for today')).toBeInTheDocument()
+    })
+
+    it('should show tasks due today', () => {
+      const todayDate = new Date('2024-01-15T15:00:00Z').getTime()
+      const item = createMockTodoItem({ id: '1', name: 'Today Task', dueDate: todayDate })
+      const toDoStats = createMockToDoStats({ sortedItems: [item] })
+
+      renderWithTheme(<PlannerSection {...defaultProps} toDoStats={toDoStats} />)
+
+      expect(screen.getByText('Today Task')).toBeInTheDocument()
+    })
+
+    it('should show overdue badge when there are overdue tasks', () => {
+      const pastDate = new Date('2024-01-10T12:00:00Z').getTime()
+      const item = createMockTodoItem({ id: '1', name: 'Old Task', dueDate: pastDate })
+      const toDoStats = createMockToDoStats({ sortedItems: [item] })
+
+      renderWithTheme(<PlannerSection {...defaultProps} toDoStats={toDoStats} />)
+
+      expect(screen.getByText('1 overdue')).toBeInTheDocument()
+    })
+
+    it('should not show tasks due in the future in Today card', () => {
+      const futureDate = new Date('2024-01-20T12:00:00Z').getTime()
+      const item = createMockTodoItem({ id: '1', name: 'Future Task', dueDate: futureDate })
+      const toDoStats = createMockToDoStats({ sortedItems: [item] })
+
+      renderWithTheme(<PlannerSection {...defaultProps} toDoStats={toDoStats} />)
+
+      expect(screen.queryByText('Future Task')).not.toBeInTheDocument()
+      expect(screen.getByText('No tasks for today')).toBeInTheDocument()
+    })
+
+    it('should show +N more when more than 3 tasks today', () => {
+      const todayDate = new Date('2024-01-15T15:00:00Z').getTime()
+      const items = Array.from({ length: 5 }, (_, i) =>
+        createMockTodoItem({ id: `${i}`, name: `Task ${i}`, dueDate: todayDate + i * 1000 })
       )
-      
-      expect(screen.getByText('No pending tasks found')).toBeInTheDocument()
+      const toDoStats = createMockToDoStats({ sortedItems: items })
+
+      renderWithTheme(<PlannerSection {...defaultProps} toDoStats={toDoStats} />)
+
+      expect(screen.getByText('+2 more')).toBeInTheDocument()
     })
   })
 
-  describe('when todo items exist', () => {
-    it('should display todo items', () => {
-      const items = [
-        createMockTodoItem({ id: '1', name: 'Task 1' }),
-        createMockTodoItem({ id: '2', name: 'Task 2' }),
-        createMockTodoItem({ id: '3', name: 'Task 3' })
+  describe('Dinner Tonight card', () => {
+    it('should show empty state when no meal planned today', () => {
+      renderWithTheme(<PlannerSection {...defaultProps} />)
+
+      expect(screen.getByText('No meal planned')).toBeInTheDocument()
+    })
+
+    it('should show today\'s meal name', () => {
+      const meal = createMockMealPlan({ recipeName: 'Chicken Alfredo' })
+
+      renderWithTheme(<PlannerSection {...defaultProps} todayMeals={[meal]} />)
+
+      expect(screen.getByText('Chicken Alfredo')).toBeInTheDocument()
+    })
+
+    it('should show +N more when there are additional meals', () => {
+      const meals = [
+        createMockMealPlan({ id: '1', recipeName: 'Breakfast Dish' }),
+        createMockMealPlan({ id: '2', recipeName: 'Lunch Dish' }),
+        createMockMealPlan({ id: '3', recipeName: 'Dinner Dish' }),
       ]
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: items,
-        sortedItems: items,
-        displayedItems: items,
-        hasMoreItems: false
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      expect(screen.getByText('Planner')).toBeInTheDocument()
-      expect(screen.getByText('3')).toBeInTheDocument()
-      expect(screen.getByText('Task 1')).toBeInTheDocument()
-      expect(screen.getByText('Task 2')).toBeInTheDocument()
-      expect(screen.getByText('Task 3')).toBeInTheDocument()
-    })
 
-    it('should show due date information', () => {
-      const tomorrowDate = new Date('2024-01-16T12:00:00Z').getTime()
-      const item = createMockTodoItem({ 
-        id: '1', 
-        name: 'Task with due date',
-        dueDate: tomorrowDate
-      })
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: [item],
-        sortedItems: [item],
-        displayedItems: [item],
-        hasMoreItems: false
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      expect(screen.getByText('due tomorrow')).toBeInTheDocument()
-    })
+      renderWithTheme(<PlannerSection {...defaultProps} todayMeals={meals} />)
 
-    it('should handle item clicks', () => {
-      const item = createMockTodoItem({ id: '1', name: 'Clickable Task' })
-      const toDoStats = createMockToDoStats({
-        pendingItems: [item],
-        sortedItems: [item],
-        displayedItems: [item],
-        hasMoreItems: false
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      fireEvent.click(screen.getByText('Clickable Task'))
-      expect(mockOnItemToggle).toHaveBeenCalledWith('1')
-    })
-
-    it('should show truncated description when not expanded', () => {
-      const longDescription = 'This is a very long description that should be truncated when the item is not expanded'
-      const item = createMockTodoItem({ 
-        id: '1', 
-        name: 'Task with long description',
-        description: longDescription
-      })
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: [item],
-        sortedItems: [item],
-        displayedItems: [item],
-        hasMoreItems: false
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      expect(screen.getByText('This is a very long description that should be tru...')).toBeInTheDocument()
-      expect(screen.queryByText(longDescription)).not.toBeInTheDocument()
-    })
-
-    it('should show full description when item is expanded', () => {
-      const item = createMockTodoItem({ 
-        id: '1', 
-        name: 'Expanded Task',
-        description: 'Full task description'
-      })
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: [item],
-        sortedItems: [item],
-        displayedItems: [item],
-        hasMoreItems: false
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set(['1'])}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      expect(screen.getByText('Full task description')).toBeInTheDocument()
-    })
-
-    it('should show expanded due date details when item is expanded', () => {
-      const tomorrowDate = new Date('2024-01-16T14:30:00Z').getTime()
-      const item = createMockTodoItem({ 
-        id: '1', 
-        name: 'Task with expanded date',
-        dueDate: tomorrowDate
-      })
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: [item],
-        sortedItems: [item],
-        displayedItems: [item],
-        hasMoreItems: false
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set(['1'])}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      expect(screen.getByText('Due Date')).toBeInTheDocument()
-      expect(screen.getByText(/Tue, Jan 16 at 02:30 PM/)).toBeInTheDocument()
+      expect(screen.getByText('Breakfast Dish')).toBeInTheDocument()
+      expect(screen.getByText('+2 more')).toBeInTheDocument()
     })
   })
 
-  describe('expansion functionality', () => {
-    it('should show "show more" indicator when there are more than 3 items', () => {
-      const items = Array.from({ length: 5 }, (_, i) => 
-        createMockTodoItem({ id: `${i + 1}`, name: `Task ${i + 1}` })
-      )
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: items,
-        sortedItems: items,
-        displayedItems: items.slice(0, 3),
-        hasMoreItems: true
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      expect(screen.getByText('+2 more items')).toBeInTheDocument()
+  describe('Birthdays card', () => {
+    it('should show empty state when no birthdays saved', () => {
+      renderWithTheme(<PlannerSection {...defaultProps} />)
+
+      expect(screen.getByText('No birthdays saved')).toBeInTheDocument()
     })
 
-    it('should show "show less" when expanded', () => {
-      const items = Array.from({ length: 5 }, (_, i) => 
-        createMockTodoItem({ id: `${i + 1}`, name: `Task ${i + 1}` })
-      )
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: items,
-        sortedItems: items,
-        displayedItems: items,
-        hasMoreItems: true
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={true}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      expect(screen.getByText('Show less')).toBeInTheDocument()
+    it('should show upcoming birthday names', () => {
+      const birthday = createMockBirthday({ id: '1', name: 'Bob', month: 2, day: 1 })
+
+      renderWithTheme(<PlannerSection {...defaultProps} birthdays={[birthday]} />)
+
+      expect(screen.getByText('Bob')).toBeInTheDocument()
     })
 
-    it('should handle expansion toggle clicks', () => {
-      const items = Array.from({ length: 5 }, (_, i) => 
-        createMockTodoItem({ id: `${i + 1}`, name: `Task ${i + 1}` })
-      )
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: items,
-        sortedItems: items,
-        displayedItems: items.slice(0, 3),
-        hasMoreItems: true
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      fireEvent.click(screen.getByText('+2 more items'))
-      expect(mockOnToggleExpansion).toHaveBeenCalledTimes(1)
-    })
-  })
+    it('should show "Today!" for a birthday today', () => {
+      // System time is 2024-01-15
+      const birthday = createMockBirthday({ id: '1', name: 'Charlie', month: 1, day: 15 })
 
-  describe('due date styling', () => {
-    it('should apply correct styling for overdue tasks', () => {
-      const yesterdayDate = new Date('2024-01-14T12:00:00Z').getTime()
-      const item = createMockTodoItem({ 
-        id: '1', 
-        name: 'Overdue task',
-        dueDate: yesterdayDate
-      })
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: [item],
-        sortedItems: [item],
-        displayedItems: [item],
-        hasMoreItems: false
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      const dueDateElement = screen.getByText('overdue by 1 day')
-      expect(dueDateElement).toHaveClass('overdue')
+      renderWithTheme(<PlannerSection {...defaultProps} birthdays={[birthday]} />)
+
+      expect(screen.getByText('Today!')).toBeInTheDocument()
     })
 
-    it('should apply correct styling for tasks due today', () => {
-      const todayDate = new Date('2024-01-15T12:00:00Z').getTime()
-      const item = createMockTodoItem({ 
-        id: '1', 
-        name: 'Today task',
-        dueDate: todayDate
-      })
-      
-      const toDoStats = createMockToDoStats({
-        pendingItems: [item],
-        sortedItems: [item],
-        displayedItems: [item],
-        hasMoreItems: false
-      })
-      
-      renderWithTheme(
-        <PlannerSection
-          toDoStats={toDoStats}
-          isLoading={false}
-          isExpanded={false}
-          expandedItems={new Set()}
-          onToggleExpansion={mockOnToggleExpansion}
-          onItemToggle={mockOnItemToggle}
-        />
-      )
-      
-      const dueDateElement = screen.getByText('due today')
-      expect(dueDateElement).toHaveClass('today')
+    it('should show "Tomorrow" for a birthday tomorrow', () => {
+      // System time is 2024-01-15
+      const birthday = createMockBirthday({ id: '1', name: 'Diana', month: 1, day: 16 })
+
+      renderWithTheme(<PlannerSection {...defaultProps} birthdays={[birthday]} />)
+
+      expect(screen.getByText('Tomorrow')).toBeInTheDocument()
+    })
+
+    it('should show days until for a birthday in the future', () => {
+      // System time is 2024-01-15
+      const birthday = createMockBirthday({ id: '1', name: 'Eve', month: 1, day: 25 })
+
+      renderWithTheme(<PlannerSection {...defaultProps} birthdays={[birthday]} />)
+
+      expect(screen.getByText('in 10d')).toBeInTheDocument()
+    })
+
+    it('should show only the next 3 upcoming birthdays', () => {
+      const birthdays = [
+        createMockBirthday({ id: '1', name: 'Person 1', month: 1, day: 16 }),
+        createMockBirthday({ id: '2', name: 'Person 2', month: 1, day: 17 }),
+        createMockBirthday({ id: '3', name: 'Person 3', month: 1, day: 18 }),
+        createMockBirthday({ id: '4', name: 'Person 4', month: 1, day: 19 }),
+      ]
+
+      renderWithTheme(<PlannerSection {...defaultProps} birthdays={birthdays} />)
+
+      expect(screen.getByText('Person 1')).toBeInTheDocument()
+      expect(screen.getByText('Person 2')).toBeInTheDocument()
+      expect(screen.getByText('Person 3')).toBeInTheDocument()
+      expect(screen.queryByText('Person 4')).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -1,73 +1,64 @@
 import React from 'react'
-import SectionCard from '../../../../components/SectionCard'
-import HomeToDoItemPlaceholder from '../HomeToDoItemPlaceholder'
-import ToDoItemCard from './components/ToDoItemCard'
-import EmptyState from '../shared/EmptyState'
 import ChecklistIcon from '@mui/icons-material/Checklist'
+import RestaurantIcon from '@mui/icons-material/Restaurant'
+import CakeIcon from '@mui/icons-material/Cake'
 import { IToDoSectionProps } from './types'
-import { formatDueDateRelative, getDueDateClass } from '../../../../utils/dateTime'
-import { CompactItemList, MoreItemsIndicator } from './index.styled'
+import TodayTasksCard from './components/TodayTasksCard'
+import TodayMealCard from './components/TodayMealCard'
+import UpcomingBirthdaysCard from './components/UpcomingBirthdaysCard'
+import {
+  MiniCardsGrid,
+  MiniCard,
+  MiniCardContent,
+  MiniCardHeader,
+  MiniCardIcon,
+  MiniCardTitle,
+  MiniCardBody,
+} from './index.styled'
 
 export const PlannerSection: React.FC<IToDoSectionProps> = ({
   toDoStats,
-  isLoading,
-  isExpanded,
-  onToggleExpansion,
-  onItemToggle,
-  expandedItems,
+  birthdays,
+  todayMeals,
 }) => {
-  const renderContent = () => {
-    if (isLoading) {
-      return (
-        <CompactItemList>
-          {Array.from({ length: 3 }).map((_, index) => (
-            <HomeToDoItemPlaceholder key={index} />
-          ))}
-        </CompactItemList>
-      )
-    }
-
-    if (toDoStats.displayedItems.length === 0) {
-      return <EmptyState>No pending tasks found</EmptyState>
-    }
-
-    return (
-      <CompactItemList>
-        {toDoStats.displayedItems.map((item) => {
-          const dueDateText = formatDueDateRelative(item.dueDate)
-          const dueDateClass = getDueDateClass(item.dueDate)
-
-          return (
-            <ToDoItemCard
-              key={item.id}
-              item={item}
-              dueDateText={dueDateText}
-              dueDateClass={dueDateClass}
-              isExpanded={expandedItems.has(item.id)}
-              onClick={() => onItemToggle(item.id)}
-            />
-          )
-        })}
-        {toDoStats.hasMoreItems && (
-          <MoreItemsIndicator onClick={onToggleExpansion}>
-            {isExpanded 
-              ? 'Show less'
-              : `+${toDoStats.pendingItems.length - 3} more items`
-            }
-          </MoreItemsIndicator>
-        )}
-      </CompactItemList>
-    )
-  }
-
   return (
-    <SectionCard
-      icon={ChecklistIcon}
-      title="Planner"
-      count={toDoStats.pendingItems.length}
-    >
-      {renderContent()}
-    </SectionCard>
+    <MiniCardsGrid>
+      <MiniCard>
+        <MiniCardContent>
+          <MiniCardHeader>
+            <MiniCardIcon><ChecklistIcon /></MiniCardIcon>
+            <MiniCardTitle>Today's Tasks</MiniCardTitle>
+          </MiniCardHeader>
+          <MiniCardBody>
+            <TodayTasksCard sortedItems={toDoStats.sortedItems} />
+          </MiniCardBody>
+        </MiniCardContent>
+      </MiniCard>
+
+      <MiniCard>
+        <MiniCardContent>
+          <MiniCardHeader>
+            <MiniCardIcon><RestaurantIcon /></MiniCardIcon>
+            <MiniCardTitle>Dinner Tonight</MiniCardTitle>
+          </MiniCardHeader>
+          <MiniCardBody>
+            <TodayMealCard todayMeals={todayMeals} />
+          </MiniCardBody>
+        </MiniCardContent>
+      </MiniCard>
+
+      <MiniCard>
+        <MiniCardContent>
+          <MiniCardHeader>
+            <MiniCardIcon><CakeIcon /></MiniCardIcon>
+            <MiniCardTitle>Birthdays</MiniCardTitle>
+          </MiniCardHeader>
+          <MiniCardBody>
+            <UpcomingBirthdaysCard birthdays={birthdays} />
+          </MiniCardBody>
+        </MiniCardContent>
+      </MiniCard>
+    </MiniCardsGrid>
   )
 }
 

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
@@ -1,8 +1,11 @@
-import { ITodoItem } from '../../../../api/toDoList/retrieve/types'
 import { IToDoStats } from '../../../../hooks/useHomeData/types'
+import { IBirthdayItem } from '../../../../api/birthdays/retrieve/types'
+import { IMealPlan } from '../../../../types/mealPlan'
 
 export interface IToDoSectionProps {
   toDoStats: IToDoStats
+  birthdays: IBirthdayItem[]
+  todayMeals: IMealPlan[]
   isLoading: boolean
   isExpanded: boolean
   onToggleExpansion: () => void

--- a/packages/web/src/routes/HomeRoute/index.test.tsx
+++ b/packages/web/src/routes/HomeRoute/index.test.tsx
@@ -7,6 +7,8 @@ import HomeRoute from '.'
 import * as GroceryAPI from '../../api/groceryList'
 import * as ToDoAPI from '../../api/toDoList'
 import * as NoiseAPI from '../../api/noiseTracking'
+import * as BirthdayAPI from '../../api/birthdays/retrieve'
+import * as MealPlanAPI from '../../api/mealPlans'
 import { GroceryItemUnit } from '../../enums/groceryItem'
 import { useAppState } from '../../providers/AppStateProvider'
 import { ProjectProvider, useProjectContext } from '../../providers/ProjectProvider'
@@ -25,6 +27,8 @@ jest.mock('../../providers/ProjectProvider', () => ({
 jest.mock('../../api/groceryList')
 jest.mock('../../api/toDoList')
 jest.mock('../../api/noiseTracking')
+jest.mock('../../api/birthdays/retrieve')
+jest.mock('../../api/mealPlans')
 jest.mock('react-router', () => ({
   ...jest.requireActual('react-router'),
   useNavigate: jest.fn(() => jest.fn()),
@@ -68,6 +72,8 @@ describe('Given the HomeRoute component', () => {
     jest.spyOn(GroceryAPI, 'retrieveGroceryList').mockResolvedValue([])
     jest.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue([])
     jest.spyOn(NoiseAPI, 'retrieveNoiseTrackingItems').mockResolvedValue([])
+    jest.spyOn(BirthdayAPI, 'retrieveBirthdays').mockResolvedValue([])
+    jest.spyOn(MealPlanAPI, 'getMealPlans').mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -95,7 +101,9 @@ describe('Given the HomeRoute component', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Grocery List')).toBeVisible()
-      expect(screen.getByText('Planner')).toBeVisible()
+      expect(screen.getByText("Today's Tasks")).toBeVisible()
+      expect(screen.getByText('Dinner Tonight')).toBeVisible()
+      expect(screen.getByText('Birthdays')).toBeVisible()
       expect(screen.getByText('Noise Recordings')).toBeVisible()
     })
   })
@@ -107,7 +115,9 @@ describe('Given the HomeRoute component', () => {
 
     await waitFor(() => {
       expect(screen.getByText('No grocery items found')).toBeVisible()
-      expect(screen.getByText('No pending tasks found')).toBeVisible()
+      expect(screen.getByText('No tasks for today')).toBeVisible()
+      expect(screen.getByText('No meal planned')).toBeVisible()
+      expect(screen.getByText('No birthdays saved')).toBeVisible()
       expect(screen.getByText('No noise recordings found')).toBeVisible()
     })
   })
@@ -266,14 +276,13 @@ describe('Given the HomeRoute component', () => {
     })
   })
 
-  it('should display top three pending to-do items sorted by due date', async () => {
-    const now = Date.now()
+  it('should display tasks due today in the Today\'s Tasks card', async () => {
+    const now = new Date()
+    const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate())
     const mockToDoList = [
-      { id: '1', name: 'Completed Task', description: 'Done', isDone: true, dueDate: now + 86400000 },
-      { id: '2', name: 'Task 1', description: 'Description 1', isDone: false, dueDate: now + 4 * 86400000 }, // 4 days from now
-      { id: '3', name: 'Task 2', description: 'Description 2', isDone: false, dueDate: now + 2 * 86400000 }, // 2 days from now  
-      { id: '4', name: 'Task 3', description: 'Description 3', isDone: false, dueDate: now + 86400000 }, // 1 day from now
-      { id: '5', name: 'Task 4', description: 'Description 4', isDone: false, dueDate: now + 3 * 86400000 }, // 3 days from now
+      { id: '1', name: 'Completed Task', isDone: true, dueDate: todayMidnight.getTime() + 2 * 3600000 },
+      { id: '2', name: 'Today Task', isDone: false, dueDate: todayMidnight.getTime() + 3 * 3600000 },
+      { id: '3', name: 'Future Task', isDone: false, dueDate: todayMidnight.getTime() + 2 * 86400000 },
     ]
 
     jest.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue(mockToDoList)
@@ -283,79 +292,26 @@ describe('Given the HomeRoute component', () => {
     })
 
     await waitFor(() => {
-      // Should show tasks sorted by earliest due date first (Task 3, Task 2, Task 4)
-      expect(screen.getByText('Task 3')).toBeVisible() // Due tomorrow  
-      expect(screen.getByText('Task 2')).toBeVisible() // Due in 2 days
-      expect(screen.getByText('Task 4')).toBeVisible() // Due in 3 days
-      expect(screen.getByText('+1 more items')).toBeVisible() // Task 1 is not shown
-      expect(screen.queryByText('Task 1')).not.toBeInTheDocument() // Task 1 due later not shown
+      expect(screen.getByText('Today Task')).toBeVisible()
+      expect(screen.queryByText('Future Task')).not.toBeInTheDocument()
       expect(screen.queryByText('Completed Task')).not.toBeInTheDocument()
     })
   })
 
-  it('should expand and collapse to-do items when clicking more items indicator', async () => {
-    const tomorrow = new Date()
-    tomorrow.setDate(tomorrow.getDate() + 1)
-    const twoDaysLater = new Date()
-    twoDaysLater.setDate(twoDaysLater.getDate() + 2)
-    const threeDaysLater = new Date()
-    threeDaysLater.setDate(threeDaysLater.getDate() + 3)
-    const fourDaysLater = new Date()
-    fourDaysLater.setDate(fourDaysLater.getDate() + 4)
+  it('should display today\'s meal from meal plan', async () => {
+    const today = new Date()
+    const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
 
-    const mockToDoList = [
-      { id: '1', name: 'Task 1', isDone: false, dueDate: fourDaysLater.getTime() },
-      { id: '2', name: 'Task 2', isDone: false, dueDate: twoDaysLater.getTime() },
-      { id: '3', name: 'Task 3', isDone: false, dueDate: tomorrow.getTime() },
-      { id: '4', name: 'Task 4', isDone: false, dueDate: threeDaysLater.getTime() },
-      { id: '5', name: 'Completed Task', isDone: true }
-    ]
-
-    jest.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue(mockToDoList)
+    jest.spyOn(MealPlanAPI, 'getMealPlans').mockResolvedValue([
+      { id: '1', projectId: 'test-project-id', date: todayStr, recipeName: 'Spaghetti Bolognese', createdAt: '', updatedAt: '' }
+    ])
 
     await act(async () => {
       renderComponent()
     })
 
-    // Initially should show only first 3 items
     await waitFor(() => {
-      expect(screen.getByText('Task 3')).toBeVisible()
-      expect(screen.getByText('Task 2')).toBeVisible() 
-      expect(screen.getByText('Task 4')).toBeVisible()
-      expect(screen.queryByText('Task 1')).not.toBeInTheDocument()
-      expect(screen.getByText('+1 more items')).toBeVisible()
-    })
-
-    // Click expand
-    const moreItemsButton = screen.getByText('+1 more items')
-    await act(async () => {
-      fireEvent.click(moreItemsButton)
-    })
-
-    // Should now show all items and "Show less"
-    await waitFor(() => {
-      expect(screen.getByText('Task 3')).toBeVisible()
-      expect(screen.getByText('Task 2')).toBeVisible()
-      expect(screen.getByText('Task 4')).toBeVisible()
-      expect(screen.getByText('Task 1')).toBeVisible() // Now visible
-      expect(screen.getByText('Show less')).toBeVisible()
-      expect(screen.queryByText('+1 more items')).not.toBeInTheDocument()
-    })
-
-    // Click collapse
-    const showLessButton = screen.getByText('Show less')
-    await act(async () => {
-      fireEvent.click(showLessButton)
-    })
-
-    // Should be back to original state
-    await waitFor(() => {
-      expect(screen.getByText('Task 3')).toBeVisible()
-      expect(screen.getByText('Task 2')).toBeVisible()
-      expect(screen.getByText('Task 4')).toBeVisible()
-      expect(screen.queryByText('Task 1')).not.toBeInTheDocument()
-      expect(screen.getByText('+1 more items')).toBeVisible()
-      expect(screen.queryByText('Show less')).not.toBeInTheDocument()
+      expect(screen.getByText('Spaghetti Bolognese')).toBeVisible()
     })
   })
 
@@ -413,20 +369,20 @@ describe('Given the HomeRoute component', () => {
     })
   })
 
-  it('should display to-do items with descriptions', async () => {
-    const mockToDoList = [
-      { id: '1', name: 'Buy groceries', description: 'Milk and bread', isDone: false },
-    ]
+  it('should display upcoming birthdays in the Birthdays card', async () => {
+    const today = new Date()
+    const nextMonth = today.getMonth() + 2 // +1 for 0-index, +1 for next month
 
-    jest.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue(mockToDoList)
+    jest.spyOn(BirthdayAPI, 'retrieveBirthdays').mockResolvedValue([
+      { id: '1', name: 'John Doe', month: nextMonth > 12 ? nextMonth - 12 : nextMonth, day: 1 }
+    ])
 
     await act(async () => {
       renderComponent()
     })
 
     await waitFor(() => {
-      expect(screen.getByText('Buy groceries')).toBeVisible()
-      expect(screen.getByText('Milk and bread')).toBeVisible()
+      expect(screen.getByText('John Doe')).toBeVisible()
     })
   })
 
@@ -494,7 +450,7 @@ describe('Given the HomeRoute component', () => {
       jest.useRealTimers()
     })
 
-    it('should display overdue items correctly', async () => {
+    it('should show overdue badge for overdue items', async () => {
       const overdueItem = {
         id: '1',
         name: 'Overdue Task',
@@ -512,11 +468,11 @@ describe('Given the HomeRoute component', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByText('overdue by 5 days')).toBeInTheDocument()
+        expect(screen.getByText('1 overdue')).toBeInTheDocument()
       })
     })
 
-    it('should display items due today correctly', async () => {
+    it('should display tasks due today in Today\'s Tasks card', async () => {
       const todayItem = {
         id: '2',
         name: 'Today Task',
@@ -534,11 +490,11 @@ describe('Given the HomeRoute component', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByText(/due today/i)).toBeInTheDocument()
+        expect(screen.getByText('Today Task')).toBeInTheDocument()
       })
     })
 
-    it('should display items due tomorrow correctly', async () => {
+    it('should not show tasks due tomorrow in Today\'s Tasks card', async () => {
       const tomorrowItem = {
         id: '3',
         name: 'Tomorrow Task',
@@ -556,11 +512,12 @@ describe('Given the HomeRoute component', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByText('due tomorrow')).toBeInTheDocument()
+        expect(screen.queryByText('Tomorrow Task')).not.toBeInTheDocument()
+        expect(screen.getByText('No tasks for today')).toBeInTheDocument()
       })
     })
 
-    it('should display items due in weeks correctly', async () => {
+    it('should not show tasks due in weeks in Today\'s Tasks card', async () => {
       const weekItem = {
         id: '4',
         name: 'Week Task',
@@ -578,11 +535,12 @@ describe('Given the HomeRoute component', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByText('in 2 weeks')).toBeInTheDocument()
+        expect(screen.queryByText('Week Task')).not.toBeInTheDocument()
+        expect(screen.getByText('No tasks for today')).toBeInTheDocument()
       })
     })
 
-    it('should display items due in months correctly', async () => {
+    it('should not show tasks due in months in Today\'s Tasks card', async () => {
       const monthItem = {
         id: '5',
         name: 'Month Task',
@@ -600,7 +558,8 @@ describe('Given the HomeRoute component', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByText('in 2 months')).toBeInTheDocument()
+        expect(screen.queryByText('Month Task')).not.toBeInTheDocument()
+        expect(screen.getByText('No tasks for today')).toBeInTheDocument()
       })
     })
 
@@ -622,10 +581,9 @@ describe('Given the HomeRoute component', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByText('No Date Task')).toBeInTheDocument()
-        // Should not display specific due date text
-        expect(screen.queryByText('due today')).not.toBeInTheDocument()
-        expect(screen.queryByText('overdue by')).not.toBeInTheDocument()
+        // Tasks without due dates don't appear in Today's Tasks
+        expect(screen.queryByText('No Date Task')).not.toBeInTheDocument()
+        expect(screen.getByText('No tasks for today')).toBeInTheDocument()
       })
     })
   })
@@ -747,21 +705,18 @@ describe('Given the HomeRoute component', () => {
     })
   })
 
-  describe('todo item expansion', () => {
-    it('should expand todo item on click and show detailed information', async () => {
-      const tomorrow = new Date()
-      tomorrow.setDate(tomorrow.getDate() + 1)
-      tomorrow.setHours(14, 30, 0, 0) // 2:30 PM tomorrow
-      
-      const todoItem = {
-        id: 'test-todo-1',
-        name: 'Test Todo Item',
-        description: 'This is a longer description that provides more details about the task that needs to be completed.',
-        isDone: false,
-        dueDate: tomorrow.getTime()
-      }
+  describe('planner mini-cards data', () => {
+    it('should show multiple overdue tasks as a single badge count', async () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2024-01-15T12:00:00Z'))
 
-      jest.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue([todoItem])
+      const overdueTasks = [
+        { id: '1', name: 'Old Task 1', isDone: false, dueDate: new Date('2024-01-10T12:00:00Z').getTime() },
+        { id: '2', name: 'Old Task 2', isDone: false, dueDate: new Date('2024-01-11T12:00:00Z').getTime() },
+        { id: '3', name: 'Old Task 3', isDone: false, dueDate: new Date('2024-01-12T12:00:00Z').getTime() },
+      ]
+
+      jest.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue(overdueTasks)
       jest.spyOn(GroceryAPI, 'retrieveGroceryList').mockResolvedValue([])
       jest.spyOn(NoiseAPI, 'retrieveNoiseTrackingItems').mockResolvedValue([])
 
@@ -769,104 +724,45 @@ describe('Given the HomeRoute component', () => {
         renderComponent()
       })
 
-      // Should show todo item initially
       await waitFor(() => {
-        expect(screen.getByText('Test Todo Item')).toBeVisible()
+        expect(screen.getByText('3 overdue')).toBeInTheDocument()
       })
 
-      // Click on the todo item to expand it
-      const todoElement = screen.getByText('Test Todo Item').closest('li')
-      expect(todoElement).not.toBeNull()
-      
-      await act(async () => {
-        fireEvent.click(todoElement!)
-      })
-
-      // Should show expanded content with full description
-      await waitFor(() => {
-        expect(screen.getByText('This is a longer description that provides more details about the task that needs to be completed.')).toBeVisible()
-        expect(screen.getByText('Due Date')).toBeVisible()
-      })
+      jest.useRealTimers()
     })
 
-    it('should collapse todo item on second click', async () => {
-      const tomorrow = new Date()
-      tomorrow.setDate(tomorrow.getDate() + 1)
-      tomorrow.setHours(14, 30, 0, 0) // 2:30 PM tomorrow
-      
-      const todoItem = {
-        id: 'test-todo-2',
-        name: 'Test Todo Item 2',
-        description: 'Another test description.',
-        isDone: false,
-        dueDate: tomorrow.getTime()
-      }
+    it('should show birthday that is today', async () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2024-01-15T12:00:00Z'))
 
-      jest.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue([todoItem])
-      jest.spyOn(GroceryAPI, 'retrieveGroceryList').mockResolvedValue([])
-      jest.spyOn(NoiseAPI, 'retrieveNoiseTrackingItems').mockResolvedValue([])
+      jest.spyOn(BirthdayAPI, 'retrieveBirthdays').mockResolvedValue([
+        { id: '1', name: 'Happy Person', month: 1, day: 15 }
+      ])
 
       await act(async () => {
         renderComponent()
       })
 
-      const todoElement = screen.getByText('Test Todo Item 2').closest('li')
-      
-      // Click to expand
-      await act(async () => {
-        fireEvent.click(todoElement!)
-      })
-
       await waitFor(() => {
-        expect(screen.getByText('Due Date')).toBeVisible()
+        expect(screen.getByText('Happy Person')).toBeInTheDocument()
+        expect(screen.getByText('Today!')).toBeInTheDocument()
       })
 
-      // Click again to collapse
-      await act(async () => {
-        fireEvent.click(todoElement!)
-      })
-
-      await waitFor(() => {
-        expect(screen.queryByText('Due Date')).not.toBeInTheDocument()
-      })
+      jest.useRealTimers()
     })
 
-    it('should handle todo items without descriptions', async () => {
-      const todoItem = {
-        id: 'test-todo-3',
-        name: 'Simple Todo',
-        description: undefined,
-        isDone: false,
-        dueDate: undefined
-      }
-
-      jest.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue([todoItem])
-      jest.spyOn(GroceryAPI, 'retrieveGroceryList').mockResolvedValue([])
-      jest.spyOn(NoiseAPI, 'retrieveNoiseTrackingItems').mockResolvedValue([])
+    it('should not show a meal for a different day', async () => {
+      jest.spyOn(MealPlanAPI, 'getMealPlans').mockResolvedValue([
+        { id: '1', projectId: 'test-project-id', date: '2020-01-01', recipeName: 'Old Meal', createdAt: '', updatedAt: '' }
+      ])
 
       await act(async () => {
         renderComponent()
       })
 
-      const todoElement = screen.getByText('Simple Todo').closest('li')
-      
-      await act(async () => {
-        fireEvent.click(todoElement!)
-      })
-
-      // Should show expanded state but no additional content since there's no description or due date
       await waitFor(() => {
-        expect(screen.queryByText('Due Date')).not.toBeInTheDocument() // No due date
-        expect(screen.getByText('Simple Todo')).toBeVisible() // Main title still visible
-      })
-
-      // Verify we can collapse it again
-      await act(async () => {
-        fireEvent.click(todoElement!)
-      })
-
-      await waitFor(() => {
-        expect(screen.getByText('Simple Todo')).toBeVisible() // Still visible in collapsed state
+        expect(screen.queryByText('Old Meal')).not.toBeInTheDocument()
+        expect(screen.getByText('No meal planned')).toBeInTheDocument()
       })
     })
   })

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router'
 import { useGroceryListContext, GroceryListProvider } from '../../providers/GroceryListProvider'
 import { usePlannerContext, PlannerProvider } from '../../providers/PlannerProvider'
 import { useNoiseTrackingContext, NoiseTrackingProvider } from '../../providers/NoiseTrackingProvider'
+import { useBirthdayContext, BirthdayProvider } from '../../providers/BirthdayProvider'
+import { useMealPlanContext, MealPlanProvider } from '../../providers/MealPlanProvider'
 import { useAppState } from '../../providers/AppStateProvider'
 import { useProjectContext } from '../../providers/ProjectProvider'
 import { AgentChatProvider } from '../../providers/AgentChatProvider'
@@ -24,10 +26,20 @@ import { useHomeInteractions } from '../../hooks/useHomeInteractions'
 
 import { Container } from './index.styled'
 
+const getTodayString = (): string => {
+  const now = new Date()
+  const yyyy = now.getFullYear()
+  const mm = String(now.getMonth() + 1).padStart(2, '0')
+  const dd = String(now.getDate()).padStart(2, '0')
+  return `${yyyy}-${mm}-${dd}`
+}
+
 const HomeDataContent = () => {
   const { groceryList, isLoading: isGroceryLoading } = useGroceryListContext()
   const { toDoList, isLoading: isToDoLoading, removeFromToDoList, updateToDoItemFields } = usePlannerContext()
   const { noiseTrackingItems, isLoading: isNoiseLoading } = useNoiseTrackingContext()
+  const { birthdays } = useBirthdayContext()
+  const { mealPlans } = useMealPlanContext()
   const { state: { purchasedItems }, dispatch } = useAppState()
   const { currentProject } = useProjectContext()
   const navigate = useNavigate()
@@ -41,6 +53,8 @@ const HomeDataContent = () => {
     purchasedItems,
     isToDoItemsExpanded: interactions.isToDoItemsExpanded
   })
+
+  const todayMeals = mealPlans.filter(plan => plan.date === getTodayString())
 
   const handleMarkDone = useCallback(async (id: string) => {
     try {
@@ -89,6 +103,8 @@ const HomeDataContent = () => {
 
         <PlannerSection
           toDoStats={homeData.toDoStats}
+          birthdays={birthdays}
+          todayMeals={todayMeals}
           isLoading={isToDoLoading}
           isExpanded={interactions.isToDoItemsExpanded}
           onToggleExpansion={interactions.handleToggleToDoItems}
@@ -128,7 +144,11 @@ const HomeContent = () => {
         <GroceryListProvider key={`grocery-${currentProject?.id || 'no-project'}`}>
           <PlannerProvider key={`planner-${currentProject?.id || 'no-project'}`}>
             <NoiseTrackingProvider key={`noise-${currentProject?.id || 'no-project'}`}>
-              <HomeDataContent />
+              <BirthdayProvider key={`birthday-${currentProject?.id || 'no-project'}`}>
+                <MealPlanProvider key={`meal-${currentProject?.id || 'no-project'}`}>
+                  <HomeDataContent />
+                </MealPlanProvider>
+              </BirthdayProvider>
             </NoiseTrackingProvider>
           </PlannerProvider>
         </GroceryListProvider>


### PR DESCRIPTION
Replace the single todo-list planner card with three focused
mini-cards displayed side-by-side:
- Today's Tasks: shows tasks due today with overdue badge
- Dinner Tonight: shows today's meal plan from MealPlanProvider
- Birthdays: shows next upcoming birthdays sorted by closest date

Wire BirthdayProvider and MealPlanProvider into HomeRoute so the
home page can access birthday and meal plan data.

https://claude.ai/code/session_01BKbEotQLwVDRJ69hZh3pMc