### PR TITLE
improve planner widget: normalize meal card styling and add recipe photo thumbnail

### DIFF
--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
@@ -1,8 +1,47 @@
 import { styled } from '@mui/material/styles'
+import { Box } from '@mui/material'
+
+const GRADIENTS = [
+  'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+  'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)',
+  'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)',
+  'linear-gradient(135deg, #fa709a 0%, #fee140 100%)',
+  'linear-gradient(135deg, #a18cd1 0%, #fbc2eb 100%)',
+]
+
+export const MealRow = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.4rem',
+})
+
+export const MealThumbnail = styled('img')({
+  width: '36px',
+  height: '36px',
+  borderRadius: '6px',
+  objectFit: 'cover',
+  flexShrink: 0,
+})
+
+export const MealThumbnailPlaceholder = styled(Box)<{ seed: number }>(({ seed }) => ({
+  width: '36px',
+  height: '36px',
+  borderRadius: '6px',
+  flexShrink: 0,
+  background: GRADIENTS[seed % GRADIENTS.length],
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: 'rgba(255,255,255,0.85)',
+  fontWeight: 700,
+  fontSize: '0.85rem',
+  userSelect: 'none',
+}))
 
 export const MealName = styled('div')(({ theme }) => ({
-  fontSize: '0.78rem',
-  fontWeight: 600,
+  fontSize: '0.75rem',
+  fontWeight: 500,
   color: theme.palette.text.primary,
   lineHeight: '1.3',
   overflow: 'hidden',

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { IMealPlan } from '../../../../../../types/mealPlan'
-import { MealName, AdditionalMeals } from './index.styled'
+import { ITodayMealItem } from '../../types'
+import { MealRow, MealThumbnail, MealThumbnailPlaceholder, MealName, AdditionalMeals } from './index.styled'
 
 interface ITodayMealCardProps {
-  todayMeals: IMealPlan[]
+  todayMeals: ITodayMealItem[]
 }
 
 export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals }) => {
@@ -15,7 +15,15 @@ export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals }) => 
 
   return (
     <>
-      <MealName>{first.recipeName}</MealName>
+      <MealRow>
+        {first.imagePath
+          ? <MealThumbnail src={first.imagePath} alt={first.recipeName} />
+          : <MealThumbnailPlaceholder seed={first.recipeName.charCodeAt(0)}>
+              {first.recipeName.charAt(0).toUpperCase()}
+            </MealThumbnailPlaceholder>
+        }
+        <MealName>{first.recipeName}</MealName>
+      </MealRow>
       {rest.length > 0 && (
         <AdditionalMeals>+{rest.length} more</AdditionalMeals>
       )}

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
@@ -2,10 +2,14 @@ import { IToDoStats } from '../../../../hooks/useHomeData/types'
 import { IBirthdayItem } from '../../../../api/birthdays/retrieve/types'
 import { IMealPlan } from '../../../../types/mealPlan'
 
+export interface ITodayMealItem extends IMealPlan {
+  imagePath?: string
+}
+
 export interface IToDoSectionProps {
   toDoStats: IToDoStats
   birthdays: IBirthdayItem[]
-  todayMeals: IMealPlan[]
+  todayMeals: ITodayMealItem[]
   isLoading: boolean
   isExpanded: boolean
   onToggleExpansion: () => void

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -5,6 +5,7 @@ import { usePlannerContext, PlannerProvider } from '../../providers/PlannerProvi
 import { useNoiseTrackingContext, NoiseTrackingProvider } from '../../providers/NoiseTrackingProvider'
 import { useBirthdayContext, BirthdayProvider } from '../../providers/BirthdayProvider'
 import { useMealPlanContext, MealPlanProvider } from '../../providers/MealPlanProvider'
+import { useRecipeContext, RecipeProvider } from '../../providers/RecipeProvider'
 import { useAppState } from '../../providers/AppStateProvider'
 import { useProjectContext } from '../../providers/ProjectProvider'
 import { AgentChatProvider } from '../../providers/AgentChatProvider'
@@ -40,6 +41,7 @@ const HomeDataContent = () => {
   const { noiseTrackingItems, isLoading: isNoiseLoading } = useNoiseTrackingContext()
   const { birthdays } = useBirthdayContext()
   const { mealPlans } = useMealPlanContext()
+  const { recipes } = useRecipeContext()
   const { state: { purchasedItems }, dispatch } = useAppState()
   const { currentProject } = useProjectContext()
   const navigate = useNavigate()
@@ -54,7 +56,12 @@ const HomeDataContent = () => {
     isToDoItemsExpanded: interactions.isToDoItemsExpanded
   })
 
-  const todayMeals = mealPlans.filter(plan => plan.date === getTodayString())
+  const todayMeals = mealPlans
+    .filter(plan => plan.date === getTodayString())
+    .map(plan => {
+      const recipe = plan.recipeId ? recipes.find(r => r.id === plan.recipeId) : undefined
+      return { ...plan, imagePath: recipe?.imagePath }
+    })
 
   const handleMarkDone = useCallback(async (id: string) => {
     try {
@@ -146,7 +153,9 @@ const HomeContent = () => {
             <NoiseTrackingProvider key={`noise-${currentProject?.id || 'no-project'}`}>
               <BirthdayProvider key={`birthday-${currentProject?.id || 'no-project'}`}>
                 <MealPlanProvider key={`meal-${currentProject?.id || 'no-project'}`}>
-                  <HomeDataContent />
+                  <RecipeProvider>
+                    <HomeDataContent />
+                  </RecipeProvider>
                 </MealPlanProvider>
               </BirthdayProvider>
             </NoiseTrackingProvider>


### PR DESCRIPTION
- Normalize MealName font weight (600→500) and size (0.78→0.75rem) to match
  visual weight of task/birthday card body text
- Add RecipeProvider to HomeRoute provider tree so recipe data is available
- Enrich todayMeals with recipe imagePath by joining on recipeId
- TodayMealCard now renders a 36x36px recipe thumbnail (or gradient initial
  placeholder when no image) alongside the meal name
- Export ITodayMealItem type from PlannerSection/types for shared use

https://claude.ai/code/session_01RgtSKBajbqEYzZ2zT7xhPM