### PR TITLE
Add meal types, meal carousel widget, and reorder home sections

### DIFF
--- a/packages/lambdas/sources/add_meal_plan/body/index.ts
+++ b/packages/lambdas/sources/add_meal_plan/body/index.ts
@@ -13,6 +13,10 @@ const validateBody = (body: any): body is IRequestBody => {
     return false;
   }
 
+  if (body.mealType !== undefined && typeof body.mealType !== 'string') {
+    return false;
+  }
+
   return true;
 };
 

--- a/packages/lambdas/sources/add_meal_plan/body/types.ts
+++ b/packages/lambdas/sources/add_meal_plan/body/types.ts
@@ -2,4 +2,5 @@ export interface IRequestBody {
     date: string;
     recipeName: string;
     recipeId?: string;
+    mealType?: string;
 }

--- a/packages/lambdas/sources/add_meal_plan/database/index.ts
+++ b/packages/lambdas/sources/add_meal_plan/database/index.ts
@@ -6,6 +6,7 @@ export const createMealPlan = async (mealPlan: {
   date: string;
   recipeName: string;
   recipeId?: string;
+  mealType?: string;
 }): Promise<string> => {
   const id = randomUUID();
   const now = new Date().toISOString();
@@ -21,6 +22,10 @@ export const createMealPlan = async (mealPlan: {
 
   if (mealPlan.recipeId) {
     item.recipeId = mealPlan.recipeId;
+  }
+
+  if (mealPlan.mealType) {
+    item.mealType = mealPlan.mealType;
   }
 
   await putItem({

--- a/packages/lambdas/sources/add_meal_plan/index.ts
+++ b/packages/lambdas/sources/add_meal_plan/index.ts
@@ -23,9 +23,9 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
       });
     }
 
-    const { date, recipeName, recipeId } = body;
+    const { date, recipeName, recipeId, mealType } = body;
 
-    const id = await createMealPlan({ projectId, date, recipeName, recipeId });
+    const id = await createMealPlan({ projectId, date, recipeName, recipeId, mealType });
 
     return createResponse({
       statusCode: 201,

--- a/packages/lambdas/sources/update_meal_plan/body/index.ts
+++ b/packages/lambdas/sources/update_meal_plan/body/index.ts
@@ -13,6 +13,10 @@ const validateBody = (body: any): body is IRequestBody => {
     return false;
   }
 
+  if (body.mealType !== undefined && body.mealType !== null && typeof body.mealType !== 'string') {
+    return false;
+  }
+
   return true;
 };
 

--- a/packages/lambdas/sources/update_meal_plan/body/types.ts
+++ b/packages/lambdas/sources/update_meal_plan/body/types.ts
@@ -3,4 +3,5 @@ export interface IRequestBody {
     date?: string;
     recipeName?: string;
     recipeId?: string | null;
+    mealType?: string | null;
 }

--- a/packages/lambdas/sources/update_meal_plan/database/index.ts
+++ b/packages/lambdas/sources/update_meal_plan/database/index.ts
@@ -2,7 +2,7 @@ import { DynamoDBTable, updateItem } from "@kairos-lambdas-libs/dynamodb";
 
 export const updateMealPlan = async (
   id: string,
-  fields: { date?: string; recipeName?: string; recipeId?: string | null }
+  fields: { date?: string; recipeName?: string; recipeId?: string | null; mealType?: string | null }
 ): Promise<void> => {
   const updatedFields: Record<string, any> = {
     updatedAt: new Date().toISOString(),
@@ -18,6 +18,10 @@ export const updateMealPlan = async (
 
   if (fields.recipeId !== undefined) {
     updatedFields.recipeId = fields.recipeId || null;
+  }
+
+  if (fields.mealType !== undefined) {
+    updatedFields.mealType = fields.mealType || null;
   }
 
   await updateItem({

--- a/packages/lambdas/sources/update_meal_plan/index.ts
+++ b/packages/lambdas/sources/update_meal_plan/index.ts
@@ -23,9 +23,9 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
       });
     }
 
-    const { id, date, recipeName, recipeId } = body;
+    const { id, date, recipeName, recipeId, mealType } = body;
 
-    await updateMealPlan(id, { date, recipeName, recipeId });
+    await updateMealPlan(id, { date, recipeName, recipeId, mealType });
 
     return createResponse({
       statusCode: 200,

--- a/packages/web/src/api/mealPlans/add/index.ts
+++ b/packages/web/src/api/mealPlans/add/index.ts
@@ -3,7 +3,7 @@ import { API_BASE_URL } from '../../index'
 import { createFetchOptions } from '../../../utils/api'
 
 export const addMealPlan = async (
-  mealPlan: { date: string; recipeName: string; recipeId?: string },
+  mealPlan: { date: string; recipeName: string; recipeId?: string; mealType?: string },
   projectId?: string
 ): Promise<IMealPlan> => {
   const response = await fetch(`${API_BASE_URL}/meal-plans`, createFetchOptions({

--- a/packages/web/src/api/mealPlans/update/index.ts
+++ b/packages/web/src/api/mealPlans/update/index.ts
@@ -3,7 +3,7 @@ import { createFetchOptions } from '../../../utils/api'
 
 export const updateMealPlan = async (
   id: string,
-  fields: { date?: string; recipeName?: string; recipeId?: string | null },
+  fields: { date?: string; recipeName?: string; recipeId?: string | null; mealType?: string | null },
   projectId?: string
 ): Promise<void> => {
   const response = await fetch(`${API_BASE_URL}/meal-plans/${id}`, createFetchOptions({

--- a/packages/web/src/components/MealPlanDrawer/index.tsx
+++ b/packages/web/src/components/MealPlanDrawer/index.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Drawer, ToggleButton, InputAdornment, Dialog, DialogContent, DialogTitle, IconButton, Box, Typography } from '@mui/material'
+import { Drawer, ToggleButton, InputAdornment, Dialog, DialogContent, DialogTitle, IconButton, Box, Typography, MenuItem } from '@mui/material'
 import RestaurantIcon from '@mui/icons-material/Restaurant'
 import SearchIcon from '@mui/icons-material/Search'
 import VisibilityIcon from '@mui/icons-material/Visibility'
 import dayjs from 'dayjs'
 import { IMealPlan } from '../../types/mealPlan'
 import { IRecipe } from '../../types/recipe'
+import { MealType, MEAL_TYPE_ORDER } from '../../enums/mealType'
 import { useRecipeContext } from '../../providers/RecipeProvider'
 import { GroceryItemUnitLabelMap } from '../../enums/groceryItem'
 import {
@@ -32,7 +33,7 @@ interface IMealPlanDrawerProps {
   date: string | null
   mealPlan?: IMealPlan
   onClose: () => void
-  onSave: (date: string, recipeName: string, recipeId?: string) => void
+  onSave: (date: string, recipeName: string, recipeId?: string, mealType?: MealType) => void
   onDelete?: (id: string) => void
 }
 
@@ -43,6 +44,7 @@ const MealPlanDrawer = ({ open, date, mealPlan, onClose, onSave, onDelete }: IMe
   const [selectedRecipeId, setSelectedRecipeId] = useState<string | undefined>(undefined)
   const [search, setSearch] = useState('')
   const [previewRecipe, setPreviewRecipe] = useState<IRecipe | null>(null)
+  const [mealType, setMealType] = useState<MealType>(MealType.Dinner)
 
   useEffect(() => {
     if (open) {
@@ -56,10 +58,12 @@ const MealPlanDrawer = ({ open, date, mealPlan, onClose, onSave, onDelete }: IMe
           setCustomName(mealPlan.recipeName)
           setSelectedRecipeId(undefined)
         }
+        setMealType(mealPlan.mealType ?? MealType.Dinner)
       } else {
         setMode('recipe')
         setCustomName('')
         setSelectedRecipeId(undefined)
+        setMealType(MealType.Dinner)
       }
       setSearch('')
     }
@@ -83,9 +87,9 @@ const MealPlanDrawer = ({ open, date, mealPlan, onClose, onSave, onDelete }: IMe
     if (!date) return
 
     if (mode === 'recipe' && selectedRecipe) {
-      onSave(date, selectedRecipe.name, selectedRecipe.id)
+      onSave(date, selectedRecipe.name, selectedRecipe.id, mealType)
     } else if (mode === 'custom' && customName.trim()) {
-      onSave(date, customName.trim(), undefined)
+      onSave(date, customName.trim(), undefined, mealType)
     }
   }
 
@@ -106,6 +110,19 @@ const MealPlanDrawer = ({ open, date, mealPlan, onClose, onSave, onDelete }: IMe
         </DrawerHeader>
 
         <DateLabel>{displayDate}</DateLabel>
+
+        <StyledTextField
+          select
+          size="small"
+          label="Meal type"
+          value={mealType}
+          onChange={(e) => setMealType(e.target.value as MealType)}
+          fullWidth
+        >
+          {MEAL_TYPE_ORDER.map(type => (
+            <MenuItem key={type} value={type}>{type}</MenuItem>
+          ))}
+        </StyledTextField>
 
         <ModeToggle
           value={mode}

--- a/packages/web/src/enums/mealType.ts
+++ b/packages/web/src/enums/mealType.ts
@@ -1,0 +1,17 @@
+export enum MealType {
+  Breakfast = 'Breakfast',
+  Brunch = 'Brunch',
+  Lunch = 'Lunch',
+  Snack = 'Snack',
+  Dinner = 'Dinner',
+  Other = 'Other',
+}
+
+export const MEAL_TYPE_ORDER: MealType[] = [
+  MealType.Breakfast,
+  MealType.Brunch,
+  MealType.Lunch,
+  MealType.Snack,
+  MealType.Dinner,
+  MealType.Other,
+]

--- a/packages/web/src/providers/MealPlanProvider/index.tsx
+++ b/packages/web/src/providers/MealPlanProvider/index.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, useLayoutEffect, useMemo } from 'react'
 import { IMealPlan } from '../../types/mealPlan'
+import { MealType } from '../../enums/mealType'
 import { getMealPlans, addMealPlan as addMealPlanApi, updateMealPlan as updateMealPlanApi, deleteMealPlan } from '../../api/mealPlans'
 import { IState, IMealPlanProviderProps } from './types'
 import { useProjectContext } from '../ProjectProvider'
@@ -37,21 +38,22 @@ export const MealPlanProvider = ({ children }: IMealPlanProviderProps) => {
     }
   }, [currentProject])
 
-  const addMealPlan = useCallback(async (date: string, recipeName: string, recipeId?: string) => {
+  const addMealPlan = useCallback(async (date: string, recipeName: string, recipeId?: string, mealType?: MealType) => {
     if (!currentProject) return
 
-    const result = await addMealPlanApi({ date, recipeName, recipeId }, currentProject.id)
+    const result = await addMealPlanApi({ date, recipeName, recipeId, mealType }, currentProject.id)
     const newMealPlan: IMealPlan = {
       ...result,
       date,
       recipeName,
       recipeId,
+      mealType,
       projectId: currentProject.id,
     }
     setMealPlans((prev) => [...prev, newMealPlan])
   }, [currentProject])
 
-  const updateMealPlan = useCallback(async (id: string, fields: { date?: string; recipeName?: string; recipeId?: string | null }) => {
+  const updateMealPlan = useCallback(async (id: string, fields: { date?: string; recipeName?: string; recipeId?: string | null; mealType?: MealType | null }) => {
     if (!currentProject) return
 
     await updateMealPlanApi(id, fields, currentProject.id)

--- a/packages/web/src/providers/MealPlanProvider/types.ts
+++ b/packages/web/src/providers/MealPlanProvider/types.ts
@@ -1,11 +1,13 @@
 import { IMealPlan } from '../../types/mealPlan'
 
+import { MealType } from '../../enums/mealType'
+
 export interface IState {
   mealPlans: IMealPlan[]
   isLoading: boolean
   fetchMealPlans: () => Promise<void>
-  addMealPlan: (date: string, recipeName: string, recipeId?: string) => Promise<void>
-  updateMealPlan: (id: string, fields: { date?: string; recipeName?: string; recipeId?: string | null }) => Promise<void>
+  addMealPlan: (date: string, recipeName: string, recipeId?: string, mealType?: MealType) => Promise<void>
+  updateMealPlan: (id: string, fields: { date?: string; recipeName?: string; recipeId?: string | null; mealType?: MealType | null }) => Promise<void>
   removeMealPlan: (id: string) => Promise<void>
 }
 

--- a/packages/web/src/routes/AddPlannerItemRoute/MealForm/index.tsx
+++ b/packages/web/src/routes/AddPlannerItemRoute/MealForm/index.tsx
@@ -8,12 +8,14 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   InputAdornment,
+  MenuItem,
 } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import RestaurantIcon from '@mui/icons-material/Restaurant'
 import SearchIcon from '@mui/icons-material/Search'
 import { useNavigate } from 'react-router'
 import { Route } from '../../../enums/route'
+import { MealType, MEAL_TYPE_ORDER } from '../../../enums/mealType'
 import { useMealPlanContext } from '../../../providers/MealPlanProvider'
 import { useRecipeContext } from '../../../providers/RecipeProvider'
 import {
@@ -150,6 +152,7 @@ const MealForm = () => {
   const [customName, setCustomName] = useState('')
   const [selectedRecipeId, setSelectedRecipeId] = useState<string | undefined>(undefined)
   const [search, setSearch] = useState('')
+  const [mealType, setMealType] = useState<MealType>(MealType.Dinner)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
 
@@ -171,9 +174,9 @@ const MealForm = () => {
     setIsLoading(true)
     try {
       if (mode === 'recipe' && selectedRecipe) {
-        await addMealPlan(date, selectedRecipe.name, selectedRecipe.id)
+        await addMealPlan(date, selectedRecipe.name, selectedRecipe.id, mealType)
       } else if (mode === 'custom' && customName.trim()) {
-        await addMealPlan(date, customName.trim(), undefined)
+        await addMealPlan(date, customName.trim(), undefined, mealType)
       }
       navigate(Route.Planner)
     } catch (err) {
@@ -198,6 +201,19 @@ const MealForm = () => {
                 disabled={isLoading}
                 InputLabelProps={{ shrink: true }}
               />
+
+              <MealTextField
+                select
+                fullWidth
+                label="Meal type"
+                value={mealType}
+                onChange={e => setMealType(e.target.value as MealType)}
+                disabled={isLoading}
+              >
+                {MEAL_TYPE_ORDER.map(type => (
+                  <MenuItem key={type} value={type}>{type}</MenuItem>
+                ))}
+              </MealTextField>
 
               <MealModeToggle
                 value={mode}

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
@@ -10,12 +10,59 @@ const GRADIENTS = [
   'linear-gradient(135deg, #a18cd1 0%, #fbc2eb 100%)',
 ]
 
+// Carousel outer container — clips slides
+export const CarouselContainer = styled(Box)({
+  position: 'relative',
+  width: '100%',
+  overflow: 'hidden',
+  borderRadius: '16px',
+  height: '200px',
+  cursor: 'grab',
+  '&:active': { cursor: 'grabbing' },
+})
+
+// Sliding track
+export const CarouselTrack = styled(Box)<{ offset: number }>(({ offset }) => ({
+  display: 'flex',
+  height: '100%',
+  transform: `translateX(-${offset * 100}%)`,
+  transition: 'transform 0.35s cubic-bezier(0.4, 0, 0.2, 1)',
+}))
+
+// Each slide takes full width
+export const CarouselSlide = styled(Box)({
+  flexShrink: 0,
+  width: '100%',
+  height: '100%',
+  position: 'relative',
+})
+
+export const CarouselDots = styled(Box)({
+  position: 'absolute',
+  bottom: '10px',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  display: 'flex',
+  gap: '5px',
+  zIndex: 3,
+})
+
+export const CarouselDot = styled('button')<{ active: boolean }>(({ active }) => ({
+  width: active ? '18px' : '6px',
+  height: '6px',
+  borderRadius: '3px',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+  background: active ? 'rgba(255,255,255,0.95)' : 'rgba(255,255,255,0.45)',
+  transition: 'all 0.25s ease',
+  flexShrink: 0,
+}))
+
 export const HeroWrapper = styled(Box)({
   position: 'relative',
   width: '100%',
-  height: '200px',
-  borderRadius: '16px',
-  overflow: 'hidden',
+  height: '100%',
 })
 
 export const HeroImage = styled('img')({
@@ -80,67 +127,8 @@ export const HeroTitle = styled('div')({
   textShadow: '0 1px 4px rgba(0,0,0,0.3)',
 })
 
-export const AdditionalMeals = styled('div')({
-  display: 'flex',
-  gap: '0.4rem',
-  flexWrap: 'wrap',
-  paddingTop: '0.1rem',
-})
-
-export const AdditionalMealPill = styled('span')({
-  fontSize: '0.65rem',
-  fontWeight: 600,
-  color: 'rgba(255,255,255,0.85)',
-  background: 'rgba(255,255,255,0.18)',
-  backdropFilter: 'blur(6px)',
-  borderRadius: '20px',
-  padding: '0.15rem 0.55rem',
-  border: '1px solid rgba(255,255,255,0.22)',
-})
-
 export const EmptyState = styled('div')(({ theme }) => ({
   fontSize: '0.75rem',
   color: theme.palette.text.secondary,
   padding: '1.2rem',
-}))
-
-// Legacy exports kept to avoid breaking any residual imports
-export const MealRow = styled('div')({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '0.4rem',
-})
-
-export const MealThumbnail = styled('img')({
-  width: '48px',
-  height: '48px',
-  borderRadius: '8px',
-  objectFit: 'cover',
-  flexShrink: 0,
-})
-
-export const MealThumbnailPlaceholder = styled(Box)<{ seed: number }>(({ seed }) => ({
-  width: '48px',
-  height: '48px',
-  borderRadius: '8px',
-  flexShrink: 0,
-  background: GRADIENTS[seed % GRADIENTS.length],
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  color: 'rgba(255,255,255,0.85)',
-  fontWeight: 700,
-  fontSize: '0.85rem',
-  userSelect: 'none',
-}))
-
-export const MealName = styled('div')(({ theme }) => ({
-  fontSize: '0.75rem',
-  fontWeight: 500,
-  color: theme.palette.text.primary,
-  lineHeight: '1.3',
-  overflow: 'hidden',
-  display: '-webkit-box',
-  WebkitLineClamp: 2,
-  WebkitBoxOrient: 'vertical',
 }))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
@@ -81,7 +81,7 @@ export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals }) => 
   }
 
   if (meals.length === 0) {
-    return <EmptyState>No meal planned for today</EmptyState>
+    return <EmptyState>No meal planned</EmptyState>
   }
 
   return (

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
@@ -1,7 +1,13 @@
-import React from 'react'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
 import RestaurantIcon from '@mui/icons-material/Restaurant'
 import { ITodayMealItem } from '../../types'
+import { MEAL_TYPE_ORDER } from '../../../../../../enums/mealType'
 import {
+  CarouselContainer,
+  CarouselTrack,
+  CarouselSlide,
+  CarouselDots,
+  CarouselDot,
   HeroWrapper,
   HeroImage,
   HeroPlaceholder,
@@ -9,48 +15,119 @@ import {
   HeroOverlay,
   HeroLabel,
   HeroTitle,
-  AdditionalMeals,
-  AdditionalMealPill,
   EmptyState,
 } from './index.styled'
+
+const AUTO_SCROLL_MS = 4000
 
 interface ITodayMealCardProps {
   todayMeals: ITodayMealItem[]
 }
 
+const sortedMeals = (meals: ITodayMealItem[]): ITodayMealItem[] =>
+  [...meals].sort((a, b) => {
+    const ai = a.mealType ? MEAL_TYPE_ORDER.indexOf(a.mealType) : MEAL_TYPE_ORDER.length
+    const bi = b.mealType ? MEAL_TYPE_ORDER.indexOf(b.mealType) : MEAL_TYPE_ORDER.length
+    return ai - bi
+  })
+
 export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals }) => {
-  if (todayMeals.length === 0) {
+  const meals = sortedMeals(todayMeals)
+  const [activeIndex, setActiveIndex] = useState(0)
+  const touchStartX = useRef(0)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const next = useCallback(() => {
+    setActiveIndex(i => (i + 1) % meals.length)
+  }, [meals.length])
+
+  const prev = useCallback(() => {
+    setActiveIndex(i => (i - 1 + meals.length) % meals.length)
+  }, [meals.length])
+
+  const resetTimer = useCallback(() => {
+    if (timerRef.current) clearInterval(timerRef.current)
+    if (meals.length > 1) {
+      timerRef.current = setInterval(next, AUTO_SCROLL_MS)
+    }
+  }, [meals.length, next])
+
+  useEffect(() => {
+    resetTimer()
+    return () => { if (timerRef.current) clearInterval(timerRef.current) }
+  }, [resetTimer])
+
+  // Reset index when meal list changes
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [meals.length])
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    const diff = touchStartX.current - e.changedTouches[0].clientX
+    if (Math.abs(diff) > 40) {
+      if (diff > 0) next()
+      else prev()
+      resetTimer()
+    }
+  }
+
+  const handleDotClick = (index: number) => {
+    setActiveIndex(index)
+    resetTimer()
+  }
+
+  if (meals.length === 0) {
     return <EmptyState>No meal planned for today</EmptyState>
   }
 
-  const [first, ...rest] = todayMeals
-  const seed = first.recipeName.charCodeAt(0)
-
   return (
-    <HeroWrapper>
-      {first.imagePath
-        ? <HeroImage src={first.imagePath} alt={first.recipeName} />
-        : (
-          <HeroPlaceholder seed={seed}>
-            <HeroPlaceholderInitial>{first.recipeName.charAt(0).toUpperCase()}</HeroPlaceholderInitial>
-          </HeroPlaceholder>
-        )
-      }
-      <HeroOverlay>
-        <HeroLabel>
-          <RestaurantIcon />
-          Dinner Tonight
-        </HeroLabel>
-        <HeroTitle>{first.recipeName}</HeroTitle>
-        {rest.length > 0 && (
-          <AdditionalMeals>
-            {rest.map((meal) => (
-              <AdditionalMealPill key={meal.id}>{meal.recipeName}</AdditionalMealPill>
-            ))}
-          </AdditionalMeals>
-        )}
-      </HeroOverlay>
-    </HeroWrapper>
+    <CarouselContainer
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <CarouselTrack offset={activeIndex}>
+        {meals.map((meal) => {
+          const seed = meal.recipeName.charCodeAt(0)
+          return (
+            <CarouselSlide key={meal.id}>
+              <HeroWrapper>
+                {meal.imagePath
+                  ? <HeroImage src={meal.imagePath} alt={meal.recipeName} />
+                  : (
+                    <HeroPlaceholder seed={seed}>
+                      <HeroPlaceholderInitial>{meal.recipeName.charAt(0).toUpperCase()}</HeroPlaceholderInitial>
+                    </HeroPlaceholder>
+                  )
+                }
+                <HeroOverlay>
+                  <HeroLabel>
+                    <RestaurantIcon />
+                    {meal.mealType ?? 'Meal'}
+                  </HeroLabel>
+                  <HeroTitle>{meal.recipeName}</HeroTitle>
+                </HeroOverlay>
+              </HeroWrapper>
+            </CarouselSlide>
+          )
+        })}
+      </CarouselTrack>
+
+      {meals.length > 1 && (
+        <CarouselDots>
+          {meals.map((_, i) => (
+            <CarouselDot
+              key={i}
+              active={i === activeIndex}
+              onClick={() => handleDotClick(i)}
+            />
+          ))}
+        </CarouselDots>
+      )}
+    </CarouselContainer>
   )
 }
 

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.test.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.test.tsx
@@ -77,7 +77,7 @@ describe('PlannerSection component', () => {
       renderWithTheme(<PlannerSection {...defaultProps} />)
 
       expect(screen.getByText("Today's Tasks")).toBeInTheDocument()
-      expect(screen.getByText('Dinner Tonight')).toBeInTheDocument()
+      expect(screen.getByText('No meal planned')).toBeInTheDocument()
       expect(screen.getByText('Birthdays')).toBeInTheDocument()
     })
   })
@@ -133,7 +133,7 @@ describe('PlannerSection component', () => {
     })
   })
 
-  describe('Dinner Tonight card', () => {
+  describe('Today\'s Meals card', () => {
     it('should show empty state when no meal planned today', () => {
       renderWithTheme(<PlannerSection {...defaultProps} />)
 
@@ -148,7 +148,7 @@ describe('PlannerSection component', () => {
       expect(screen.getByText('Chicken Alfredo')).toBeInTheDocument()
     })
 
-    it('should show +N more when there are additional meals', () => {
+    it('should show all meals in the carousel when there are multiple meals', () => {
       const meals = [
         createMockMealPlan({ id: '1', recipeName: 'Breakfast Dish' }),
         createMockMealPlan({ id: '2', recipeName: 'Lunch Dish' }),
@@ -158,7 +158,8 @@ describe('PlannerSection component', () => {
       renderWithTheme(<PlannerSection {...defaultProps} todayMeals={meals} />)
 
       expect(screen.getByText('Breakfast Dish')).toBeInTheDocument()
-      expect(screen.getByText('+2 more')).toBeInTheDocument()
+      expect(screen.getByText('Lunch Dish')).toBeInTheDocument()
+      expect(screen.getByText('Dinner Dish')).toBeInTheDocument()
     })
   })
 

--- a/packages/web/src/routes/HomeRoute/index.test.tsx
+++ b/packages/web/src/routes/HomeRoute/index.test.tsx
@@ -102,7 +102,7 @@ describe('Given the HomeRoute component', () => {
     await waitFor(() => {
       expect(screen.getByText('Grocery List')).toBeVisible()
       expect(screen.getByText("Today's Tasks")).toBeVisible()
-      expect(screen.getByText('Dinner Tonight')).toBeVisible()
+      expect(screen.getByText('No meal planned')).toBeVisible()
       expect(screen.getByText('Birthdays')).toBeVisible()
       expect(screen.getByText('Noise Recordings')).toBeVisible()
     })
@@ -116,7 +116,7 @@ describe('Given the HomeRoute component', () => {
     await waitFor(() => {
       expect(screen.getByText('No grocery items found')).toBeVisible()
       expect(screen.getByText('No tasks for today')).toBeVisible()
-      expect(screen.getByText('No meal planned')).toBeVisible()
+      expect(screen.getAllByText('No meal planned')[0]).toBeVisible()
       expect(screen.getByText('No birthdays saved')).toBeVisible()
       expect(screen.getByText('No noise recordings found')).toBeVisible()
     })
@@ -762,7 +762,7 @@ describe('Given the HomeRoute component', () => {
 
       await waitFor(() => {
         expect(screen.queryByText('Old Meal')).not.toBeInTheDocument()
-        expect(screen.getByText('No meal planned')).toBeInTheDocument()
+        expect(screen.getAllByText('No meal planned')[0]).toBeInTheDocument()
       })
     })
   })

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -94,6 +94,17 @@ const HomeDataContent = () => {
   return (
     <>
       <Container>
+        <PlannerSection
+          toDoStats={homeData.toDoStats}
+          birthdays={birthdays}
+          todayMeals={todayMeals}
+          isLoading={isToDoLoading}
+          isExpanded={interactions.isToDoItemsExpanded}
+          onToggleExpansion={interactions.handleToggleToDoItems}
+          onItemToggle={interactions.handleToDoItemToggle}
+          expandedItems={interactions.expandedToDoItems}
+        />
+
         <GrocerySection
           groceryStats={homeData.groceryStats}
           isLoading={isGroceryLoading}
@@ -106,17 +117,6 @@ const HomeDataContent = () => {
           isLoading={isNoiseLoading}
           noiseView={interactions.noiseView}
           onNoiseViewChange={interactions.handleNoiseViewChange}
-        />
-
-        <PlannerSection
-          toDoStats={homeData.toDoStats}
-          birthdays={birthdays}
-          todayMeals={todayMeals}
-          isLoading={isToDoLoading}
-          isExpanded={interactions.isToDoItemsExpanded}
-          onToggleExpansion={interactions.handleToggleToDoItems}
-          onItemToggle={interactions.handleToDoItemToggle}
-          expandedItems={interactions.expandedToDoItems}
         />
 
         <AgentMessageButton />

--- a/packages/web/src/routes/PlannerRoute/index.tsx
+++ b/packages/web/src/routes/PlannerRoute/index.tsx
@@ -20,6 +20,7 @@ import { useProjectContext } from '../../providers/ProjectProvider'
 import { updateToDoItems } from '../../api/toDoList'
 import { PlannerViewMode } from '../../enums/plannerViewMode'
 import { IMealPlan } from '../../types/mealPlan'
+import { MealType } from '../../enums/mealType'
 import dayjs from 'dayjs'
 
 const PlannerContent = () => {
@@ -131,12 +132,12 @@ const PlannerContent = () => {
     setMealDrawerOpen(true)
   }, [])
 
-  const handleMealPlanSave = useCallback(async (date: string, recipeName: string, recipeId?: string) => {
+  const handleMealPlanSave = useCallback(async (date: string, recipeName: string, recipeId?: string, mealType?: MealType) => {
     try {
       if (editingMealPlan) {
-        await updateMealPlan(editingMealPlan.id, { date, recipeName, recipeId: recipeId ?? null })
+        await updateMealPlan(editingMealPlan.id, { date, recipeName, recipeId: recipeId ?? null, mealType: mealType ?? null })
       } else {
-        await addMealPlan(date, recipeName, recipeId)
+        await addMealPlan(date, recipeName, recipeId, mealType)
       }
       setMealDrawerOpen(false)
     } catch (error) {

--- a/packages/web/src/types/mealPlan.ts
+++ b/packages/web/src/types/mealPlan.ts
@@ -1,9 +1,12 @@
+import { MealType } from '../enums/mealType'
+
 export interface IMealPlan {
     id: string
     projectId: string
     date: string          // YYYY-MM-DD
     recipeName: string    // display name (custom or from linked recipe)
     recipeId?: string     // optional link to existing IRecipe
+    mealType?: MealType
     createdAt: string
     updatedAt: string
 }


### PR DESCRIPTION
- Add MealType enum (Breakfast, Brunch, Lunch, Snack, Dinner, Other)
- Add mealType field to IMealPlan type and propagate through API, provider, and forms
- Replace static "Dinner Tonight" hero card with a carousel that auto-scrolls every 4s and supports touch swipe; slides are sorted by meal type order
- Add meal type selector to MealPlanDrawer and MealForm
- Move PlannerSection (meals/tasks/birthdays) above GrocerySection on the home page

https://claude.ai/code/session_01NR6U7GZ91D114NLA1pCZwd