### PR TITLE
Add skeleton shimmer placeholder for meal card during loading

### DIFF
--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.styled.tsx
@@ -1,5 +1,14 @@
-import { styled } from '@mui/material/styles'
+import { styled, keyframes } from '@mui/material/styles'
 import { Box } from '@mui/material'
+
+const shimmer = keyframes`
+  0% {
+    background-position: -200px 0;
+  }
+  100% {
+    background-position: calc(200px + 100%) 0;
+  }
+`
 
 const GRADIENTS = [
   'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
@@ -154,4 +163,58 @@ export const EmptyState = styled('div')(({ theme }) => ({
   fontSize: '0.75rem',
   color: theme.palette.text.secondary,
   padding: '1.2rem',
+}))
+
+export const SkeletonContainer = styled(Box)(({ theme }) => ({
+  position: 'relative',
+  width: '100%',
+  height: '200px',
+  borderRadius: '16px',
+  overflow: 'hidden',
+  backgroundColor: theme.palette.custom?.surfaces?.secondary || '#f5f5f5',
+  '&::after': {
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    background: `linear-gradient(90deg, ${theme.palette.action.hover} 25%, ${theme.palette.action.selected} 50%, ${theme.palette.action.hover} 75%)`,
+    backgroundSize: '200px 100%',
+    animation: `${shimmer} 1.5s infinite`,
+  },
+}))
+
+export const SkeletonBadge = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  top: '10px',
+  left: '10px',
+  zIndex: 1,
+  width: '80px',
+  height: '20px',
+  borderRadius: '20px',
+  backgroundColor: theme.palette.action.selected,
+}))
+
+export const SkeletonOverlay = styled(Box)({
+  position: 'absolute',
+  bottom: 0,
+  left: 0,
+  right: 0,
+  padding: '1rem 1.1rem 0.9rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.35rem',
+})
+
+export const SkeletonLine = styled(Box)(({ theme }) => ({
+  height: '10px',
+  borderRadius: '4px',
+  backgroundColor: theme.palette.action.selected,
+}))
+
+export const SkeletonTitle = styled(Box)(({ theme }) => ({
+  height: '20px',
+  borderRadius: '4px',
+  backgroundColor: theme.palette.action.selected,
 }))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayMealCard/index.tsx
@@ -18,12 +18,18 @@ import {
   HeroLabel,
   HeroTitle,
   EmptyState,
+  SkeletonContainer,
+  SkeletonBadge,
+  SkeletonOverlay,
+  SkeletonLine,
+  SkeletonTitle,
 } from './index.styled'
 
 const AUTO_SCROLL_MS = 4000
 
 interface ITodayMealCardProps {
   todayMeals: ITodayMealItem[]
+  isLoading?: boolean
   onMealClick?: (meal: ITodayMealItem) => void
 }
 
@@ -51,7 +57,7 @@ const getDayLabel = (dateStr: string): string => {
   return new Date(`${dateStr}T00:00:00`).toLocaleDateString('en-US', { weekday: 'long' })
 }
 
-export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals, onMealClick }) => {
+export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals, isLoading, onMealClick }) => {
   const meals = sortedMeals(todayMeals)
   const [activeIndex, setActiveIndex] = useState(0)
   const touchStartX = useRef(0)
@@ -110,6 +116,18 @@ export const TodayMealCard: React.FC<ITodayMealCardProps> = ({ todayMeals, onMea
   const handleDotClick = (index: number) => {
     setActiveIndex(index)
     resetTimer()
+  }
+
+  if (isLoading) {
+    return (
+      <SkeletonContainer>
+        <SkeletonBadge />
+        <SkeletonOverlay>
+          <SkeletonLine sx={{ width: '45%' }} />
+          <SkeletonTitle sx={{ width: '70%' }} />
+        </SkeletonOverlay>
+      </SkeletonContainer>
+    )
   }
 
   if (meals.length === 0) {

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -20,12 +20,13 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
   toDoStats,
   birthdays,
   todayMeals,
+  isLoading,
   onMealClick,
 }) => {
   return (
     <MiniCardsGrid>
       <MiniCard sx={{ gridColumn: '1 / 3', gridRow: 1, minHeight: 'unset' }}>
-        <TodayMealCard todayMeals={todayMeals} onMealClick={onMealClick} />
+        <TodayMealCard todayMeals={todayMeals} isLoading={isLoading} onMealClick={onMealClick} />
       </MiniCard>
 
       <MiniCard sx={{ gridColumn: 1, gridRow: 2 }}>

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -50,7 +50,7 @@ const HomeDataContent = () => {
   const { toDoList, isLoading: isToDoLoading, removeFromToDoList, updateToDoItemFields } = usePlannerContext()
   const { noiseTrackingItems, isLoading: isNoiseLoading } = useNoiseTrackingContext()
   const { birthdays } = useBirthdayContext()
-  const { mealPlans } = useMealPlanContext()
+  const { mealPlans, isLoading: isMealLoading } = useMealPlanContext()
   const { recipes } = useRecipeContext()
   const { state: { purchasedItems }, dispatch } = useAppState()
   const { currentProject } = useProjectContext()
@@ -116,7 +116,7 @@ const HomeDataContent = () => {
           toDoStats={homeData.toDoStats}
           birthdays={birthdays}
           todayMeals={todayMeals}
-          isLoading={isToDoLoading}
+          isLoading={isToDoLoading || isMealLoading}
           isExpanded={interactions.isToDoItemsExpanded}
           onToggleExpansion={interactions.handleToggleToDoItems}
           onItemToggle={interactions.handleToDoItemToggle}


### PR DESCRIPTION
Replace the "No meal planned" empty state shown during loading with
a shimmer skeleton that matches the carousel card dimensions. The
skeleton displays while either the meal plan or todo data is fetching.

https://claude.ai/code/session_011tTCL8JXrZj2JYK7gkB379