### PR TITLE
Fix calendar day cells to use consistent fixed height

### DIFF
--- a/packages/web/src/components/Planner/CalendarView/index.styled.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.styled.tsx
@@ -53,7 +53,7 @@ interface IDayCellProps {
 }
 
 export const DayCell = styled('div')<IDayCellProps>(({ isToday, isCurrentMonth, isSelected }) => ({
-  minHeight: '48px',
+  height: '80px',
   padding: '4px',
   borderRadius: '6px',
   backgroundColor: isSelected ? '#dbeafe' : isToday ? '#ecfdf5' : isCurrentMonth ? '#ffffff' : '#f9fafb',
@@ -63,6 +63,7 @@ export const DayCell = styled('div')<IDayCellProps>(({ isToday, isCurrentMonth, 
   alignItems: 'center',
   gap: '4px',
   boxSizing: 'border-box',
+  overflow: 'hidden',
   opacity: isCurrentMonth ? 1 : 0.4,
   cursor: 'pointer',
   userSelect: 'none',


### PR DESCRIPTION
Replace minHeight with a fixed height of 80px and add overflow: hidden
so all day cells remain the same size regardless of how many items
(todos, birthdays, meal plans) are present for a given day.

https://claude.ai/code/session_01RTVZQMu2M7mW6YpfyVNA8J