### PR TITLE
feat: open recipe detail drawer when clicking meal banner on home page

### DIFF
--- a/packages/web/src/components/RecipeDetailDrawer/index.tsx
+++ b/packages/web/src/components/RecipeDetailDrawer/index.tsx
@@ -1,0 +1,144 @@
+import { useCallback, useRef, useState } from 'react'
+import { Box, Drawer, IconButton } from '@mui/material'
+import RestaurantIcon from '@mui/icons-material/Restaurant'
+import CloseIcon from '@mui/icons-material/Close'
+import { IRecipe } from '../../types/recipe'
+import RecipeItem from '../RecipeItem'
+import {
+  DrawerHeader,
+  DrawerHeaderLeft,
+  DrawerIconBox,
+  DrawerTitle,
+  ContentContainer,
+} from '../RecipeDrawer/index.styled'
+
+const DRAG_CLOSE_THRESHOLD = 100
+
+interface RecipeDetailDrawerProps {
+  open: boolean
+  onClose: () => void
+  recipe: IRecipe | null
+}
+
+const RecipeDetailDrawer = ({ open, onClose, recipe }: RecipeDetailDrawerProps) => {
+  const [dragOffset, setDragOffset] = useState(0)
+  const isDragging = useRef(false)
+  const dragStartY = useRef(0)
+
+  const handleClose = useCallback(() => {
+    onClose()
+  }, [onClose])
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    isDragging.current = true
+    dragStartY.current = e.clientY
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [])
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging.current) return
+    const offset = Math.max(0, e.clientY - dragStartY.current)
+    setDragOffset(offset)
+  }, [])
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (isDragging.current) {
+      const finalOffset = Math.max(0, e.clientY - dragStartY.current)
+      if (finalOffset >= DRAG_CLOSE_THRESHOLD) {
+        handleClose()
+      }
+    }
+    isDragging.current = false
+    setDragOffset(0)
+  }, [handleClose])
+
+  return (
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={handleClose}
+      transitionDuration={{ enter: 350, exit: 300 }}
+      PaperProps={{
+        sx: {
+          height: 'calc(100% - env(safe-area-inset-top) - 16px)',
+          borderRadius: '16px 16px 0 0',
+          overflow: 'hidden',
+          background: 'transparent',
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          paddingBottom: 'env(safe-area-inset-bottom)',
+          bgcolor: 'background.paper',
+          transform: `translateY(${dragOffset}px)`,
+          transition: isDragging.current
+            ? 'transform 0s'
+            : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        }}
+      >
+        <Box
+          role="button"
+          aria-label="Drag to close"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          sx={{
+            width: '100%',
+            flexShrink: 0,
+            cursor: 'grab',
+            touchAction: 'none',
+            userSelect: 'none',
+            '& *': { touchAction: 'none', userSelect: 'none' },
+            '&:active': { cursor: 'grabbing' },
+          }}
+        >
+          <Box
+            sx={{
+              width: '100%',
+              display: 'flex',
+              justifyContent: 'center',
+              pt: '10px',
+              pb: '2px',
+            }}
+          >
+            <Box
+              sx={{
+                width: '36px',
+                height: '4px',
+                borderRadius: '2px',
+                background: 'rgba(0,0,0,0.15)',
+              }}
+            />
+          </Box>
+          <DrawerHeader>
+            <DrawerHeaderLeft>
+              <DrawerIconBox>
+                <RestaurantIcon />
+              </DrawerIconBox>
+              <DrawerTitle>{recipe?.name ?? 'Recipe'}</DrawerTitle>
+            </DrawerHeaderLeft>
+            <IconButton size="small" onClick={handleClose} aria-label="Close">
+              <CloseIcon />
+            </IconButton>
+          </DrawerHeader>
+        </Box>
+
+        <ContentContainer>
+          {recipe && (
+            <RecipeItem
+              recipe={recipe}
+              onEdit={() => {}}
+              onUseRecipe={() => {}}
+            />
+          )}
+        </ContentContainer>
+      </Box>
+    </Drawer>
+  )
+}
+
+export default RecipeDetailDrawer

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
@@ -22,6 +22,7 @@ const AUTO_SCROLL_MS = 4000
 
 interface ITodayMealCardProps {
   todayMeals: ITodayMealItem[]
+  onMealClick?: (meal: ITodayMealItem) => void
 }
 
 const sortedMeals = (meals: ITodayMealItem[]): ITodayMealItem[] =>
@@ -31,10 +32,11 @@ const sortedMeals = (meals: ITodayMealItem[]): ITodayMealItem[] =>
     return ai - bi
   })
 
-export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals }) => {
+export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals, onMealClick }) => {
   const meals = sortedMeals(todayMeals)
   const [activeIndex, setActiveIndex] = useState(0)
   const touchStartX = useRef(0)
+  const didSwipe = useRef(false)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const next = useCallback(() => {
@@ -72,7 +74,18 @@ export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals }) => 
       if (diff > 0) next()
       else prev()
       resetTimer()
+      didSwipe.current = true
+    } else {
+      didSwipe.current = false
     }
+  }
+
+  const handleMealClick = (meal: ITodayMealItem) => {
+    if (didSwipe.current) {
+      didSwipe.current = false
+      return
+    }
+    onMealClick?.(meal)
   }
 
   const handleDotClick = (index: number) => {
@@ -94,7 +107,10 @@ export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals }) => 
           const seed = meal.recipeName.charCodeAt(0)
           return (
             <CarouselSlide key={meal.id}>
-              <HeroWrapper>
+              <HeroWrapper
+                onClick={() => handleMealClick(meal)}
+                sx={meal.recipeId ? { cursor: 'pointer' } : undefined}
+              >
                 {meal.imagePath
                   ? <HeroImage src={meal.imagePath} alt={meal.recipeName} />
                   : (

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -20,11 +20,12 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
   toDoStats,
   birthdays,
   todayMeals,
+  onMealClick,
 }) => {
   return (
     <MiniCardsGrid>
       <MiniCard sx={{ gridColumn: '1 / 3', gridRow: 1, minHeight: 'unset' }}>
-        <TodayMealCard todayMeals={todayMeals} />
+        <TodayMealCard todayMeals={todayMeals} onMealClick={onMealClick} />
       </MiniCard>
 
       <MiniCard sx={{ gridColumn: 1, gridRow: 2 }}>

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
@@ -15,4 +15,5 @@ export interface IToDoSectionProps {
   onToggleExpansion: () => void
   onItemToggle: (id: string) => void
   expandedItems: Set<string>
+  onMealClick?: (meal: ITodayMealItem) => void
 }

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useGroceryListContext, GroceryListProvider } from '../../providers/GroceryListProvider'
 import { usePlannerContext, PlannerProvider } from '../../providers/PlannerProvider'
@@ -9,6 +9,7 @@ import { useRecipeContext, RecipeProvider } from '../../providers/RecipeProvider
 import { useAppState } from '../../providers/AppStateProvider'
 import { useProjectContext } from '../../providers/ProjectProvider'
 import { AgentChatProvider } from '../../providers/AgentChatProvider'
+import { IRecipe } from '../../types/recipe'
 import { updateToDoItems } from '../../api/toDoList'
 import { showAlert } from '../../utils/alert'
 import { Route } from '../../enums/route'
@@ -19,6 +20,7 @@ import AgentChatDrawer from '../../components/AgentChatDrawer'
 import AgentMessageButton from '../../components/AgentMessageButton'
 import GroceryItemPreviewPopup from '../../components/GroceryItemPreviewPopup'
 import ToDoItemPreviewDrawer from '../../components/ToDoItemPreviewDrawer'
+import RecipeDetailDrawer from '../../components/RecipeDetailDrawer'
 import GrocerySection from './components/GrocerySection'
 import NoiseSection from './components/NoiseSection'
 import PlannerSection from './components/PlannerSection'
@@ -47,6 +49,7 @@ const HomeDataContent = () => {
   const navigate = useNavigate()
 
   const interactions = useHomeInteractions()
+  const [selectedRecipe, setSelectedRecipe] = useState<IRecipe | null>(null)
 
   const homeData = useHomeData({
     groceryList,
@@ -73,6 +76,12 @@ const HomeDataContent = () => {
       showAlert({ description: 'Failed to mark task as done', severity: 'error' }, dispatch)
     }
   }, [currentProject, removeFromToDoList, interactions.handleToDoItemDeselect, dispatch])
+
+  const handleMealClick = useCallback((meal: { recipeId?: string }) => {
+    if (!meal.recipeId) return
+    const recipe = recipes.find(r => r.id === meal.recipeId)
+    if (recipe) setSelectedRecipe(recipe)
+  }, [recipes])
 
   const handleEditTask = useCallback((id: string) => {
     navigate(Route.EditPlannerItem.replace(':id', id))
@@ -103,6 +112,7 @@ const HomeDataContent = () => {
           onToggleExpansion={interactions.handleToggleToDoItems}
           onItemToggle={interactions.handleToDoItemToggle}
           expandedItems={interactions.expandedToDoItems}
+          onMealClick={handleMealClick}
         />
 
         <GrocerySection
@@ -135,6 +145,12 @@ const HomeDataContent = () => {
         onEdit={handleEditTask}
         onMarkDone={handleMarkDone}
         onStepToggle={handleStepToggle}
+      />
+
+      <RecipeDetailDrawer
+        open={selectedRecipe !== null}
+        onClose={() => setSelectedRecipe(null)}
+        recipe={selectedRecipe}
       />
     </>
   )


### PR DESCRIPTION
- Add onMealClick callback to TodayMealCard, distinguishing swipes from taps
- Create RecipeDetailDrawer component to show recipe info (ingredients & instructions)
- Wire up meal click handler in HomeRoute to look up recipe by ID and open drawer

https://claude.ai/code/session_01L2MQdJsDShHsSzU7nwaBiH