### PR TITLE
Remove add meal button from calendar day detail panel

### DIFF
--- a/packages/web/src/components/Planner/CalendarView/index.styled.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.styled.tsx
@@ -291,21 +291,6 @@ export const MealDayDetailItem = styled('div')({
   },
 })
 
-export const AddMealButton = styled('div')({
-  fontSize: '0.85rem',
-  color: '#d97706',
-  padding: '8px 10px',
-  cursor: 'pointer',
-  borderRadius: '4px',
-  display: 'flex',
-  alignItems: 'center',
-  gap: '4px',
-  fontWeight: 500,
-  '&:hover': {
-    backgroundColor: '#fef3c7',
-  },
-})
-
 export const MealsSectionHeader = styled(Typography)({
   fontSize: '0.75rem',
   fontWeight: 600,

--- a/packages/web/src/components/Planner/CalendarView/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.tsx
@@ -3,7 +3,6 @@ import { IconButton } from '@mui/material'
 import CakeIcon from '@mui/icons-material/Cake'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
-import AddIcon from '@mui/icons-material/Add'
 import LinkIcon from '@mui/icons-material/Link'
 import dayjs, { Dayjs } from 'dayjs'
 import { ITodoItem } from '../../../api/toDoList/retrieve/types'
@@ -34,7 +33,6 @@ import {
   BirthdayDayDetailItem,
   MealPlanIcon,
   MealDayDetailItem,
-  AddMealButton,
   MealsSectionHeader,
 } from './index.styled'
 
@@ -286,10 +284,6 @@ const CalendarView = ({
               {plan.recipeId && <LinkIcon sx={{ fontSize: '0.75rem', color: '#d97706', marginLeft: 'auto', flexShrink: 0 }} />}
             </MealDayDetailItem>
           ))}
-          <AddMealButton onClick={() => onAddMealPlan?.(selectedDay)}>
-            <AddIcon sx={{ fontSize: '0.9rem' }} />
-            Add meal
-          </AddMealButton>
         </DayDetailPanel>
       )}
 


### PR DESCRIPTION
Meals should only be added via the plus icon, not from the day detail
panel that appears when clicking a day in the calendar view.

https://claude.ai/code/session_01QY8oKJtsFFQJGRniUKnvGN