### PR TITLE
Fix store selector showing URLs instead of shop names

### DIFF
--- a/packages/web/src/components/RecipeItem/index.tsx
+++ b/packages/web/src/components/RecipeItem/index.tsx
@@ -294,7 +294,10 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
               >
                 {shops.map((shop) => (
                   <MenuItem key={shop.id} value={shop.id}>
-                    {shop.icon ? `${shop.icon} ` : ''}{shop.name}
+                    {shop.icon && (
+                      <Box component="img" src={shop.icon} alt="" sx={{ width: 20, height: 20, objectFit: 'contain', mr: 1 }} />
+                    )}
+                    {shop.name}
                   </MenuItem>
                 ))}
               </Select>


### PR DESCRIPTION
Use an img element to render shop.icon instead of concatenating
the URL string directly into the MenuItem text content.

https://claude.ai/code/session_01FDyF1NP1C66Tk5DQgmM4Ha