### PR TITLE
Redesign planner widget: full-width recipe hero card + two-column bottom row

### DIFF
--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
@@ -10,6 +10,101 @@ const GRADIENTS = [
   'linear-gradient(135deg, #a18cd1 0%, #fbc2eb 100%)',
 ]
 
+export const HeroWrapper = styled(Box)({
+  position: 'relative',
+  width: '100%',
+  height: '200px',
+  borderRadius: '16px',
+  overflow: 'hidden',
+})
+
+export const HeroImage = styled('img')({
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  display: 'block',
+})
+
+export const HeroPlaceholder = styled(Box)<{ seed: number }>(({ seed }) => ({
+  width: '100%',
+  height: '100%',
+  background: GRADIENTS[seed % GRADIENTS.length],
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}))
+
+export const HeroPlaceholderInitial = styled('span')({
+  fontSize: '4rem',
+  fontWeight: 800,
+  color: 'rgba(255,255,255,0.6)',
+  userSelect: 'none',
+  lineHeight: 1,
+})
+
+export const HeroOverlay = styled(Box)({
+  position: 'absolute',
+  inset: 0,
+  background: 'linear-gradient(to top, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.18) 55%, transparent 100%)',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'flex-end',
+  padding: '1rem 1.1rem 0.9rem',
+  gap: '0.35rem',
+})
+
+export const HeroLabel = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.3rem',
+  fontSize: '0.65rem',
+  fontWeight: 700,
+  color: 'rgba(255,255,255,0.7)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  '& .MuiSvgIcon-root': {
+    fontSize: '0.75rem',
+  },
+})
+
+export const HeroTitle = styled('div')({
+  fontSize: '1.25rem',
+  fontWeight: 700,
+  color: '#fff',
+  lineHeight: '1.25',
+  letterSpacing: '-0.01em',
+  overflow: 'hidden',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: 'vertical',
+  textShadow: '0 1px 4px rgba(0,0,0,0.3)',
+})
+
+export const AdditionalMeals = styled('div')({
+  display: 'flex',
+  gap: '0.4rem',
+  flexWrap: 'wrap',
+  paddingTop: '0.1rem',
+})
+
+export const AdditionalMealPill = styled('span')({
+  fontSize: '0.65rem',
+  fontWeight: 600,
+  color: 'rgba(255,255,255,0.85)',
+  background: 'rgba(255,255,255,0.18)',
+  backdropFilter: 'blur(6px)',
+  borderRadius: '20px',
+  padding: '0.15rem 0.55rem',
+  border: '1px solid rgba(255,255,255,0.22)',
+})
+
+export const EmptyState = styled('div')(({ theme }) => ({
+  fontSize: '0.75rem',
+  color: theme.palette.text.secondary,
+  padding: '1.2rem',
+}))
+
+// Legacy exports kept to avoid breaking any residual imports
 export const MealRow = styled('div')({
   display: 'flex',
   alignItems: 'center',
@@ -48,10 +143,4 @@ export const MealName = styled('div')(({ theme }) => ({
   display: '-webkit-box',
   WebkitLineClamp: 2,
   WebkitBoxOrient: 'vertical',
-}))
-
-export const AdditionalMeals = styled('div')(({ theme }) => ({
-  fontSize: '0.7rem',
-  color: theme.palette.text.secondary,
-  fontWeight: 500,
 }))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
@@ -1,6 +1,18 @@
 import React from 'react'
+import RestaurantIcon from '@mui/icons-material/Restaurant'
 import { ITodayMealItem } from '../../types'
-import { MealRow, MealThumbnail, MealThumbnailPlaceholder, MealName, AdditionalMeals } from './index.styled'
+import {
+  HeroWrapper,
+  HeroImage,
+  HeroPlaceholder,
+  HeroPlaceholderInitial,
+  HeroOverlay,
+  HeroLabel,
+  HeroTitle,
+  AdditionalMeals,
+  AdditionalMealPill,
+  EmptyState,
+} from './index.styled'
 
 interface ITodayMealCardProps {
   todayMeals: ITodayMealItem[]
@@ -8,26 +20,37 @@ interface ITodayMealCardProps {
 
 export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals }) => {
   if (todayMeals.length === 0) {
-    return <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>No meal planned</span>
+    return <EmptyState>No meal planned for today</EmptyState>
   }
 
   const [first, ...rest] = todayMeals
+  const seed = first.recipeName.charCodeAt(0)
 
   return (
-    <>
-      <MealRow>
-        {first.imagePath
-          ? <MealThumbnail src={first.imagePath} alt={first.recipeName} />
-          : <MealThumbnailPlaceholder seed={first.recipeName.charCodeAt(0)}>
-              {first.recipeName.charAt(0).toUpperCase()}
-            </MealThumbnailPlaceholder>
-        }
-        <MealName>{first.recipeName}</MealName>
-      </MealRow>
-      {rest.length > 0 && (
-        <AdditionalMeals>+{rest.length} more</AdditionalMeals>
-      )}
-    </>
+    <HeroWrapper>
+      {first.imagePath
+        ? <HeroImage src={first.imagePath} alt={first.recipeName} />
+        : (
+          <HeroPlaceholder seed={seed}>
+            <HeroPlaceholderInitial>{first.recipeName.charAt(0).toUpperCase()}</HeroPlaceholderInitial>
+          </HeroPlaceholder>
+        )
+      }
+      <HeroOverlay>
+        <HeroLabel>
+          <RestaurantIcon />
+          Dinner Tonight
+        </HeroLabel>
+        <HeroTitle>{first.recipeName}</HeroTitle>
+        {rest.length > 0 && (
+          <AdditionalMeals>
+            {rest.map((meal) => (
+              <AdditionalMealPill key={meal.id}>{meal.recipeName}</AdditionalMealPill>
+            ))}
+          </AdditionalMeals>
+        )}
+      </HeroOverlay>
+    </HeroWrapper>
   )
 }
 

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.styled.tsx
@@ -3,7 +3,7 @@ import { Box, Card, CardContent } from '@mui/material'
 
 export const MiniCardsGrid = styled(Box)({
   display: 'grid',
-  gridTemplateColumns: '3fr 2fr',
+  gridTemplateColumns: '1fr 1fr',
   gridTemplateRows: 'auto auto',
   gap: '0.6rem',
   width: '100%',

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import ChecklistIcon from '@mui/icons-material/Checklist'
-import RestaurantIcon from '@mui/icons-material/Restaurant'
 import CakeIcon from '@mui/icons-material/Cake'
 import { IToDoSectionProps } from './types'
 import TodayTasksCard from './components/TodayTasksCard'
@@ -16,6 +15,7 @@ import {
   MiniCardBody,
 } from './index.styled'
 
+
 export const PlannerSection: React.FC<IToDoSectionProps> = ({
   toDoStats,
   birthdays,
@@ -23,19 +23,11 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
 }) => {
   return (
     <MiniCardsGrid>
-      <MiniCard sx={{ gridColumn: 1, gridRow: '1 / 3' }}>
-        <MiniCardContent>
-          <MiniCardHeader>
-            <MiniCardIcon><RestaurantIcon /></MiniCardIcon>
-            <MiniCardTitle>Dinner Tonight</MiniCardTitle>
-          </MiniCardHeader>
-          <MiniCardBody>
-            <TodayMealCard todayMeals={todayMeals} />
-          </MiniCardBody>
-        </MiniCardContent>
+      <MiniCard sx={{ gridColumn: '1 / 3', gridRow: 1, minHeight: 'unset' }}>
+        <TodayMealCard todayMeals={todayMeals} />
       </MiniCard>
 
-      <MiniCard sx={{ gridColumn: 2, gridRow: 1 }}>
+      <MiniCard sx={{ gridColumn: 1, gridRow: 2 }}>
         <MiniCardContent>
           <MiniCardHeader>
             <MiniCardIcon><ChecklistIcon /></MiniCardIcon>


### PR DESCRIPTION
- Recipe card now spans full width (top row) with a large hero image (200px),
  gradient overlay, and recipe name rendered as a bold title on the image
- Additional meals shown as frosted-glass pills over the hero image
- Tasks and Birthdays moved to a symmetric two-column grid below
- TodayMealCard rebuilt with HeroWrapper/HeroOverlay styled components;
  placeholder shows a large initial letter on a gradient background

https://claude.ai/code/session_01CYfa4hRAssS5QkTtF4S4cd