### PR TITLE
Extract useDragToClose hook to eliminate duplicated drag-to-close logic

### DIFF
--- a/packages/web/src/components/BirthdayPreviewDrawer/index.tsx
+++ b/packages/web/src/components/BirthdayPreviewDrawer/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback } from 'react'
 import { Box, Button, Drawer } from '@mui/material'
 import CakeIcon from '@mui/icons-material/Cake'
 import EditIcon from '@mui/icons-material/Edit'
@@ -6,6 +6,7 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
 import dayjs from 'dayjs'
 import { IBirthdayItem } from '../../api/birthdays/retrieve/types'
+import { useDragToClose } from '../../hooks/useDragToClose'
 import {
   ContentContainer,
   DrawerHeader,
@@ -19,8 +20,6 @@ import {
   PersonName,
 } from './index.styled'
 
-const DRAG_CLOSE_THRESHOLD = 100
-
 const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June',
   'July', 'August', 'September', 'October', 'November', 'December']
 
@@ -32,9 +31,7 @@ interface BirthdayPreviewDrawerProps {
 }
 
 const BirthdayPreviewDrawer = ({ item, onClose, onEdit, onDelete }: BirthdayPreviewDrawerProps) => {
-  const [dragOffset, setDragOffset] = useState(0)
-  const isDragging = useRef(false)
-  const dragStartY = useRef(0)
+  const { dragOffset, isDragging, onPointerDown, onPointerMove, onPointerUp } = useDragToClose({ onClose })
 
   const handleEdit = useCallback(() => {
     if (!item) return
@@ -47,29 +44,6 @@ const BirthdayPreviewDrawer = ({ item, onClose, onEdit, onDelete }: BirthdayPrev
     onDelete(item.id)
     onClose()
   }, [item, onDelete, onClose])
-
-  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    isDragging.current = true
-    dragStartY.current = e.clientY
-    e.currentTarget.setPointerCapture(e.pointerId)
-  }, [])
-
-  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isDragging.current) return
-    const offset = Math.max(0, e.clientY - dragStartY.current)
-    setDragOffset(offset)
-  }, [])
-
-  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (isDragging.current) {
-      const finalOffset = Math.max(0, e.clientY - dragStartY.current)
-      if (finalOffset >= DRAG_CLOSE_THRESHOLD) {
-        onClose()
-      }
-    }
-    isDragging.current = false
-    setDragOffset(0)
-  }, [onClose])
 
   const birthdayDate = item
     ? `${item.day} ${MONTH_NAMES[item.month - 1]}`

--- a/packages/web/src/components/GroceryList/Placeholder/index.tsx
+++ b/packages/web/src/components/GroceryList/Placeholder/index.tsx
@@ -1,22 +1,16 @@
 import GroceryItemPlaceholder from '../../GroceryItem/Placeholder';
-import CollapsibleSectionPlaceholder from '../../CollapsibleSectionPlaceholder';
-import { Container, PlaceholdersWrapper } from './index.styled';
+import GroupedListPlaceholder from '../../GroupedListPlaceholder';
+import { Container } from './index.styled';
 import { IPlaceholderProps } from './types';
 
-const Placeholder = ({ numberOfGroups = 5 }: IPlaceholderProps) => {
-  return (
-    <Container>
-      <PlaceholdersWrapper aria-label="Loading grocery items">
-        {Array.from({ length: numberOfGroups }).map((_, groupIndex) => (
-          <CollapsibleSectionPlaceholder key={groupIndex}>
-            {Array.from({ length: 2 + groupIndex }).map((_, itemIndex) => (
-              <GroceryItemPlaceholder key={itemIndex} />
-            ))}
-          </CollapsibleSectionPlaceholder>
-        ))}
-      </PlaceholdersWrapper>
-    </Container>
-  );
-};
+const Placeholder = ({ numberOfGroups = 5 }: IPlaceholderProps) => (
+  <Container>
+    <GroupedListPlaceholder
+      ItemPlaceholder={GroceryItemPlaceholder}
+      ariaLabel="Loading grocery items"
+      numberOfGroups={numberOfGroups}
+    />
+  </Container>
+);
 
 export default Placeholder;

--- a/packages/web/src/components/GroupedListPlaceholder/index.tsx
+++ b/packages/web/src/components/GroupedListPlaceholder/index.tsx
@@ -1,0 +1,36 @@
+import { ComponentType, ReactNode } from 'react'
+import { styled } from '@mui/material/styles'
+import CollapsibleSectionPlaceholder from '../CollapsibleSectionPlaceholder'
+
+const PlaceholdersWrapper = styled('div')({
+  display: 'flex',
+  flexDirection: 'column'
+})
+
+interface GroupedListPlaceholderProps {
+  ItemPlaceholder: ComponentType
+  ariaLabel: string
+  numberOfGroups: number
+  itemsPerGroup?: (groupIndex: number) => number
+  groupHeaderRightContent?: ReactNode
+}
+
+const GroupedListPlaceholder = ({
+  ItemPlaceholder,
+  ariaLabel,
+  numberOfGroups,
+  itemsPerGroup = (groupIndex) => 2 + groupIndex,
+  groupHeaderRightContent,
+}: GroupedListPlaceholderProps) => (
+  <PlaceholdersWrapper aria-label={ariaLabel}>
+    {Array.from({ length: numberOfGroups }).map((_, groupIndex) => (
+      <CollapsibleSectionPlaceholder key={groupIndex} headerRightContent={groupHeaderRightContent}>
+        {Array.from({ length: itemsPerGroup(groupIndex) }).map((_, itemIndex) => (
+          <ItemPlaceholder key={itemIndex} />
+        ))}
+      </CollapsibleSectionPlaceholder>
+    ))}
+  </PlaceholdersWrapper>
+)
+
+export default GroupedListPlaceholder

--- a/packages/web/src/components/NoiseTrackingList/Placeholder/index.tsx
+++ b/packages/web/src/components/NoiseTrackingList/Placeholder/index.tsx
@@ -1,7 +1,7 @@
 import NoiseTrackingItemPlaceholder from '../../NoiseTrackingItem/Placeholder';
-import CollapsibleSectionPlaceholder from '../../CollapsibleSectionPlaceholder';
+import GroupedListPlaceholder from '../../GroupedListPlaceholder';
 import { MiniTimelinePlaceholder, TimelineBarPlaceholder } from '../../CollapsibleSectionPlaceholder/index.styled';
-import { Container, PlaceholdersWrapper } from './index.styled';
+import { Container } from './index.styled';
 import { IPlaceholderProps } from './types';
 
 const MiniTimelinePlaceholderComponent = () => (
@@ -12,23 +12,15 @@ const MiniTimelinePlaceholderComponent = () => (
   </MiniTimelinePlaceholder>
 );
 
-const Placeholder = ({ numberOfGroups = 3 }: IPlaceholderProps) => {
-  return (
-    <Container>
-      <PlaceholdersWrapper aria-label="Loading noise tracking items">
-        {Array.from({ length: numberOfGroups }).map((_, groupIndex) => (
-          <CollapsibleSectionPlaceholder 
-            key={groupIndex}
-            headerRightContent={<MiniTimelinePlaceholderComponent />}
-          >
-            {Array.from({ length: 2 + groupIndex }).map((_, itemIndex) => (
-              <NoiseTrackingItemPlaceholder key={itemIndex} />
-            ))}
-          </CollapsibleSectionPlaceholder>
-        ))}
-      </PlaceholdersWrapper>
-    </Container>
-  );
-};
+const Placeholder = ({ numberOfGroups = 3 }: IPlaceholderProps) => (
+  <Container>
+    <GroupedListPlaceholder
+      ItemPlaceholder={NoiseTrackingItemPlaceholder}
+      ariaLabel="Loading noise tracking items"
+      numberOfGroups={numberOfGroups}
+      groupHeaderRightContent={<MiniTimelinePlaceholderComponent />}
+    />
+  </Container>
+);
 
 export default Placeholder;

--- a/packages/web/src/components/Planner/Placeholder/index.tsx
+++ b/packages/web/src/components/Planner/Placeholder/index.tsx
@@ -1,22 +1,17 @@
 import ToDoItemPlaceholder from '../../ToDoItem/Placeholder';
-import CollapsibleSectionPlaceholder from '../../CollapsibleSectionPlaceholder';
-import { Container, PlaceholdersWrapper } from './index.styled';
+import GroupedListPlaceholder from '../../GroupedListPlaceholder';
+import { Container } from './index.styled';
 import { IPlaceholderProps } from './types';
 
-const Placeholder = ({ numberOfGroups = 4 }: IPlaceholderProps) => {
-  return (
-    <Container>
-      <PlaceholdersWrapper aria-label="Loading to-do items">
-        {Array.from({ length: numberOfGroups }).map((_, groupIndex) => (
-          <CollapsibleSectionPlaceholder key={groupIndex}>
-            {Array.from({ length: 3 + groupIndex }).map((_, itemIndex) => (
-              <ToDoItemPlaceholder key={itemIndex} />
-            ))}
-          </CollapsibleSectionPlaceholder>
-        ))}
-      </PlaceholdersWrapper>
-    </Container>
-  );
-};
+const Placeholder = ({ numberOfGroups = 4 }: IPlaceholderProps) => (
+  <Container>
+    <GroupedListPlaceholder
+      ItemPlaceholder={ToDoItemPlaceholder}
+      ariaLabel="Loading to-do items"
+      numberOfGroups={numberOfGroups}
+      itemsPerGroup={(groupIndex) => 3 + groupIndex}
+    />
+  </Container>
+);
 
 export default Placeholder;

--- a/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
+++ b/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback } from 'react'
 import { Box, Button, Checkbox, Chip, Drawer, FormControlLabel, Typography } from '@mui/material'
 import AssignmentIcon from '@mui/icons-material/Assignment'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
@@ -7,6 +7,7 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
 import dayjs from 'dayjs'
 import { ITodoItem } from '../../api/toDoList/retrieve/types'
+import { useDragToClose } from '../../hooks/useDragToClose'
 import {
   ContentContainer,
   DescriptionText,
@@ -20,8 +21,6 @@ import {
   NoDescriptionText,
 } from './index.styled'
 
-const DRAG_CLOSE_THRESHOLD = 100
-
 interface ToDoItemPreviewDrawerProps {
   item: ITodoItem | null
   onClose: () => void
@@ -32,9 +31,7 @@ interface ToDoItemPreviewDrawerProps {
 }
 
 const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle, onDelete }: ToDoItemPreviewDrawerProps) => {
-  const [dragOffset, setDragOffset] = useState(0)
-  const isDragging = useRef(false)
-  const dragStartY = useRef(0)
+  const { dragOffset, isDragging, onPointerDown, onPointerMove, onPointerUp } = useDragToClose({ onClose })
 
   const handleEdit = useCallback(() => {
     if (!item) return
@@ -53,29 +50,6 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
     onDelete?.(item.id)
     onClose()
   }, [item, onDelete, onClose])
-
-  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    isDragging.current = true
-    dragStartY.current = e.clientY
-    e.currentTarget.setPointerCapture(e.pointerId)
-  }, [])
-
-  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isDragging.current) return
-    const offset = Math.max(0, e.clientY - dragStartY.current)
-    setDragOffset(offset)
-  }, [])
-
-  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (isDragging.current) {
-      const finalOffset = Math.max(0, e.clientY - dragStartY.current)
-      if (finalOffset >= DRAG_CLOSE_THRESHOLD) {
-        onClose()
-      }
-    }
-    isDragging.current = false
-    setDragOffset(0)
-  }, [onClose])
 
   const steps = item?.steps ?? []
 

--- a/packages/web/src/hooks/useDragToClose/index.ts
+++ b/packages/web/src/hooks/useDragToClose/index.ts
@@ -1,0 +1,47 @@
+import { useCallback, useRef, useState } from 'react'
+
+const DEFAULT_THRESHOLD = 100
+
+interface UseDragToCloseOptions {
+  onClose: () => void
+  threshold?: number
+}
+
+interface UseDragToCloseResult {
+  dragOffset: number
+  isDragging: React.MutableRefObject<boolean>
+  onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerUp: (e: React.PointerEvent<HTMLDivElement>) => void
+}
+
+export const useDragToClose = ({ onClose, threshold = DEFAULT_THRESHOLD }: UseDragToCloseOptions): UseDragToCloseResult => {
+  const [dragOffset, setDragOffset] = useState(0)
+  const isDragging = useRef(false)
+  const dragStartY = useRef(0)
+
+  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    isDragging.current = true
+    dragStartY.current = e.clientY
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }, [])
+
+  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging.current) return
+    const offset = Math.max(0, e.clientY - dragStartY.current)
+    setDragOffset(offset)
+  }, [])
+
+  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (isDragging.current) {
+      const finalOffset = Math.max(0, e.clientY - dragStartY.current)
+      if (finalOffset >= threshold) {
+        onClose()
+      }
+    }
+    isDragging.current = false
+    setDragOffset(0)
+  }, [onClose, threshold])
+
+  return { dragOffset, isDragging, onPointerDown, onPointerMove, onPointerUp }
+}


### PR DESCRIPTION
Both ToDoItemPreviewDrawer and BirthdayPreviewDrawer had identical
implementations of pointer-based drag-to-close behavior. Extracted into
a reusable useDragToClose hook that accepts onClose and an optional
threshold parameter.

https://claude.ai/code/session_01PxbzhboPuTae8b36jg3Edk