### PR TITLE
Replace calendar day detail panel with fixed bottom drawer

### DIFF
--- a/packages/web/src/components/Planner/CalendarView/index.styled.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.styled.tsx
@@ -96,6 +96,37 @@ export const TodoDot = styled('div')<{ count?: number; isOverdue?: boolean }>(({
   visibility: count > 0 ? 'visible' : 'hidden',
 }))
 
+export const DrawerOverlay = styled('div')({
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.3)',
+  zIndex: 1000,
+})
+
+export const BottomDrawer = styled('div')({
+  position: 'fixed',
+  bottom: 0,
+  left: 0,
+  right: 0,
+  backgroundColor: '#eff6ff',
+  borderRadius: '16px 16px 0 0',
+  border: '1px solid #bfdbfe',
+  borderBottom: 'none',
+  boxShadow: '0 -4px 24px rgba(0, 0, 0, 0.12)',
+  zIndex: 1001,
+  maxHeight: '50vh',
+  overflowY: 'auto',
+  padding: '0.75em',
+})
+
+export const DrawerHandle = styled('div')({
+  width: '40px',
+  height: '4px',
+  backgroundColor: '#bfdbfe',
+  borderRadius: '2px',
+  margin: '0 auto 0.75em',
+})
+
 export const DayDetailPanel = styled('div')({
   marginTop: '0.75em',
   padding: '0.75em',

--- a/packages/web/src/components/Planner/CalendarView/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.tsx
@@ -21,7 +21,9 @@ import {
   DayNumber,
   TodoDot,
   CompletedTodoDot,
-  DayDetailPanel,
+  DrawerOverlay,
+  BottomDrawer,
+  DrawerHandle,
   DayDetailHeader,
   DayDetailItem,
   OverdueDayDetailItem,
@@ -247,51 +249,58 @@ const CalendarView = ({
       </CalendarGrid>
 
       {selectedDay && (
-        <DayDetailPanel>
-          <DayDetailHeader>
-            {dayjs(selectedDay).format('dddd, D MMMM')}
-          </DayDetailHeader>
-          {selectedDayPendingTodos.length === 0 && selectedDayCompletedTodos.length === 0 ? (
-            <DayDetailEmpty>No tasks on this day</DayDetailEmpty>
-          ) : (
-            <>
-              {selectedDayPendingTodos.map(todo => (
-                isSelectedDayOverdue ? (
-                  <OverdueDayDetailItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+        <>
+          <DrawerOverlay onClick={() => {
+            setSelectedDay(null)
+            dispatch({ type: ActionName.SET_SELECTED_CALENDAR_DATE, payload: null })
+          }} />
+          <BottomDrawer>
+            <DrawerHandle />
+            <DayDetailHeader>
+              {dayjs(selectedDay).format('dddd, D MMMM')}
+            </DayDetailHeader>
+            {selectedDayPendingTodos.length === 0 && selectedDayCompletedTodos.length === 0 ? (
+              <DayDetailEmpty>No tasks on this day</DayDetailEmpty>
+            ) : (
+              <>
+                {selectedDayPendingTodos.map(todo => (
+                  isSelectedDayOverdue ? (
+                    <OverdueDayDetailItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                      {todo.name}
+                    </OverdueDayDetailItem>
+                  ) : (
+                    <DayDetailItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                      {todo.name}
+                    </DayDetailItem>
+                  )
+                ))}
+                {selectedDayCompletedTodos.map(todo => (
+                  <CompletedDayDetailItem key={todo.id} onClick={() => onItemClick(todo.id)}>
                     {todo.name}
-                  </OverdueDayDetailItem>
-                ) : (
-                  <DayDetailItem key={todo.id} onClick={() => onItemClick(todo.id)}>
-                    {todo.name}
-                  </DayDetailItem>
-                )
-              ))}
-              {selectedDayCompletedTodos.map(todo => (
-                <CompletedDayDetailItem key={todo.id} onClick={() => onItemClick(todo.id)}>
-                  {todo.name}
-                </CompletedDayDetailItem>
-              ))}
-            </>
-          )}
-          {selectedDayBirthdays.length > 0 && (
-            <>
-              {selectedDayBirthdays.map(birthday => (
-                <BirthdayDayDetailItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
-                  <CakeIcon sx={{ fontSize: '0.9rem', color: '#db2777', flexShrink: 0 }} />
-                  {birthday.name}
-                </BirthdayDayDetailItem>
-              ))}
-            </>
-          )}
-          <MealsSectionHeader>Meals</MealsSectionHeader>
-          {selectedDayMealPlans.map(plan => (
-            <MealDayDetailItem key={plan.id} onClick={() => onMealPlanClick?.(plan)}>
-              <MealPlanIcon sx={{ fontSize: '0.9rem', flexShrink: 0 }} />
-              {plan.recipeName}
-              {plan.recipeId && <LinkIcon sx={{ fontSize: '0.75rem', color: '#d97706', marginLeft: 'auto', flexShrink: 0 }} />}
-            </MealDayDetailItem>
-          ))}
-        </DayDetailPanel>
+                  </CompletedDayDetailItem>
+                ))}
+              </>
+            )}
+            {selectedDayBirthdays.length > 0 && (
+              <>
+                {selectedDayBirthdays.map(birthday => (
+                  <BirthdayDayDetailItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
+                    <CakeIcon sx={{ fontSize: '0.9rem', color: '#db2777', flexShrink: 0 }} />
+                    {birthday.name}
+                  </BirthdayDayDetailItem>
+                ))}
+              </>
+            )}
+            <MealsSectionHeader>Meals</MealsSectionHeader>
+            {selectedDayMealPlans.map(plan => (
+              <MealDayDetailItem key={plan.id} onClick={() => onMealPlanClick?.(plan)}>
+                <MealPlanIcon sx={{ fontSize: '0.9rem', flexShrink: 0 }} />
+                {plan.recipeName}
+                {plan.recipeId && <LinkIcon sx={{ fontSize: '0.75rem', color: '#d97706', marginLeft: 'auto', flexShrink: 0 }} />}
+              </MealDayDetailItem>
+            ))}
+          </BottomDrawer>
+        </>
       )}
 
       {itemsWithoutDueDate.length > 0 && (


### PR DESCRIPTION
When a calendar cell is clicked, the day detail now slides up as a
fixed bottom drawer (max-height 50vh, scrollable) overlaying the page,
so it's always visible regardless of screen height. Tapping the
semi-transparent backdrop dismisses the drawer.

https://claude.ai/code/session_01Bz6UrbFBqma1P6fBkBiec5