### PR TITLE
Redesign weekly planner view for improved readability and UX

### DIFF
--- a/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
@@ -3,46 +3,83 @@ import { Box, Typography, Button } from '@mui/material'
 import CakeIcon from '@mui/icons-material/Cake'
 import RestaurantIcon from '@mui/icons-material/Restaurant'
 
+const TODAY_COLOR = '#6366f1'
+const TODAY_BG = '#eef2ff'
+const TODAY_BORDER = '#a5b4fc'
+const OVERDUE_COLOR = '#ef4444'
+const MEAL_COLOR = '#f59e0b'
+const MEAL_BG = '#fffbeb'
+const BIRTHDAY_COLOR = '#ec4899'
+const BIRTHDAY_BG = '#fdf2f8'
+const BORDER_COLOR = '#f1f5f9'
+
 export const WeeklyContainer = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
-  padding: '0 0.5em',
-  boxSizing: 'border-box',
+  height: '100%',
+  overflow: 'hidden',
+  backgroundColor: '#f8fafc',
 })
 
 export const WeekHeader = styled(Box)({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  marginBottom: '0.5em',
+  padding: '14px 16px 10px',
+  flexShrink: 0,
+  gap: '8px',
 })
 
 export const WeekRangeLabel = styled(Typography)({
-  fontWeight: 600,
+  fontWeight: 700,
   fontSize: '1rem',
+  color: '#0f172a',
   flex: 1,
   textAlign: 'center',
+  letterSpacing: '-0.01em',
 })
 
 export const TodayButton = styled(Button)({
-  fontSize: '0.75rem',
+  fontSize: '0.72rem',
+  fontWeight: 600,
   minWidth: 'auto',
-  padding: '2px 8px',
+  padding: '4px 12px',
   textTransform: 'none',
-  color: '#059669',
-  borderColor: '#059669',
+  borderRadius: '20px',
+  color: TODAY_COLOR,
+  borderColor: TODAY_BORDER,
   '&:hover': {
-    backgroundColor: '#d1fae5',
-    borderColor: '#059669',
+    backgroundColor: TODAY_BG,
+    borderColor: TODAY_COLOR,
+  },
+})
+
+export const WeekGridWrapper = styled('div')({
+  flex: 1,
+  overflowX: 'auto',
+  overflowY: 'hidden',
+  padding: '0 12px 16px',
+  scrollBehavior: 'smooth',
+  WebkitOverflowScrolling: 'touch',
+  '&::-webkit-scrollbar': {
+    height: '4px',
+  },
+  '&::-webkit-scrollbar-track': {
+    background: 'transparent',
+  },
+  '&::-webkit-scrollbar-thumb': {
+    background: '#cbd5e1',
+    borderRadius: '4px',
   },
 })
 
 export const WeekGrid = styled('div')({
   display: 'grid',
-  gridTemplateColumns: 'repeat(7, 1fr)',
-  gap: '4px',
-  overflowX: 'auto',
+  gridTemplateColumns: 'repeat(7, 120px)',
+  gap: '8px',
+  height: '100%',
+  minHeight: '420px',
 })
 
 interface IDayColumnProps {
@@ -52,153 +89,167 @@ interface IDayColumnProps {
 export const DayColumn = styled('div')<IDayColumnProps>(({ isToday }) => ({
   display: 'flex',
   flexDirection: 'column',
-  minWidth: 0,
-  borderRadius: '8px',
-  border: isToday ? '1.5px solid #059669' : '1px solid #e5e7eb',
-  backgroundColor: isToday ? '#ecfdf5' : '#ffffff',
+  borderRadius: '16px',
+  border: `1.5px solid ${isToday ? TODAY_BORDER : BORDER_COLOR}`,
+  backgroundColor: isToday ? TODAY_BG : '#ffffff',
   overflow: 'hidden',
+  transition: 'box-shadow 0.15s ease, transform 0.15s ease',
+  boxShadow: isToday ? '0 4px 16px rgba(99,102,241,0.15)' : '0 1px 4px rgba(0,0,0,0.04)',
+  '&:hover': {
+    boxShadow: isToday
+      ? '0 6px 20px rgba(99,102,241,0.2)'
+      : '0 4px 12px rgba(0,0,0,0.08)',
+    transform: 'translateY(-1px)',
+  },
 }))
 
 export const DayColumnHeader = styled('div')<IDayColumnProps>(({ isToday }) => ({
   textAlign: 'center',
-  padding: '6px 4px',
-  backgroundColor: isToday ? '#d1fae5' : '#f9fafb',
-  borderBottom: isToday ? '1px solid #a7f3d0' : '1px solid #e5e7eb',
+  padding: '14px 8px 12px',
+  background: isToday
+    ? `linear-gradient(135deg, ${TODAY_COLOR} 0%, #818cf8 100%)`
+    : 'transparent',
+  flexShrink: 0,
 }))
 
-export const DayName = styled(Typography)<IDayColumnProps>(({ isToday }) => ({
+export const DayName = styled('div')<IDayColumnProps>(({ isToday }) => ({
   fontSize: '0.65rem',
-  fontWeight: 600,
-  color: isToday ? '#059669' : '#6b7280',
+  fontWeight: 700,
+  color: isToday ? 'rgba(255,255,255,0.75)' : '#94a3b8',
   textTransform: 'uppercase',
-  lineHeight: 1.2,
+  letterSpacing: '0.1em',
+  lineHeight: 1,
+  marginBottom: '5px',
 }))
 
-export const DayNumber = styled(Typography)<IDayColumnProps>(({ isToday }) => ({
-  fontSize: '0.9rem',
-  fontWeight: isToday ? 700 : 500,
-  color: isToday ? '#059669' : '#374151',
-  lineHeight: 1.2,
+export const DayNumber = styled('div')<IDayColumnProps>(({ isToday }) => ({
+  fontSize: '1.5rem',
+  fontWeight: isToday ? 800 : 600,
+  color: isToday ? '#ffffff' : '#1e293b',
+  lineHeight: 1,
 }))
 
 export const DayColumnBody = styled('div')({
   flex: 1,
   display: 'flex',
   flexDirection: 'column',
-  padding: '4px',
-  gap: '2px',
-  minHeight: '80px',
+  padding: '8px 6px',
+  gap: '5px',
+  overflowY: 'auto',
+  '&::-webkit-scrollbar': {
+    width: '3px',
+  },
+  '&::-webkit-scrollbar-thumb': {
+    background: '#e2e8f0',
+    borderRadius: '2px',
+  },
 })
 
-export const DayItem = styled('div')({
-  fontSize: '0.75rem',
-  color: '#374151',
-  padding: '4px 6px',
-  borderRadius: '4px',
+const baseItem = {
+  fontSize: '0.72rem',
+  padding: '5px 7px 5px 9px',
+  borderRadius: '8px',
   cursor: 'pointer',
-  wordBreak: 'break-word',
-  lineHeight: 1.3,
+  wordBreak: 'break-word' as const,
+  lineHeight: 1.4,
+  transition: 'all 0.12s ease',
+  flexShrink: 0,
+}
+
+export const DayItem = styled('div')({
+  ...baseItem,
+  color: '#334155',
+  backgroundColor: '#f8fafc',
+  borderLeft: `3px solid ${TODAY_COLOR}`,
   '&:hover': {
-    backgroundColor: '#dbeafe',
+    backgroundColor: TODAY_BG,
+    color: '#3730a3',
   },
 })
 
 export const OverdueDayItem = styled('div')({
-  fontSize: '0.75rem',
-  color: '#dc2626',
-  padding: '4px 6px',
-  borderRadius: '4px',
-  cursor: 'pointer',
-  wordBreak: 'break-word',
-  lineHeight: 1.3,
+  ...baseItem,
+  color: '#7f1d1d',
+  backgroundColor: '#fff5f5',
+  borderLeft: `3px solid ${OVERDUE_COLOR}`,
   '&:hover': {
     backgroundColor: '#fee2e2',
+    color: '#991b1b',
   },
 })
 
 export const CompletedDayItem = styled('div')({
-  fontSize: '0.75rem',
-  color: '#9ca3af',
+  ...baseItem,
+  color: '#94a3b8',
+  backgroundColor: '#f9fafb',
+  borderLeft: '3px solid #cbd5e1',
   textDecoration: 'line-through',
-  padding: '4px 6px',
-  borderRadius: '4px',
-  cursor: 'pointer',
-  wordBreak: 'break-word',
-  lineHeight: 1.3,
-  display: 'flex',
-  alignItems: 'flex-start',
-  gap: '3px',
-  '&::before': {
-    content: '"✓"',
-    color: '#059669',
-    fontWeight: 700,
-    textDecoration: 'none',
-    flexShrink: 0,
-    fontSize: '0.65rem',
-  },
+  opacity: 0.7,
   '&:hover': {
-    backgroundColor: '#f3f4f6',
+    opacity: 1,
+    backgroundColor: '#f1f5f9',
   },
 })
 
 export const BirthdayItem = styled('div')({
-  fontSize: '0.75rem',
-  color: '#9d174d',
-  padding: '4px 6px',
-  borderRadius: '4px',
-  cursor: 'pointer',
-  wordBreak: 'break-word',
-  lineHeight: 1.3,
+  ...baseItem,
+  color: '#831843',
+  backgroundColor: BIRTHDAY_BG,
+  borderLeft: `3px solid ${BIRTHDAY_COLOR}`,
   display: 'flex',
   alignItems: 'flex-start',
-  gap: '3px',
+  gap: '4px',
   '&:hover': {
     backgroundColor: '#fce7f3',
   },
 })
 
 export const BirthdayIconStyled = styled(CakeIcon)({
-  fontSize: '0.75rem',
-  color: '#db2777',
+  fontSize: '0.7rem',
+  color: BIRTHDAY_COLOR,
   flexShrink: 0,
-  marginTop: '1px',
+  marginTop: '2px',
 })
 
 export const MealItem = styled('div')({
-  fontSize: '0.75rem',
-  color: '#92400e',
-  padding: '4px 6px',
-  borderRadius: '4px',
-  cursor: 'pointer',
-  wordBreak: 'break-word',
-  lineHeight: 1.3,
+  ...baseItem,
+  color: '#78350f',
+  backgroundColor: MEAL_BG,
+  borderLeft: `3px solid ${MEAL_COLOR}`,
   display: 'flex',
   alignItems: 'flex-start',
-  gap: '3px',
+  gap: '4px',
   '&:hover': {
     backgroundColor: '#fef3c7',
   },
 })
 
 export const MealIconStyled = styled(RestaurantIcon)({
-  fontSize: '0.75rem',
-  color: '#d97706',
+  fontSize: '0.7rem',
+  color: MEAL_COLOR,
   flexShrink: 0,
-  marginTop: '1px',
+  marginTop: '2px',
 })
 
 export const AddMealButton = styled('div')({
-  fontSize: '0.7rem',
-  color: '#d97706',
-  padding: '3px 6px',
+  fontSize: '0.68rem',
+  color: '#94a3b8',
+  padding: '7px 6px',
   cursor: 'pointer',
-  borderRadius: '4px',
+  borderRadius: '8px',
   display: 'flex',
   alignItems: 'center',
-  gap: '2px',
-  fontWeight: 500,
+  justifyContent: 'center',
+  gap: '3px',
+  fontWeight: 600,
   marginTop: 'auto',
+  border: '1.5px dashed #e2e8f0',
+  letterSpacing: '0.02em',
+  transition: 'all 0.15s ease',
   '&:hover': {
-    backgroundColor: '#fef3c7',
+    backgroundColor: MEAL_BG,
+    color: MEAL_COLOR,
+    borderColor: MEAL_COLOR,
+    borderStyle: 'solid',
   },
 })

--- a/packages/web/src/components/Planner/WeeklyView/index.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import { IconButton } from '@mui/material'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
@@ -12,6 +12,7 @@ import {
   WeekHeader,
   WeekRangeLabel,
   TodayButton,
+  WeekGridWrapper,
   WeekGrid,
   DayColumn,
   DayColumnHeader,
@@ -49,11 +50,24 @@ const WeeklyView = ({
 }: IWeeklyViewProps) => {
   const [currentWeek, setCurrentWeek] = useState<Dayjs>(() => dayjs().startOf('week'))
   const today = dayjs()
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const todayColumnRef = useRef<HTMLDivElement>(null)
 
   const weekDays = useMemo(
     () => Array.from({ length: 7 }, (_, i) => currentWeek.add(i, 'day')),
     [currentWeek]
   )
+
+  // Scroll to today's column whenever the week changes
+  useEffect(() => {
+    const wrapper = wrapperRef.current
+    const todayEl = todayColumnRef.current
+    if (wrapper && todayEl) {
+      const scrollLeft =
+        todayEl.offsetLeft - wrapper.clientWidth / 2 + todayEl.clientWidth / 2
+      wrapper.scrollTo({ left: Math.max(0, scrollLeft), behavior: 'smooth' })
+    }
+  }, [currentWeek])
 
   const goToPrevWeek = () => setCurrentWeek(prev => prev.subtract(1, 'week'))
   const goToNextWeek = () => setCurrentWeek(prev => prev.add(1, 'week'))
@@ -150,66 +164,72 @@ const WeeklyView = ({
         </IconButton>
       </WeekHeader>
 
-      <WeekGrid>
-        {weekDays.map(day => {
-          const key = day.format('YYYY-MM-DD')
-          const isToday = day.isSame(today, 'day')
-          const isOverdue = day.isBefore(today, 'day')
-          const pendingTodos = pendingTodosByDay.get(key) ?? []
-          const completedTodos = completedTodosByDay.get(key) ?? []
-          const birthdayKey = `${day.month() + 1}-${day.date()}`
-          const dayBirthdays = birthdaysByDay.get(birthdayKey) ?? []
-          const dayMeals = mealPlansByDay.get(key) ?? []
+      <WeekGridWrapper ref={wrapperRef}>
+        <WeekGrid>
+          {weekDays.map(day => {
+            const key = day.format('YYYY-MM-DD')
+            const isToday = day.isSame(today, 'day')
+            const isOverdue = day.isBefore(today, 'day')
+            const pendingTodos = pendingTodosByDay.get(key) ?? []
+            const completedTodos = completedTodosByDay.get(key) ?? []
+            const birthdayKey = `${day.month() + 1}-${day.date()}`
+            const dayBirthdays = birthdaysByDay.get(birthdayKey) ?? []
+            const dayMeals = mealPlansByDay.get(key) ?? []
 
-          return (
-            <DayColumn key={key} isToday={isToday}>
-              <DayColumnHeader isToday={isToday}>
-                <DayName isToday={isToday}>{day.format('ddd')}</DayName>
-                <DayNumber isToday={isToday}>{day.date()}</DayNumber>
-              </DayColumnHeader>
+            return (
+              <DayColumn
+                key={key}
+                isToday={isToday}
+                ref={isToday ? todayColumnRef : undefined}
+              >
+                <DayColumnHeader isToday={isToday}>
+                  <DayName isToday={isToday}>{day.format('ddd')}</DayName>
+                  <DayNumber isToday={isToday}>{day.date()}</DayNumber>
+                </DayColumnHeader>
 
-              <DayColumnBody>
-                {pendingTodos.map(todo => (
-                  isOverdue ? (
-                    <OverdueDayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                <DayColumnBody>
+                  {pendingTodos.map(todo =>
+                    isOverdue ? (
+                      <OverdueDayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                        {todo.name}
+                      </OverdueDayItem>
+                    ) : (
+                      <DayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                        {todo.name}
+                      </DayItem>
+                    )
+                  )}
+
+                  {completedTodos.map(todo => (
+                    <CompletedDayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
                       {todo.name}
-                    </OverdueDayItem>
-                  ) : (
-                    <DayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
-                      {todo.name}
-                    </DayItem>
-                  )
-                ))}
+                    </CompletedDayItem>
+                  ))}
 
-                {completedTodos.map(todo => (
-                  <CompletedDayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
-                    {todo.name}
-                  </CompletedDayItem>
-                ))}
+                  {dayBirthdays.map(birthday => (
+                    <BirthdayItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
+                      <BirthdayIconStyled />
+                      {birthday.name}
+                    </BirthdayItem>
+                  ))}
 
-                {dayBirthdays.map(birthday => (
-                  <BirthdayItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
-                    <BirthdayIconStyled />
-                    {birthday.name}
-                  </BirthdayItem>
-                ))}
+                  {dayMeals.map(plan => (
+                    <MealItem key={plan.id} onClick={() => onMealPlanClick?.(plan)}>
+                      <MealIconStyled />
+                      {plan.recipeName}
+                    </MealItem>
+                  ))}
 
-                {dayMeals.map(plan => (
-                  <MealItem key={plan.id} onClick={() => onMealPlanClick?.(plan)}>
-                    <MealIconStyled />
-                    {plan.recipeName}
-                  </MealItem>
-                ))}
-
-                <AddMealButton onClick={() => onAddMealPlan?.(key)}>
-                  <AddIcon sx={{ fontSize: '0.7rem' }} />
-                  Meal
-                </AddMealButton>
-              </DayColumnBody>
-            </DayColumn>
-          )
-        })}
-      </WeekGrid>
+                  <AddMealButton onClick={() => onAddMealPlan?.(key)}>
+                    <AddIcon sx={{ fontSize: '0.65rem' }} />
+                    Meal
+                  </AddMealButton>
+                </DayColumnBody>
+              </DayColumn>
+            )
+          })}
+        </WeekGrid>
+      </WeekGridWrapper>
     </WeeklyContainer>
   )
 }


### PR DESCRIPTION
- Replace cramped 7-column fixed grid with horizontally scrollable layout
  (each column min 120px wide) so content is never squished on mobile
- Redesign day column headers: today gets a bold indigo gradient fill
  with large 1.5rem date number for instant visual orientation
- Add left-border color coding for all item types: indigo for pending,
  red for overdue, gray for completed, amber for meals, pink for birthdays
- Replace flat item rows with card-style chips (background + border + left accent)
- Restyle Add Meal button as a dashed-border full-width button that
  highlights amber on hover
- Auto-scroll to today's column on mount and week navigation
- Add smooth hover lift animation on day columns

https://claude.ai/code/session_016TnjFWaBkqkjhxVz2nXk3o