### PR TITLE
Fix meal type not being saved when changed after recipe selection

### DIFF
--- a/packages/web/src/routes/AddPlannerItemRoute/MealForm/index.tsx
+++ b/packages/web/src/routes/AddPlannerItemRoute/MealForm/index.tsx
@@ -184,7 +184,7 @@ const MealForm = () => {
     } finally {
       setIsLoading(false)
     }
-  }, [canSave, mode, selectedRecipe, customName, date, addMealPlan, navigate])
+  }, [canSave, mode, selectedRecipe, customName, date, mealType, addMealPlan, navigate])
 
   return (
     <FormContainer>


### PR DESCRIPTION
The handleSubmit useCallback was missing mealType in its dependency array,
causing it to capture a stale mealType value when the user selected a recipe
before changing the meal type. The submitted mealType would silently revert
to whatever it was when the callback was last recreated.

https://claude.ai/code/session_012QmMHafqnUWiyWJvuLz8DT