### PR TITLE
Fix grocery item default image loading via CloudFront

### DIFF
--- a/packages/infra/modules/policies/variables.tf
+++ b/packages/infra/modules/policies/variables.tf
@@ -32,9 +32,10 @@ variable "lambda_functions" {
         todo_notifications = optional(string, "none")
       })
       s3 = optional(object({
-        recipe_uploads = optional(string, "none")
-        shop_uploads   = optional(string, "none")
-      }), { recipe_uploads = "none", shop_uploads = "none" })
+        recipe_uploads          = optional(string, "none")
+        shop_uploads            = optional(string, "none")
+        grocery_default_uploads = optional(string, "none")
+      }), { recipe_uploads = "none", shop_uploads = "none", grocery_default_uploads = "none" })
     })
   }))
 }

--- a/packages/lambdas/sources/get_grocery_default_upload_url/package.json
+++ b/packages/lambdas/sources/get_grocery_default_upload_url/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "get_grocery_default_upload_url",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/s3-request-presigner": "^3.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0",
+    "uuid": "^9.0.0"
+  }
+}

--- a/packages/web/src/components/UserMenu/GrocerySettingsSubpage.tsx
+++ b/packages/web/src/components/UserMenu/GrocerySettingsSubpage.tsx
@@ -97,11 +97,14 @@ const GrocerySettingsSubpage: React.FC<GrocerySettingsSubpageProps> = ({ onBack 
       setFormError('')
 
       const { uploadUrl, imagePath } = await getGroceryDefaultUploadUrl('jpg', currentProject?.id)
-      await fetch(uploadUrl, {
+      const uploadResponse = await fetch(uploadUrl, {
         method: 'PUT',
         body: croppedBlob,
         headers: { 'Content-Type': 'image/jpeg' },
       })
+      if (!uploadResponse.ok) {
+        throw new Error('Upload failed')
+      }
       setIconPath(imagePath)
     } catch {
       setFormError('Failed to upload image. Please try again.')
@@ -219,11 +222,14 @@ const GrocerySettingsSubpage: React.FC<GrocerySettingsSubpageProps> = ({ onBack 
       setEditFormError('')
 
       const { uploadUrl, imagePath } = await getGroceryDefaultUploadUrl('jpg', currentProject?.id)
-      await fetch(uploadUrl, {
+      const uploadResponse = await fetch(uploadUrl, {
         method: 'PUT',
         body: croppedBlob,
         headers: { 'Content-Type': 'image/jpeg' },
       })
+      if (!uploadResponse.ok) {
+        throw new Error('Upload failed')
+      }
       setEditIconPath(imagePath)
     } catch {
       setEditFormError('Failed to upload image. Please try again.')


### PR DESCRIPTION
The IAM policy for get_grocery_default_upload_url Lambda was missing
s3:PutObject permission because policies/variables.tf didn't include
grocery_default_uploads in the s3 object type. Terraform silently
stripped the attribute during type coercion, so the presigned URL PUT
would return 403 and the S3 object was never created — leaving a
CloudFront URL pointing at nothing.

- policies/variables.tf: add grocery_default_uploads to s3 object type
  so the IAM policy statement for S3PutGroceryDefaultUploads is applied
- GrocerySettingsSubpage.tsx: check PUT response.ok in both upload
  handlers so failures surface as user-visible errors rather than
  silently saving a broken image path
- get_grocery_default_upload_url/package.json: add missing package.json
  matching the get_recipe_upload_url pattern

https://claude.ai/code/session_017PJiiNRWprySsPkZUBzNEv