### PR TITLE
Disable autoFocus on task name field in AddPlannerItemRoute

### DIFF
--- a/packages/web/src/routes/AddPlannerItemRoute/index.tsx
+++ b/packages/web/src/routes/AddPlannerItemRoute/index.tsx
@@ -36,7 +36,6 @@ const TASK_FIELDS: Array<IFormField> = [
     label: 'Name',
     type: FormFieldType.TEXT,
     required: true,
-    autoFocus: true,
     value: '',
   },
   {


### PR DESCRIPTION
The Name input was grabbing focus on render, making it difficult to
switch between task types (Task / Birthday / Meal) in the segmented control.

https://claude.ai/code/session_01DshtqBKJKcnG5jprn1dpan