### PR TITLE
fix: add swipe-to-close to all drawers via shared DraggableBottomDrawer component

### DIFF
--- a/packages/web/src/components/AgentChatDrawer/index.tsx
+++ b/packages/web/src/components/AgentChatDrawer/index.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef, useState, useCallback } from 'react'
-import { Box, Drawer } from '@mui/material'
+import { useEffect, useRef } from 'react'
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined'
 import { useAgentChatContext } from '../../providers/AgentChatProvider'
 import ChatMessageBubble from './components/ChatMessageBubble'
 import ChatEmptyState from './components/ChatEmptyState'
 import ChatInput from './components/ChatInput'
 import TypingIndicator from './components/TypingIndicator'
+import DraggableBottomDrawer from '../DraggableBottomDrawer'
 import {
   DrawerHeader,
   DrawerHeaderLeft,
@@ -17,15 +17,10 @@ import {
   MessageList,
 } from './index.styled'
 
-const DRAG_CLOSE_THRESHOLD = 100
-
 const AgentChatDrawer = () => {
   const { isOpen, closeChat, messages, sendMessage, isTyping } = useAgentChatContext()
   const hasStreamingBubble = messages.some((m) => m.role === 'agent' && m.isStreaming)
   const messageListRef = useRef<HTMLDivElement>(null)
-  const [dragOffset, setDragOffset] = useState(0)
-  const isDragging = useRef(false)
-  const dragStartY = useRef(0)
 
   useEffect(() => {
     if (messageListRef.current) {
@@ -33,91 +28,13 @@ const AgentChatDrawer = () => {
     }
   }, [messages])
 
-  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    isDragging.current = true
-    dragStartY.current = e.clientY
-    e.currentTarget.setPointerCapture(e.pointerId)
-  }, [])
-
-  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isDragging.current) return
-    const offset = Math.max(0, e.clientY - dragStartY.current)
-    setDragOffset(offset)
-  }, [])
-
-  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (isDragging.current) {
-      const finalOffset = Math.max(0, e.clientY - dragStartY.current)
-      if (finalOffset >= DRAG_CLOSE_THRESHOLD) {
-        closeChat()
-      }
-    }
-    isDragging.current = false
-    setDragOffset(0)
-  }, [closeChat])
-
   return (
-    <Drawer
-      anchor="bottom"
+    <DraggableBottomDrawer
       open={isOpen}
       onClose={closeChat}
-      transitionDuration={{ enter: 350, exit: 300 }}
-      PaperProps={{
-        sx: {
-          height: 'calc(100% - env(safe-area-inset-top) - 16px)',
-          borderRadius: '16px 16px 0 0',
-          overflow: 'hidden',
-          background: 'transparent',
-        },
-      }}
-    >
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          paddingBottom: 'env(safe-area-inset-bottom)',
-          bgcolor: 'background.paper',
-          transform: `translateY(${dragOffset}px)`,
-          transition: isDragging.current
-            ? 'transform 0s'
-            : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-        }}
-      >
-      <Box
-        role="button"
-        aria-label="Drag to close"
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        sx={{
-          width: '100%',
-          flexShrink: 0,
-          cursor: 'grab',
-          touchAction: 'none',
-          userSelect: 'none',
-          '& *': { touchAction: 'none', userSelect: 'none' },
-          '&:active': { cursor: 'grabbing' },
-        }}
-      >
-        <Box
-          sx={{
-            width: '100%',
-            display: 'flex',
-            justifyContent: 'center',
-            pt: '10px',
-            pb: '2px',
-          }}
-        >
-          <Box
-            sx={{
-              width: '36px',
-              height: '4px',
-              borderRadius: '2px',
-              background: 'rgba(0,0,0,0.15)',
-            }}
-          />
-        </Box>
+      paperSx={{ height: 'calc(100% - env(safe-area-inset-top) - 16px)' }}
+      contentSx={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      dragHandleContent={
         <DrawerHeader>
           <DrawerHeaderLeft>
             <DrawerIconBox>
@@ -132,8 +49,8 @@ const AgentChatDrawer = () => {
             </div>
           </DrawerHeaderLeft>
         </DrawerHeader>
-      </Box>
-
+      }
+    >
       <MessageList ref={messageListRef} data-testid="message-list">
         {messages.length === 0 ? (
           <ChatEmptyState />
@@ -144,8 +61,7 @@ const AgentChatDrawer = () => {
       </MessageList>
 
       <ChatInput onSend={sendMessage} />
-      </Box>
-    </Drawer>
+    </DraggableBottomDrawer>
   )
 }
 

--- a/packages/web/src/components/BirthdayPreviewDrawer/index.tsx
+++ b/packages/web/src/components/BirthdayPreviewDrawer/index.tsx
@@ -1,12 +1,12 @@
 import { useCallback } from 'react'
-import { Box, Button, Drawer } from '@mui/material'
+import { Button } from '@mui/material'
 import CakeIcon from '@mui/icons-material/Cake'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
 import dayjs from 'dayjs'
 import { IBirthdayItem } from '../../api/birthdays/retrieve/types'
-import { useDragToClose } from '../../hooks/useDragToClose'
+import DraggableBottomDrawer from '../DraggableBottomDrawer'
 import {
   ContentContainer,
   DrawerHeader,
@@ -31,8 +31,6 @@ interface BirthdayPreviewDrawerProps {
 }
 
 const BirthdayPreviewDrawer = ({ item, onClose, onEdit, onDelete }: BirthdayPreviewDrawerProps) => {
-  const { dragOffset, isDragging, onPointerDown, onPointerMove, onPointerUp } = useDragToClose({ onClose })
-
   const handleEdit = useCallback(() => {
     if (!item) return
     onEdit(item)
@@ -63,133 +61,76 @@ const BirthdayPreviewDrawer = ({ item, onClose, onEdit, onDelete }: BirthdayPrev
   })()
 
   return (
-    <Drawer
-      anchor="bottom"
+    <DraggableBottomDrawer
       open={item !== null}
       onClose={onClose}
-      transitionDuration={{ enter: 350, exit: 300 }}
-      PaperProps={{
-        sx: {
-          borderRadius: '16px 16px 0 0',
-          overflow: 'hidden',
-          background: 'transparent',
-          maxHeight: '80vh',
-        },
-      }}
+      paperSx={{ maxHeight: '80vh' }}
+      dragHandleContent={
+        <DrawerHeader>
+          <DrawerHeaderLeft>
+            <DrawerIconBox>
+              <CakeIcon />
+            </DrawerIconBox>
+            <DrawerTitle>Birthday</DrawerTitle>
+          </DrawerHeaderLeft>
+        </DrawerHeader>
+      }
     >
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          bgcolor: 'background.paper',
-          transform: `translateY(${dragOffset}px)`,
-          transition: isDragging.current
-            ? 'transform 0s'
-            : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-        }}
-      >
-        {/* Drag handle */}
-        <Box
-          role="button"
-          aria-label="Drag to close"
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
+      <ContentContainer>
+        <PersonName>{item?.name}</PersonName>
+
+        <MetaRow>
+          <CalendarTodayIcon sx={{ fontSize: '1rem' }} />
+          {birthdayDate}
+          {ageInfo !== null && (
+            <span style={{ color: '#db2777', fontWeight: 600 }}>
+              · {ageInfo.label}
+            </span>
+          )}
+        </MetaRow>
+
+        {item?.notes ? (
+          <NotesText>{item.notes}</NotesText>
+        ) : (
+          <NoNotesText>No notes</NoNotesText>
+        )}
+      </ContentContainer>
+
+      <Footer>
+        <Button
+          variant="contained"
+          fullWidth
+          startIcon={<EditIcon />}
+          onClick={handleEdit}
           sx={{
-            width: '100%',
-            flexShrink: 0,
-            cursor: 'grab',
-            touchAction: 'none',
-            userSelect: 'none',
-            '& *': { touchAction: 'none', userSelect: 'none' },
-            '&:active': { cursor: 'grabbing' },
+            background: 'linear-gradient(135deg, #ec4899 0%, #db2777 100%)',
+            borderRadius: '10px',
+            textTransform: 'none',
+            fontWeight: 600,
+            py: 1.25,
+            boxShadow: 'none',
+            '&:hover': { boxShadow: 'none', opacity: 0.9 },
           }}
         >
-          <Box
-            sx={{
-              width: '100%',
-              display: 'flex',
-              justifyContent: 'center',
-              pt: '10px',
-              pb: '2px',
-            }}
-          >
-            <Box
-              sx={{
-                width: '36px',
-                height: '4px',
-                borderRadius: '2px',
-                background: 'rgba(0,0,0,0.15)',
-              }}
-            />
-          </Box>
-          <DrawerHeader>
-            <DrawerHeaderLeft>
-              <DrawerIconBox>
-                <CakeIcon />
-              </DrawerIconBox>
-              <DrawerTitle>Birthday</DrawerTitle>
-            </DrawerHeaderLeft>
-          </DrawerHeader>
-        </Box>
-
-        <ContentContainer>
-          <PersonName>{item?.name}</PersonName>
-
-          <MetaRow>
-            <CalendarTodayIcon sx={{ fontSize: '1rem' }} />
-            {birthdayDate}
-            {ageInfo !== null && (
-              <span style={{ color: '#db2777', fontWeight: 600 }}>
-                · {ageInfo.label}
-              </span>
-            )}
-          </MetaRow>
-
-          {item?.notes ? (
-            <NotesText>{item.notes}</NotesText>
-          ) : (
-            <NoNotesText>No notes</NoNotesText>
-          )}
-        </ContentContainer>
-
-        <Footer>
-          <Button
-            variant="contained"
-            fullWidth
-            startIcon={<EditIcon />}
-            onClick={handleEdit}
-            sx={{
-              background: 'linear-gradient(135deg, #ec4899 0%, #db2777 100%)',
-              borderRadius: '10px',
-              textTransform: 'none',
-              fontWeight: 600,
-              py: 1.25,
-              boxShadow: 'none',
-              '&:hover': { boxShadow: 'none', opacity: 0.9 },
-            }}
-          >
-            Edit
-          </Button>
-          <Button
-            variant="outlined"
-            fullWidth
-            startIcon={<DeleteIcon />}
-            onClick={handleDelete}
-            color="error"
-            sx={{
-              borderRadius: '10px',
-              textTransform: 'none',
-              fontWeight: 600,
-              py: 1.25,
-            }}
-          >
-            Delete
-          </Button>
-        </Footer>
-      </Box>
-    </Drawer>
+          Edit
+        </Button>
+        <Button
+          variant="outlined"
+          fullWidth
+          startIcon={<DeleteIcon />}
+          onClick={handleDelete}
+          color="error"
+          sx={{
+            borderRadius: '10px',
+            textTransform: 'none',
+            fontWeight: 600,
+            py: 1.25,
+          }}
+        >
+          Delete
+        </Button>
+      </Footer>
+    </DraggableBottomDrawer>
   )
 }
 

--- a/packages/web/src/components/DayPreviewDrawer/index.tsx
+++ b/packages/web/src/components/DayPreviewDrawer/index.tsx
@@ -1,4 +1,3 @@
-import { Drawer, Box } from '@mui/material'
 import CakeIcon from '@mui/icons-material/Cake'
 import LinkIcon from '@mui/icons-material/Link'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
@@ -18,6 +17,7 @@ import {
   MealsAddButton,
 } from '../Planner/CalendarView/index.styled'
 import { DrawerContent, DrawerHeader, DateLabel, SectionLabel } from './index.styled'
+import DraggableBottomDrawer from '../DraggableBottomDrawer'
 
 interface IDayPreviewDrawerProps {
   open: boolean
@@ -49,20 +49,21 @@ const DayPreviewDrawer = ({
   onMealPlanClick,
 }: IDayPreviewDrawerProps) => {
   return (
-    <Drawer
-      anchor="bottom"
+    <DraggableBottomDrawer
       open={open}
       onClose={onClose}
-      PaperProps={{ sx: { borderRadius: '16px 16px 0 0', maxHeight: '85vh', overflow: 'hidden' } }}
+      paperSx={{ maxHeight: '85vh' }}
+      dragHandleContent={
+        <>
+          <DrawerHeader>
+            <CalendarTodayIcon sx={{ fontSize: '1.1rem' }} />
+            {selectedDay ? dayjs(selectedDay).format('dddd') : ''}
+          </DrawerHeader>
+          <DateLabel>{selectedDay ? dayjs(selectedDay).format('D MMMM YYYY') : ''}</DateLabel>
+        </>
+      }
     >
-      <Box sx={{ width: '40px', height: '4px', backgroundColor: '#cbd5e1', borderRadius: '2px', margin: '10px auto 0', flexShrink: 0 }} />
       <DrawerContent>
-        <DrawerHeader>
-          <CalendarTodayIcon sx={{ fontSize: '1.1rem' }} />
-          {selectedDay ? dayjs(selectedDay).format('dddd') : ''}
-        </DrawerHeader>
-        <DateLabel>{selectedDay ? dayjs(selectedDay).format('D MMMM YYYY') : ''}</DateLabel>
-
         <SectionLabel color={isOverdue ? '#dc2626' : '#1d4ed8'}>Tasks</SectionLabel>
         {pendingTodos.length === 0 && completedTodos.length === 0 ? (
           <DayDetailEmpty>No tasks on this day</DayDetailEmpty>
@@ -117,7 +118,7 @@ const DayPreviewDrawer = ({
           ))
         )}
       </DrawerContent>
-    </Drawer>
+    </DraggableBottomDrawer>
   )
 }
 

--- a/packages/web/src/components/DraggableBottomDrawer/index.tsx
+++ b/packages/web/src/components/DraggableBottomDrawer/index.tsx
@@ -1,0 +1,93 @@
+import { Box, Drawer, SxProps, Theme } from '@mui/material'
+import { useDragToClose } from '../../hooks/useDragToClose'
+
+interface DraggableBottomDrawerProps {
+  open: boolean
+  onClose: () => void
+  children: React.ReactNode
+  dragHandleContent?: React.ReactNode
+  paperSx?: SxProps<Theme>
+  contentSx?: SxProps<Theme>
+}
+
+const DraggableBottomDrawer = ({
+  open,
+  onClose,
+  children,
+  dragHandleContent,
+  paperSx,
+  contentSx,
+}: DraggableBottomDrawerProps) => {
+  const { dragOffset, isDragging, onPointerDown, onPointerMove, onPointerUp } = useDragToClose({ onClose })
+
+  return (
+    <Drawer
+      anchor="bottom"
+      open={open}
+      onClose={onClose}
+      transitionDuration={{ enter: 350, exit: 300 }}
+      PaperProps={{
+        sx: {
+          borderRadius: '16px 16px 0 0',
+          overflow: 'hidden',
+          background: 'transparent',
+          ...paperSx as object,
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          bgcolor: 'background.paper',
+          transform: `translateY(${dragOffset}px)`,
+          transition: isDragging.current
+            ? 'transform 0s'
+            : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          ...contentSx as object,
+        }}
+      >
+        <Box
+          role="button"
+          aria-label="Drag to close"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          sx={{
+            width: '100%',
+            flexShrink: 0,
+            cursor: 'grab',
+            touchAction: 'none',
+            userSelect: 'none',
+            '& *': { touchAction: 'none', userSelect: 'none' },
+            '&:active': { cursor: 'grabbing' },
+          }}
+        >
+          <Box
+            sx={{
+              width: '100%',
+              display: 'flex',
+              justifyContent: 'center',
+              pt: '10px',
+              pb: '2px',
+            }}
+          >
+            <Box
+              sx={{
+                width: '36px',
+                height: '4px',
+                borderRadius: '2px',
+                background: 'rgba(0,0,0,0.15)',
+              }}
+            />
+          </Box>
+          {dragHandleContent}
+        </Box>
+        {children}
+      </Box>
+    </Drawer>
+  )
+}
+
+export default DraggableBottomDrawer

--- a/packages/web/src/components/MealPlanDrawer/index.tsx
+++ b/packages/web/src/components/MealPlanDrawer/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
-import { Drawer, ToggleButton, InputAdornment, IconButton, Box, MenuItem } from '@mui/material'
+import { ToggleButton, InputAdornment, IconButton, Box, MenuItem } from '@mui/material'
 import RestaurantIcon from '@mui/icons-material/Restaurant'
 import SearchIcon from '@mui/icons-material/Search'
 import VisibilityIcon from '@mui/icons-material/Visibility'
@@ -9,6 +9,7 @@ import { IRecipe } from '../../types/recipe'
 import { MealType, MEAL_TYPE_ORDER } from '../../enums/mealType'
 import { useRecipeContext } from '../../providers/RecipeProvider'
 import RecipeDetailDrawer from '../RecipeDetailDrawer'
+import DraggableBottomDrawer from '../DraggableBottomDrawer'
 
 import {
   DrawerContent,
@@ -98,128 +99,129 @@ const MealPlanDrawer = ({ open, date, mealPlan, onClose, onSave, onDelete }: IMe
 
   return (
     <>
-    <Drawer
-      anchor="bottom"
-      open={open}
-      onClose={onClose}
-      PaperProps={{ sx: { borderRadius: '16px 16px 0 0', maxHeight: '85vh' } }}
-    >
-      <DrawerContent>
-        <DrawerHeader>
-          <RestaurantIcon sx={{ fontSize: '1.1rem', verticalAlign: 'middle', marginRight: '6px' }} />
-          {mealPlan ? 'Edit Meal' : 'Add Meal'}
-        </DrawerHeader>
-
-        <DateLabel>{displayDate}</DateLabel>
-
-        <StyledTextField
-          select
-          size="small"
-          label="Meal type"
-          value={mealType}
-          onChange={(e) => setMealType(e.target.value as MealType)}
-          fullWidth
-        >
-          {MEAL_TYPE_ORDER.map(type => (
-            <MenuItem key={type} value={type}>{type}</MenuItem>
-          ))}
-        </StyledTextField>
-
-        <ModeToggle
-          value={mode}
-          exclusive
-          onChange={(_, value) => { if (value) setMode(value) }}
-        >
-          <ToggleButton value="recipe">From Recipe</ToggleButton>
-          <ToggleButton value="custom">Custom Name</ToggleButton>
-        </ModeToggle>
-
-        {mode === 'recipe' ? (
-          <>
-            <SearchField
-              size="small"
-              placeholder="Search recipes..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon fontSize="small" />
-                  </InputAdornment>
-                ),
-              }}
-              fullWidth
-            />
-            <RecipeList>
-              {filteredRecipes.length === 0 ? (
-                <RecipeItem sx={{ color: '#9ca3af', fontStyle: 'italic' }}>
-                  {search ? 'No recipes found' : 'No recipes yet'}
-                </RecipeItem>
-              ) : (
-                filteredRecipes.map(recipe => (
-                  <RecipeItemRow
-                    key={recipe.id}
-                    selected={selectedRecipeId === recipe.id}
-                    onClick={() => setSelectedRecipeId(recipe.id)}
-                  >
-                    {recipe.imagePath ? (
-                      <RecipeThumbnail src={recipe.imagePath} alt={recipe.name} />
-                    ) : (
-                      <RecipeThumbnailPlaceholder seed={recipe.name.charCodeAt(0)}>
-                        {recipe.name.charAt(0).toUpperCase()}
-                      </RecipeThumbnailPlaceholder>
-                    )}
-                    <RecipeItemName>{recipe.name}</RecipeItemName>
-                    <IconButton
-                      size="small"
-                      onClick={(e) => { e.stopPropagation(); setPreviewRecipe(recipe) }}
-                      sx={{ color: '#9ca3af', flexShrink: 0, '&:hover': { color: '#1d4ed8' } }}
-                    >
-                      <VisibilityIcon sx={{ fontSize: '1rem' }} />
-                    </IconButton>
-                  </RecipeItemRow>
-                ))
-              )}
-            </RecipeList>
-          </>
-        ) : (
+      <DraggableBottomDrawer
+        open={open}
+        onClose={onClose}
+        paperSx={{ maxHeight: '85vh' }}
+        dragHandleContent={
+          <Box sx={{ px: '1.25em' }}>
+            <DrawerHeader>
+              <RestaurantIcon sx={{ fontSize: '1.1rem', verticalAlign: 'middle', marginRight: '6px' }} />
+              {mealPlan ? 'Edit Meal' : 'Add Meal'}
+            </DrawerHeader>
+            <DateLabel>{displayDate}</DateLabel>
+          </Box>
+        }
+      >
+        <DrawerContent>
           <StyledTextField
+            select
             size="small"
-            label="Meal name"
-            value={customName}
-            onChange={(e) => setCustomName(e.target.value)}
+            label="Meal type"
+            value={mealType}
+            onChange={(e) => setMealType(e.target.value as MealType)}
             fullWidth
-            autoFocus
-            onKeyDown={(e) => { if (e.key === 'Enter' && canSave) handleSave() }}
-          />
-        )}
-
-        <SaveButton
-          variant="contained"
-          fullWidth
-          disabled={!canSave}
-          onClick={handleSave}
-        >
-          Save
-        </SaveButton>
-
-        {mealPlan && onDelete && (
-          <DeleteButton
-            variant="outlined"
-            fullWidth
-            onClick={() => onDelete(mealPlan.id)}
           >
-            Delete
-          </DeleteButton>
-        )}
-      </DrawerContent>
-    </Drawer>
+            {MEAL_TYPE_ORDER.map(type => (
+              <MenuItem key={type} value={type}>{type}</MenuItem>
+            ))}
+          </StyledTextField>
 
-    <RecipeDetailDrawer
-      open={previewRecipe !== null}
-      onClose={() => setPreviewRecipe(null)}
-      recipe={previewRecipe}
-    />
+          <ModeToggle
+            value={mode}
+            exclusive
+            onChange={(_, value) => { if (value) setMode(value) }}
+          >
+            <ToggleButton value="recipe">From Recipe</ToggleButton>
+            <ToggleButton value="custom">Custom Name</ToggleButton>
+          </ModeToggle>
+
+          {mode === 'recipe' ? (
+            <>
+              <SearchField
+                size="small"
+                placeholder="Search recipes..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                InputProps={{
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon fontSize="small" />
+                    </InputAdornment>
+                  ),
+                }}
+                fullWidth
+              />
+              <RecipeList>
+                {filteredRecipes.length === 0 ? (
+                  <RecipeItem sx={{ color: '#9ca3af', fontStyle: 'italic' }}>
+                    {search ? 'No recipes found' : 'No recipes yet'}
+                  </RecipeItem>
+                ) : (
+                  filteredRecipes.map(recipe => (
+                    <RecipeItemRow
+                      key={recipe.id}
+                      selected={selectedRecipeId === recipe.id}
+                      onClick={() => setSelectedRecipeId(recipe.id)}
+                    >
+                      {recipe.imagePath ? (
+                        <RecipeThumbnail src={recipe.imagePath} alt={recipe.name} />
+                      ) : (
+                        <RecipeThumbnailPlaceholder seed={recipe.name.charCodeAt(0)}>
+                          {recipe.name.charAt(0).toUpperCase()}
+                        </RecipeThumbnailPlaceholder>
+                      )}
+                      <RecipeItemName>{recipe.name}</RecipeItemName>
+                      <IconButton
+                        size="small"
+                        onClick={(e) => { e.stopPropagation(); setPreviewRecipe(recipe) }}
+                        sx={{ color: '#9ca3af', flexShrink: 0, '&:hover': { color: '#1d4ed8' } }}
+                      >
+                        <VisibilityIcon sx={{ fontSize: '1rem' }} />
+                      </IconButton>
+                    </RecipeItemRow>
+                  ))
+                )}
+              </RecipeList>
+            </>
+          ) : (
+            <StyledTextField
+              size="small"
+              label="Meal name"
+              value={customName}
+              onChange={(e) => setCustomName(e.target.value)}
+              fullWidth
+              autoFocus
+              onKeyDown={(e) => { if (e.key === 'Enter' && canSave) handleSave() }}
+            />
+          )}
+
+          <SaveButton
+            variant="contained"
+            fullWidth
+            disabled={!canSave}
+            onClick={handleSave}
+          >
+            Save
+          </SaveButton>
+
+          {mealPlan && onDelete && (
+            <DeleteButton
+              variant="outlined"
+              fullWidth
+              onClick={() => onDelete(mealPlan.id)}
+            >
+              Delete
+            </DeleteButton>
+          )}
+        </DrawerContent>
+      </DraggableBottomDrawer>
+
+      <RecipeDetailDrawer
+        open={previewRecipe !== null}
+        onClose={() => setPreviewRecipe(null)}
+        recipe={previewRecipe}
+      />
     </>
   )
 }

--- a/packages/web/src/components/RecipeDetailDrawer/index.tsx
+++ b/packages/web/src/components/RecipeDetailDrawer/index.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useRef, useState } from 'react'
-import { Box, Drawer, IconButton } from '@mui/material'
+import { useCallback } from 'react'
+import { IconButton } from '@mui/material'
 import RestaurantIcon from '@mui/icons-material/Restaurant'
 import CloseIcon from '@mui/icons-material/Close'
 import { IRecipe } from '../../types/recipe'
 import RecipeItem from '../RecipeItem'
+import DraggableBottomDrawer from '../DraggableBottomDrawer'
 import {
   DrawerHeader,
   DrawerHeaderLeft,
@@ -12,8 +13,6 @@ import {
   ContentContainer,
 } from '../RecipeDrawer/index.styled'
 
-const DRAG_CLOSE_THRESHOLD = 100
-
 interface RecipeDetailDrawerProps {
   open: boolean
   onClose: () => void
@@ -21,123 +20,40 @@ interface RecipeDetailDrawerProps {
 }
 
 const RecipeDetailDrawer = ({ open, onClose, recipe }: RecipeDetailDrawerProps) => {
-  const [dragOffset, setDragOffset] = useState(0)
-  const isDragging = useRef(false)
-  const dragStartY = useRef(0)
-
   const handleClose = useCallback(() => {
     onClose()
   }, [onClose])
 
-  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    isDragging.current = true
-    dragStartY.current = e.clientY
-    e.currentTarget.setPointerCapture(e.pointerId)
-  }, [])
-
-  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isDragging.current) return
-    const offset = Math.max(0, e.clientY - dragStartY.current)
-    setDragOffset(offset)
-  }, [])
-
-  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (isDragging.current) {
-      const finalOffset = Math.max(0, e.clientY - dragStartY.current)
-      if (finalOffset >= DRAG_CLOSE_THRESHOLD) {
-        handleClose()
-      }
-    }
-    isDragging.current = false
-    setDragOffset(0)
-  }, [handleClose])
-
   return (
-    <Drawer
-      anchor="bottom"
+    <DraggableBottomDrawer
       open={open}
       onClose={handleClose}
-      transitionDuration={{ enter: 350, exit: 300 }}
-      PaperProps={{
-        sx: {
-          height: 'calc(100% - env(safe-area-inset-top) - 16px)',
-          borderRadius: '16px 16px 0 0',
-          overflow: 'hidden',
-          background: 'transparent',
-        },
-      }}
+      paperSx={{ height: 'calc(100% - env(safe-area-inset-top) - 16px)' }}
+      contentSx={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      dragHandleContent={
+        <DrawerHeader>
+          <DrawerHeaderLeft>
+            <DrawerIconBox>
+              <RestaurantIcon />
+            </DrawerIconBox>
+            <DrawerTitle>{recipe?.name ?? 'Recipe'}</DrawerTitle>
+          </DrawerHeaderLeft>
+          <IconButton size="small" onClick={handleClose} aria-label="Close">
+            <CloseIcon />
+          </IconButton>
+        </DrawerHeader>
+      }
     >
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          paddingBottom: 'env(safe-area-inset-bottom)',
-          bgcolor: 'background.paper',
-          transform: `translateY(${dragOffset}px)`,
-          transition: isDragging.current
-            ? 'transform 0s'
-            : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-        }}
-      >
-        <Box
-          role="button"
-          aria-label="Drag to close"
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-          sx={{
-            width: '100%',
-            flexShrink: 0,
-            cursor: 'grab',
-            touchAction: 'none',
-            userSelect: 'none',
-            '& *': { touchAction: 'none', userSelect: 'none' },
-            '&:active': { cursor: 'grabbing' },
-          }}
-        >
-          <Box
-            sx={{
-              width: '100%',
-              display: 'flex',
-              justifyContent: 'center',
-              pt: '10px',
-              pb: '2px',
-            }}
-          >
-            <Box
-              sx={{
-                width: '36px',
-                height: '4px',
-                borderRadius: '2px',
-                background: 'rgba(0,0,0,0.15)',
-              }}
-            />
-          </Box>
-          <DrawerHeader>
-            <DrawerHeaderLeft>
-              <DrawerIconBox>
-                <RestaurantIcon />
-              </DrawerIconBox>
-              <DrawerTitle>{recipe?.name ?? 'Recipe'}</DrawerTitle>
-            </DrawerHeaderLeft>
-            <IconButton size="small" onClick={handleClose} aria-label="Close">
-              <CloseIcon />
-            </IconButton>
-          </DrawerHeader>
-        </Box>
-
-        <ContentContainer>
-          {recipe && (
-            <RecipeItem
-              recipe={recipe}
-              onEdit={() => {}}
-              onUseRecipe={() => {}}
-            />
-          )}
-        </ContentContainer>
-      </Box>
-    </Drawer>
+      <ContentContainer>
+        {recipe && (
+          <RecipeItem
+            recipe={recipe}
+            onEdit={() => {}}
+            onUseRecipe={() => {}}
+          />
+        )}
+      </ContentContainer>
+    </DraggableBottomDrawer>
   )
 }
 

--- a/packages/web/src/components/RecipeDrawer/index.tsx
+++ b/packages/web/src/components/RecipeDrawer/index.tsx
@@ -1,11 +1,12 @@
-import { useState, useCallback, useRef } from 'react'
-import { Box, Drawer, IconButton } from '@mui/material'
+import { useState, useCallback } from 'react'
+import { IconButton } from '@mui/material'
 import MenuBookIcon from '@mui/icons-material/MenuBook'
 import AddIcon from '@mui/icons-material/Add'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
-import { IRecipe, IRecipeIngredient } from '../../types/recipe'
+import { IRecipe } from '../../types/recipe'
 import RecipeList from '../RecipeList'
 import RecipeForm from '../RecipeForm'
+import DraggableBottomDrawer from '../DraggableBottomDrawer'
 import {
   DrawerHeader,
   DrawerHeaderLeft,
@@ -13,8 +14,6 @@ import {
   DrawerTitle,
   ContentContainer,
 } from './index.styled'
-
-const DRAG_CLOSE_THRESHOLD = 100
 
 interface RecipeDrawerProps {
   open: boolean
@@ -26,9 +25,6 @@ interface RecipeDrawerProps {
 const RecipeDrawer = ({ open, onClose, onUseRecipe, shopId }: RecipeDrawerProps) => {
   const [view, setView] = useState<'list' | 'form'>('list')
   const [editingRecipe, setEditingRecipe] = useState<IRecipe | null>(null)
-  const [dragOffset, setDragOffset] = useState(0)
-  const isDragging = useRef(false)
-  const dragStartY = useRef(0)
 
   const handleAddClick = useCallback(() => {
     setEditingRecipe(null)
@@ -56,127 +52,48 @@ const RecipeDrawer = ({ open, onClose, onUseRecipe, shopId }: RecipeDrawerProps)
     onUseRecipe?.()
   }, [handleClose, onUseRecipe])
 
-  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    isDragging.current = true
-    dragStartY.current = e.clientY
-    e.currentTarget.setPointerCapture(e.pointerId)
-  }, [])
-
-  const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isDragging.current) return
-    const offset = Math.max(0, e.clientY - dragStartY.current)
-    setDragOffset(offset)
-  }, [])
-
-  const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (isDragging.current) {
-      const finalOffset = Math.max(0, e.clientY - dragStartY.current)
-      if (finalOffset >= DRAG_CLOSE_THRESHOLD) {
-        handleClose()
-      }
-    }
-    isDragging.current = false
-    setDragOffset(0)
-  }, [handleClose])
-
   return (
-    <Drawer
-      anchor="bottom"
+    <DraggableBottomDrawer
       open={open}
       onClose={handleClose}
-      transitionDuration={{ enter: 350, exit: 300 }}
-      PaperProps={{
-        sx: {
-          height: 'calc(100% - env(safe-area-inset-top) - 16px)',
-          borderRadius: '16px 16px 0 0',
-          overflow: 'hidden',
-          background: 'transparent',
-        },
-      }}
-    >
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          paddingBottom: 'env(safe-area-inset-bottom)',
-          bgcolor: 'background.paper',
-          transform: `translateY(${dragOffset}px)`,
-          transition: isDragging.current
-            ? 'transform 0s'
-            : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-        }}
-      >
-        <Box
-          role="button"
-          aria-label="Drag to close"
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-          sx={{
-            width: '100%',
-            flexShrink: 0,
-            cursor: 'grab',
-            touchAction: 'none',
-            userSelect: 'none',
-            '& *': { touchAction: 'none', userSelect: 'none' },
-            '&:active': { cursor: 'grabbing' },
-          }}
-        >
-          <Box
-            sx={{
-              width: '100%',
-              display: 'flex',
-              justifyContent: 'center',
-              pt: '10px',
-              pb: '2px',
-            }}
-          >
-            <Box
-              sx={{
-                width: '36px',
-                height: '4px',
-                borderRadius: '2px',
-                background: 'rgba(0,0,0,0.15)',
-              }}
-            />
-          </Box>
-          <DrawerHeader>
-            <DrawerHeaderLeft>
-              {view === 'form' && (
-                <IconButton size="small" onClick={handleFormDone} aria-label="Back to recipes">
-                  <ArrowBackIcon />
-                </IconButton>
-              )}
-              <DrawerIconBox>
-                <MenuBookIcon />
-              </DrawerIconBox>
-              <DrawerTitle>{view === 'form' ? (editingRecipe ? 'Edit Recipe' : 'New Recipe') : 'Recipes'}</DrawerTitle>
-            </DrawerHeaderLeft>
-            {view === 'list' && (
-              <IconButton onClick={handleAddClick} aria-label="Add recipe" size="small">
-                <AddIcon />
+      paperSx={{ height: 'calc(100% - env(safe-area-inset-top) - 16px)' }}
+      contentSx={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      dragHandleContent={
+        <DrawerHeader>
+          <DrawerHeaderLeft>
+            {view === 'form' && (
+              <IconButton size="small" onClick={handleFormDone} aria-label="Back to recipes">
+                <ArrowBackIcon />
               </IconButton>
             )}
-          </DrawerHeader>
-        </Box>
-
-        <ContentContainer>
-          {view === 'list' ? (
-            <RecipeList
-              onEditRecipe={handleEditRecipe}
-              onUseRecipe={handleUseRecipe}
-              shopId={shopId}
-            />
-          ) : (
-            <RecipeForm
-              initialRecipe={editingRecipe}
-              onDone={handleFormDone}
-            />
+            <DrawerIconBox>
+              <MenuBookIcon />
+            </DrawerIconBox>
+            <DrawerTitle>{view === 'form' ? (editingRecipe ? 'Edit Recipe' : 'New Recipe') : 'Recipes'}</DrawerTitle>
+          </DrawerHeaderLeft>
+          {view === 'list' && (
+            <IconButton onClick={handleAddClick} aria-label="Add recipe" size="small">
+              <AddIcon />
+            </IconButton>
           )}
-        </ContentContainer>
-      </Box>
-    </Drawer>
+        </DrawerHeader>
+      }
+    >
+      <ContentContainer>
+        {view === 'list' ? (
+          <RecipeList
+            onEditRecipe={handleEditRecipe}
+            onUseRecipe={handleUseRecipe}
+            shopId={shopId}
+          />
+        ) : (
+          <RecipeForm
+            initialRecipe={editingRecipe}
+            onDone={handleFormDone}
+          />
+        )}
+      </ContentContainer>
+    </DraggableBottomDrawer>
   )
 }
 

--- a/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
+++ b/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { Box, Button, Checkbox, Chip, Drawer, FormControlLabel, Typography } from '@mui/material'
+import { Box, Button, Checkbox, Chip, FormControlLabel, Typography } from '@mui/material'
 import AssignmentIcon from '@mui/icons-material/Assignment'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
@@ -7,7 +7,7 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
 import dayjs from 'dayjs'
 import { ITodoItem } from '../../api/toDoList/retrieve/types'
-import { useDragToClose } from '../../hooks/useDragToClose'
+import DraggableBottomDrawer from '../DraggableBottomDrawer'
 import {
   ContentContainer,
   DescriptionText,
@@ -31,8 +31,6 @@ interface ToDoItemPreviewDrawerProps {
 }
 
 const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle, onDelete }: ToDoItemPreviewDrawerProps) => {
-  const { dragOffset, isDragging, onPointerDown, onPointerMove, onPointerUp } = useDragToClose({ onClose })
-
   const handleEdit = useCallback(() => {
     if (!item) return
     onEdit(item.id)
@@ -54,203 +52,146 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
   const steps = item?.steps ?? []
 
   return (
-    <Drawer
-      anchor="bottom"
+    <DraggableBottomDrawer
       open={item !== null}
       onClose={onClose}
-      transitionDuration={{ enter: 350, exit: 300 }}
-      PaperProps={{
-        sx: {
-          borderRadius: '16px 16px 0 0',
-          overflow: 'hidden',
-          background: 'transparent',
-          maxHeight: '80vh',
-        },
-      }}
+      paperSx={{ maxHeight: '80vh' }}
+      dragHandleContent={
+        <DrawerHeader>
+          <DrawerHeaderLeft>
+            <DrawerIconBox>
+              <AssignmentIcon />
+            </DrawerIconBox>
+            <DrawerTitle>Task Preview</DrawerTitle>
+          </DrawerHeaderLeft>
+          <Chip
+            label={item?.isDone ? 'Done' : 'Pending'}
+            size="small"
+            color={item?.isDone ? 'success' : 'default'}
+            variant="outlined"
+          />
+        </DrawerHeader>
+      }
     >
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '100%',
-          bgcolor: 'background.paper',
-          transform: `translateY(${dragOffset}px)`,
-          transition: isDragging.current
-            ? 'transform 0s'
-            : 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
-        }}
-      >
-        {/* Drag handle */}
-        <Box
-          role="button"
-          aria-label="Drag to close"
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerUp}
-          sx={{
-            width: '100%',
-            flexShrink: 0,
-            cursor: 'grab',
-            touchAction: 'none',
-            userSelect: 'none',
-            '& *': { touchAction: 'none', userSelect: 'none' },
-            '&:active': { cursor: 'grabbing' },
-          }}
-        >
-          <Box
-            sx={{
-              width: '100%',
-              display: 'flex',
-              justifyContent: 'center',
-              pt: '10px',
-              pb: '2px',
-            }}
-          >
-            <Box
-              sx={{
-                width: '36px',
-                height: '4px',
-                borderRadius: '2px',
-                background: 'rgba(0,0,0,0.15)',
-              }}
-            />
-          </Box>
-          <DrawerHeader>
-            <DrawerHeaderLeft>
-              <DrawerIconBox>
-                <AssignmentIcon />
-              </DrawerIconBox>
-              <DrawerTitle>Task Preview</DrawerTitle>
-            </DrawerHeaderLeft>
-            <Chip
-              label={item?.isDone ? 'Done' : 'Pending'}
-              size="small"
-              color={item?.isDone ? 'success' : 'default'}
-              variant="outlined"
-            />
-          </DrawerHeader>
-        </Box>
+      <ContentContainer>
+        <ItemName>{item?.name}</ItemName>
 
-        <ContentContainer>
-          <ItemName>{item?.name}</ItemName>
+        {item?.dueDate && (
+          <MetaRow>
+            <CalendarTodayIcon sx={{ fontSize: '1rem' }} />
+            {dayjs(item.dueDate).format('dddd, D MMMM YYYY')}
+          </MetaRow>
+        )}
 
-          {item?.dueDate && (
-            <MetaRow>
-              <CalendarTodayIcon sx={{ fontSize: '1rem' }} />
-              {dayjs(item.dueDate).format('dddd, D MMMM YYYY')}
-            </MetaRow>
-          )}
+        {item?.description ? (
+          <DescriptionText>{item.description}</DescriptionText>
+        ) : (
+          <NoDescriptionText>No description</NoDescriptionText>
+        )}
 
-          {item?.description ? (
-            <DescriptionText>{item.description}</DescriptionText>
-          ) : (
-            <NoDescriptionText>No description</NoDescriptionText>
-          )}
-
-          {steps.length > 0 && (
-            <Box sx={{ mt: 2 }}>
-              <Typography
-                variant="subtitle2"
-                sx={{ fontWeight: 600, mb: 1, color: 'text.secondary', letterSpacing: 0.5, textTransform: 'uppercase', fontSize: '0.75rem' }}
-              >
-                Sub-steps
-              </Typography>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-                {steps.map(step => (
-                  <FormControlLabel
-                    key={step.id}
-                    control={
-                      <Checkbox
-                        checked={step.isDone}
-                        onChange={() => onStepToggle?.(item!.id, step.id, !step.isDone)}
-                        size="small"
-                        sx={{
-                          color: 'rgba(102, 126, 234, 0.5)',
-                          '&.Mui-checked': { color: '#667eea' },
-                        }}
-                      />
-                    }
-                    label={
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          textDecoration: step.isDone ? 'line-through' : 'none',
-                          color: step.isDone ? 'text.disabled' : 'text.primary',
-                        }}
-                      >
-                        {step.name}
-                      </Typography>
-                    }
-                    sx={{
-                      mx: 0,
-                      borderRadius: '8px',
-                      px: 1,
-                      '&:hover': { background: 'rgba(102, 126, 234, 0.05)' },
-                    }}
-                  />
-                ))}
-              </Box>
-            </Box>
-          )}
-        </ContentContainer>
-
-        <Footer>
-          {!item?.isDone && onMarkDone && (
-            <Button
-              variant="contained"
-              fullWidth
-              startIcon={<CheckCircleIcon />}
-              onClick={handleMarkDone}
-              sx={{
-                background: 'linear-gradient(135deg, #059669 0%, #047857 100%)',
-                borderRadius: '10px',
-                textTransform: 'none',
-                fontWeight: 600,
-                py: 1.25,
-                boxShadow: 'none',
-                mb: 1,
-                '&:hover': { boxShadow: 'none', opacity: 0.9 },
-              }}
+        {steps.length > 0 && (
+          <Box sx={{ mt: 2 }}>
+            <Typography
+              variant="subtitle2"
+              sx={{ fontWeight: 600, mb: 1, color: 'text.secondary', letterSpacing: 0.5, textTransform: 'uppercase', fontSize: '0.75rem' }}
             >
-              Mark as Complete
-            </Button>
-          )}
+              Sub-steps
+            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+              {steps.map(step => (
+                <FormControlLabel
+                  key={step.id}
+                  control={
+                    <Checkbox
+                      checked={step.isDone}
+                      onChange={() => onStepToggle?.(item!.id, step.id, !step.isDone)}
+                      size="small"
+                      sx={{
+                        color: 'rgba(102, 126, 234, 0.5)',
+                        '&.Mui-checked': { color: '#667eea' },
+                      }}
+                    />
+                  }
+                  label={
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        textDecoration: step.isDone ? 'line-through' : 'none',
+                        color: step.isDone ? 'text.disabled' : 'text.primary',
+                      }}
+                    >
+                      {step.name}
+                    </Typography>
+                  }
+                  sx={{
+                    mx: 0,
+                    borderRadius: '8px',
+                    px: 1,
+                    '&:hover': { background: 'rgba(102, 126, 234, 0.05)' },
+                  }}
+                />
+              ))}
+            </Box>
+          </Box>
+        )}
+      </ContentContainer>
+
+      <Footer>
+        {!item?.isDone && onMarkDone && (
           <Button
             variant="contained"
             fullWidth
-            startIcon={<EditIcon />}
-            onClick={handleEdit}
+            startIcon={<CheckCircleIcon />}
+            onClick={handleMarkDone}
             sx={{
-              background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+              background: 'linear-gradient(135deg, #059669 0%, #047857 100%)',
               borderRadius: '10px',
               textTransform: 'none',
               fontWeight: 600,
               py: 1.25,
               boxShadow: 'none',
+              mb: 1,
               '&:hover': { boxShadow: 'none', opacity: 0.9 },
             }}
           >
-            Edit Task
+            Mark as Complete
           </Button>
-          <Button
-            variant="outlined"
-            fullWidth
-            startIcon={<DeleteIcon />}
-            onClick={handleDelete}
-            color="error"
-            sx={{
-              borderRadius: '10px',
-              textTransform: 'none',
-              fontWeight: 600,
-              py: 1.25,
-              mt: 1,
-            }}
-          >
-            Delete Task
-          </Button>
-        </Footer>
-      </Box>
-    </Drawer>
+        )}
+        <Button
+          variant="contained"
+          fullWidth
+          startIcon={<EditIcon />}
+          onClick={handleEdit}
+          sx={{
+            background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+            borderRadius: '10px',
+            textTransform: 'none',
+            fontWeight: 600,
+            py: 1.25,
+            boxShadow: 'none',
+            '&:hover': { boxShadow: 'none', opacity: 0.9 },
+          }}
+        >
+          Edit Task
+        </Button>
+        <Button
+          variant="outlined"
+          fullWidth
+          startIcon={<DeleteIcon />}
+          onClick={handleDelete}
+          color="error"
+          sx={{
+            borderRadius: '10px',
+            textTransform: 'none',
+            fontWeight: 600,
+            py: 1.25,
+            mt: 1,
+          }}
+        >
+          Delete Task
+        </Button>
+      </Footer>
+    </DraggableBottomDrawer>
   )
 }
 


### PR DESCRIPTION
DayPreviewDrawer and MealPlanDrawer were missing swipe-down-to-close
functionality. Additionally, RecipeDetailDrawer, AgentChatDrawer, and
RecipeDrawer each duplicated the drag-to-close logic inline instead of
using the existing useDragToClose hook.

Created a new DraggableBottomDrawer wrapper component that encapsulates
the Drawer, useDragToClose hook, transform animation, and drag handle pill
in one reusable place. Refactored all 7 bottom-sheet drawers to use it.

https://claude.ai/code/session_018vvaorUpwZzMU5pj7KMEGz