### PR TITLE
Refactor calendar day preview to use MUI Drawer (DayPreviewDrawer)

### DIFF
--- a/packages/web/src/components/DayPreviewDrawer/index.tsx
+++ b/packages/web/src/components/DayPreviewDrawer/index.tsx
@@ -1,0 +1,114 @@
+import { Drawer, Box } from '@mui/material'
+import CakeIcon from '@mui/icons-material/Cake'
+import LinkIcon from '@mui/icons-material/Link'
+import dayjs from 'dayjs'
+import { ITodoItem } from '../../api/toDoList/retrieve/types'
+import { IBirthdayItem } from '../../api/birthdays/retrieve/types'
+import { IMealPlan } from '../../types/mealPlan'
+import {
+  DayDetailHeaderWrapper,
+  DayDetailDayOfWeek,
+  DayDetailDateLabel,
+  DayDetailItem,
+  OverdueDayDetailItem,
+  CompletedDayDetailItem,
+  DayDetailEmpty,
+  BirthdayDayDetailItem,
+  MealDayDetailItem,
+  MealPlanIcon,
+  MealsSectionHeader,
+  MealsAddButton,
+} from '../Planner/CalendarView/index.styled'
+
+interface IDayPreviewDrawerProps {
+  open: boolean
+  selectedDay: string | null
+  pendingTodos: ITodoItem[]
+  completedTodos: ITodoItem[]
+  isOverdue: boolean
+  birthdays: IBirthdayItem[]
+  mealPlans: IMealPlan[]
+  onClose: () => void
+  onTodoClick: (id: string) => void
+  onBirthdayClick?: (id: string) => void
+  onAddMealPlan?: (date: string) => void
+  onMealPlanClick?: (mealPlan: IMealPlan) => void
+}
+
+const DayPreviewDrawer = ({
+  open,
+  selectedDay,
+  pendingTodos,
+  completedTodos,
+  isOverdue,
+  birthdays,
+  mealPlans,
+  onClose,
+  onTodoClick,
+  onBirthdayClick,
+  onAddMealPlan,
+  onMealPlanClick,
+}: IDayPreviewDrawerProps) => {
+  return (
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { borderRadius: '16px 16px 0 0', maxHeight: '60vh', overflow: 'hidden' } }}
+    >
+      <Box sx={{ overflowY: 'auto', padding: '0 12px', paddingBottom: 'max(1rem, env(safe-area-inset-bottom))' }}>
+        <Box sx={{ width: '48px', height: '5px', backgroundColor: '#94a3b8', borderRadius: '3px', margin: '10px auto 14px', flexShrink: 0 }} />
+        <DayDetailHeaderWrapper>
+          <DayDetailDayOfWeek>{selectedDay ? dayjs(selectedDay).format('dddd') : ''}</DayDetailDayOfWeek>
+          <DayDetailDateLabel>{selectedDay ? dayjs(selectedDay).format('D MMMM') : ''}</DayDetailDateLabel>
+        </DayDetailHeaderWrapper>
+
+        {pendingTodos.length === 0 && completedTodos.length === 0 ? (
+          <DayDetailEmpty>No tasks on this day</DayDetailEmpty>
+        ) : (
+          <>
+            {pendingTodos.map(todo =>
+              isOverdue ? (
+                <OverdueDayDetailItem key={todo.id} onClick={() => onTodoClick(todo.id)}>
+                  {todo.name}
+                </OverdueDayDetailItem>
+              ) : (
+                <DayDetailItem key={todo.id} onClick={() => onTodoClick(todo.id)}>
+                  {todo.name}
+                </DayDetailItem>
+              )
+            )}
+            {completedTodos.map(todo => (
+              <CompletedDayDetailItem key={todo.id} onClick={() => onTodoClick(todo.id)}>
+                {todo.name}
+              </CompletedDayDetailItem>
+            ))}
+          </>
+        )}
+
+        {birthdays.length > 0 && birthdays.map(birthday => (
+          <BirthdayDayDetailItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
+            <CakeIcon sx={{ fontSize: '0.9rem', color: '#db2777', flexShrink: 0 }} />
+            {birthday.name}
+          </BirthdayDayDetailItem>
+        ))}
+
+        <MealsSectionHeader>
+          <span>Meals</span>
+          {onAddMealPlan && selectedDay && (
+            <MealsAddButton onClick={(e) => { e.stopPropagation(); onAddMealPlan(selectedDay) }}>+</MealsAddButton>
+          )}
+        </MealsSectionHeader>
+        {mealPlans.map(plan => (
+          <MealDayDetailItem key={plan.id} onClick={() => onMealPlanClick?.(plan)}>
+            <MealPlanIcon sx={{ fontSize: '0.9rem', flexShrink: 0 }} />
+            {plan.recipeName}
+            {plan.recipeId && <LinkIcon sx={{ fontSize: '0.75rem', color: '#d97706', marginLeft: 'auto', flexShrink: 0 }} />}
+          </MealDayDetailItem>
+        ))}
+      </Box>
+    </Drawer>
+  )
+}
+
+export default DayPreviewDrawer

--- a/packages/web/src/components/Planner/CalendarView/index.styled.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.styled.tsx
@@ -96,39 +96,6 @@ export const TodoDot = styled('div')<{ count?: number; isOverdue?: boolean }>(({
   visibility: count > 0 ? 'visible' : 'hidden',
 }))
 
-export const DrawerOverlay = styled('div')({
-  position: 'fixed',
-  inset: 0,
-  backgroundColor: 'rgba(0, 0, 0, 0.3)',
-  zIndex: 1000,
-})
-
-export const BottomDrawer = styled('div')({
-  position: 'fixed',
-  bottom: 0,
-  left: 0,
-  right: 0,
-  background: 'linear-gradient(180deg, #ffffff 0%, #f8fafc 100%)',
-  borderRadius: '20px 20px 0 0',
-  border: '1px solid rgba(226, 232, 240, 0.8)',
-  borderBottom: 'none',
-  boxShadow: '0 -8px 40px rgba(0, 0, 0, 0.18), 0 -2px 8px rgba(0, 0, 0, 0.06)',
-  zIndex: 1001,
-  maxHeight: '60vh',
-  overflowY: 'auto',
-  padding: '0 12px',
-  paddingBottom: 'max(1rem, env(safe-area-inset-bottom))',
-})
-
-export const DrawerHandle = styled('div')({
-  width: '48px',
-  height: '5px',
-  backgroundColor: '#94a3b8',
-  borderRadius: '3px',
-  margin: '10px auto 14px',
-  flexShrink: 0,
-})
-
 export const DayDetailPanel = styled('div')({
   marginTop: '0.75em',
   padding: '0.75em',

--- a/packages/web/src/components/Planner/CalendarView/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.tsx
@@ -1,16 +1,14 @@
 import { useState, useMemo } from 'react'
-import { createPortal } from 'react-dom'
 import { useAppState } from '../../../providers/AppStateProvider'
 import { ActionName } from '../../../providers/AppStateProvider/enums'
 import { IconButton } from '@mui/material'
-import CakeIcon from '@mui/icons-material/Cake'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
-import LinkIcon from '@mui/icons-material/Link'
 import dayjs, { Dayjs } from 'dayjs'
 import { ITodoItem } from '../../../api/toDoList/retrieve/types'
 import { IBirthdayItem } from '../../../api/birthdays/retrieve/types'
 import { IMealPlan } from '../../../types/mealPlan'
+import DayPreviewDrawer from '../../DayPreviewDrawer'
 import {
   Container,
   CalendarHeader,
@@ -22,26 +20,12 @@ import {
   DayNumber,
   TodoDot,
   CompletedTodoDot,
-  DrawerOverlay,
-  BottomDrawer,
-  DrawerHandle,
-  DayDetailHeaderWrapper,
-  DayDetailDayOfWeek,
-  DayDetailDateLabel,
-  DayDetailItem,
-  OverdueDayDetailItem,
-  CompletedDayDetailItem,
-  DayDetailEmpty,
   NoDueDateSection,
   NoDueDateHeader,
   NoDueDateItem,
   CompletedNoDueDateItem,
   BirthdayCakeIcon,
-  BirthdayDayDetailItem,
   MealPlanIcon,
-  MealDayDetailItem,
-  MealsSectionHeader,
-  MealsAddButton,
 } from './index.styled'
 
 const WEEK_DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -252,67 +236,23 @@ const CalendarView = ({
         })}
       </CalendarGrid>
 
-      {selectedDay && createPortal(
-        <>
-          <DrawerOverlay onClick={() => {
-            setSelectedDay(null)
-            dispatch({ type: ActionName.SET_SELECTED_CALENDAR_DATE, payload: null })
-          }} />
-          <BottomDrawer>
-            <DrawerHandle />
-            <DayDetailHeaderWrapper>
-              <DayDetailDayOfWeek>{dayjs(selectedDay).format('dddd')}</DayDetailDayOfWeek>
-              <DayDetailDateLabel>{dayjs(selectedDay).format('D MMMM')}</DayDetailDateLabel>
-            </DayDetailHeaderWrapper>
-            {selectedDayPendingTodos.length === 0 && selectedDayCompletedTodos.length === 0 ? (
-              <DayDetailEmpty>No tasks on this day</DayDetailEmpty>
-            ) : (
-              <>
-                {selectedDayPendingTodos.map(todo => (
-                  isSelectedDayOverdue ? (
-                    <OverdueDayDetailItem key={todo.id} onClick={() => onItemClick(todo.id)}>
-                      {todo.name}
-                    </OverdueDayDetailItem>
-                  ) : (
-                    <DayDetailItem key={todo.id} onClick={() => onItemClick(todo.id)}>
-                      {todo.name}
-                    </DayDetailItem>
-                  )
-                ))}
-                {selectedDayCompletedTodos.map(todo => (
-                  <CompletedDayDetailItem key={todo.id} onClick={() => onItemClick(todo.id)}>
-                    {todo.name}
-                  </CompletedDayDetailItem>
-                ))}
-              </>
-            )}
-            {selectedDayBirthdays.length > 0 && (
-              <>
-                {selectedDayBirthdays.map(birthday => (
-                  <BirthdayDayDetailItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
-                    <CakeIcon sx={{ fontSize: '0.9rem', color: '#db2777', flexShrink: 0 }} />
-                    {birthday.name}
-                  </BirthdayDayDetailItem>
-                ))}
-              </>
-            )}
-            <MealsSectionHeader>
-              <span>Meals</span>
-              {onAddMealPlan && selectedDay && (
-                <MealsAddButton onClick={(e) => { e.stopPropagation(); onAddMealPlan(selectedDay) }}>+</MealsAddButton>
-              )}
-            </MealsSectionHeader>
-            {selectedDayMealPlans.map(plan => (
-              <MealDayDetailItem key={plan.id} onClick={() => onMealPlanClick?.(plan)}>
-                <MealPlanIcon sx={{ fontSize: '0.9rem', flexShrink: 0 }} />
-                {plan.recipeName}
-                {plan.recipeId && <LinkIcon sx={{ fontSize: '0.75rem', color: '#d97706', marginLeft: 'auto', flexShrink: 0 }} />}
-              </MealDayDetailItem>
-            ))}
-          </BottomDrawer>
-        </>,
-        document.body
-      )}
+      <DayPreviewDrawer
+        open={selectedDay !== null}
+        selectedDay={selectedDay}
+        pendingTodos={selectedDayPendingTodos}
+        completedTodos={selectedDayCompletedTodos}
+        isOverdue={isSelectedDayOverdue}
+        birthdays={selectedDayBirthdays}
+        mealPlans={selectedDayMealPlans}
+        onClose={() => {
+          setSelectedDay(null)
+          dispatch({ type: ActionName.SET_SELECTED_CALENDAR_DATE, payload: null })
+        }}
+        onTodoClick={onItemClick}
+        onBirthdayClick={onBirthdayClick}
+        onAddMealPlan={onAddMealPlan}
+        onMealPlanClick={onMealPlanClick}
+      />
 
       {itemsWithoutDueDate.length > 0 && (
         <NoDueDateSection>


### PR DESCRIPTION
Extract a new DayPreviewDrawer component that uses MUI's Drawer (matching
the MealPlanDrawer style) to replace the custom portal-based BottomDrawer
in CalendarView. Removes DrawerOverlay, BottomDrawer, DrawerHandle styled
components that are no longer needed.

https://claude.ai/code/session_01C4GTomFnEqp8MecHgpsowy