### PR TITLE
Fix bottom drawer appearing from calendar container instead of screen bottom

### DIFF
--- a/packages/web/src/components/Planner/CalendarView/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { createPortal } from 'react-dom'
 import { useAppState } from '../../../providers/AppStateProvider'
 import { ActionName } from '../../../providers/AppStateProvider/enums'
 import { IconButton } from '@mui/material'
@@ -248,7 +249,7 @@ const CalendarView = ({
         })}
       </CalendarGrid>
 
-      {selectedDay && (
+      {selectedDay && createPortal(
         <>
           <DrawerOverlay onClick={() => {
             setSelectedDay(null)
@@ -300,7 +301,8 @@ const CalendarView = ({
               </MealDayDetailItem>
             ))}
           </BottomDrawer>
-        </>
+        </>,
+        document.body
       )}
 
       {itemsWithoutDueDate.length > 0 && (


### PR DESCRIPTION
The BottomDrawer uses position: fixed; bottom: 0, but the App Content wrapper
has willChange: transform and transform: translateZ(0), which creates a new CSS
containing block. This caused fixed positioning to resolve relative to that
container instead of the viewport.

Fix by wrapping the DrawerOverlay + BottomDrawer in ReactDOM.createPortal
rendered into document.body, bypassing the containing block entirely.

https://claude.ai/code/session_019fygw5nL5Uie4YSpCYYddd