### PR TITLE
fix: improve DayPreviewDrawer styling to match consistent drawer header pattern

### DIFF
--- a/packages/web/src/components/DayPreviewDrawer/index.styled.tsx
+++ b/packages/web/src/components/DayPreviewDrawer/index.styled.tsx
@@ -1,40 +1,75 @@
 import { styled } from '@mui/material/styles'
 import { Box, Typography } from '@mui/material'
 
+export const DrawerHeader = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '0.75rem 1.25rem 1rem',
+  borderBottom: '1px solid rgba(0, 0, 0, 0.06)',
+  flexShrink: 0,
+})
+
+export const DrawerHeaderLeft = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+})
+
+export const DrawerIconBox = styled(Box)({
+  width: '2.25rem',
+  height: '2.25rem',
+  borderRadius: '10px',
+  background: 'linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexShrink: 0,
+  '& .MuiSvgIcon-root': {
+    fontSize: '1.2rem',
+    color: 'white',
+  },
+})
+
+export const DrawerTitleGroup = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1px',
+})
+
+export const DrawerTitle = styled('span')({
+  fontSize: '1.1rem',
+  fontWeight: 700,
+  background: 'linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%)',
+  WebkitBackgroundClip: 'text',
+  WebkitTextFillColor: 'transparent',
+  backgroundClip: 'text',
+  letterSpacing: '0.3px',
+})
+
+export const DrawerSubtitle = styled(Typography)({
+  fontSize: '0.8rem',
+  color: '#6b7280',
+  fontWeight: 500,
+})
+
 export const DrawerContent = styled(Box)({
-  padding: '1.25em',
+  padding: '0.875rem 1.25rem',
   display: 'flex',
   flexDirection: 'column',
   overflowY: 'auto',
-  paddingBottom: 'max(1.25em, env(safe-area-inset-bottom))',
+  paddingBottom: 'max(1.25rem, env(safe-area-inset-bottom))',
 })
 
-export const DrawerHeader = styled(Typography)({
-  fontWeight: 700,
-  fontSize: '1.1rem',
-  color: '#1d4ed8',
-  display: 'flex',
-  alignItems: 'center',
-  gap: '6px',
-})
-
-export const DateLabel = styled(Typography)({
-  fontSize: '0.9rem',
-  color: '#6b7280',
-  fontWeight: 500,
-  marginTop: '2px',
-  marginBottom: '8px',
-})
-
-export const SectionLabel = styled(Typography)<{ color?: string; borderColor?: string }>(
-  ({ color = '#1d4ed8', borderColor = 'rgba(226, 232, 240, 0.9)' }) => ({
+export const SectionLabel = styled(Typography)<{ color?: string }>(
+  ({ color = '#1d4ed8' }) => ({
     fontSize: '0.7rem',
     fontWeight: 700,
     color,
     marginTop: '12px',
     marginBottom: '6px',
     paddingTop: '12px',
-    borderTop: `1px solid ${borderColor}`,
+    borderTop: '1px solid rgba(226, 232, 240, 0.9)',
     textTransform: 'uppercase',
     letterSpacing: '0.08em',
     display: 'flex',

--- a/packages/web/src/components/DayPreviewDrawer/index.tsx
+++ b/packages/web/src/components/DayPreviewDrawer/index.tsx
@@ -16,7 +16,16 @@ import {
   MealsSectionHeader,
   MealsAddButton,
 } from '../Planner/CalendarView/index.styled'
-import { DrawerContent, DrawerHeader, DateLabel, SectionLabel } from './index.styled'
+import {
+  DrawerContent,
+  DrawerHeader,
+  DrawerHeaderLeft,
+  DrawerIconBox,
+  DrawerTitleGroup,
+  DrawerTitle,
+  DrawerSubtitle,
+  SectionLabel,
+} from './index.styled'
 import DraggableBottomDrawer from '../DraggableBottomDrawer'
 
 interface IDayPreviewDrawerProps {
@@ -54,17 +63,30 @@ const DayPreviewDrawer = ({
       onClose={onClose}
       paperSx={{ maxHeight: '85vh' }}
       dragHandleContent={
-        <>
-          <DrawerHeader>
-            <CalendarTodayIcon sx={{ fontSize: '1.1rem' }} />
-            {selectedDay ? dayjs(selectedDay).format('dddd') : ''}
-          </DrawerHeader>
-          <DateLabel>{selectedDay ? dayjs(selectedDay).format('D MMMM YYYY') : ''}</DateLabel>
-        </>
+        <DrawerHeader>
+          <DrawerHeaderLeft>
+            <DrawerIconBox>
+              <CalendarTodayIcon />
+            </DrawerIconBox>
+            <DrawerTitleGroup>
+              <DrawerTitle>
+                {selectedDay ? dayjs(selectedDay).format('dddd') : ''}
+              </DrawerTitle>
+              <DrawerSubtitle>
+                {selectedDay ? dayjs(selectedDay).format('D MMMM YYYY') : ''}
+              </DrawerSubtitle>
+            </DrawerTitleGroup>
+          </DrawerHeaderLeft>
+        </DrawerHeader>
       }
     >
       <DrawerContent>
-        <SectionLabel color={isOverdue ? '#dc2626' : '#1d4ed8'}>Tasks</SectionLabel>
+        <SectionLabel
+          color={isOverdue ? '#dc2626' : '#1d4ed8'}
+          sx={{ mt: 0, pt: 0, borderTop: 'none' }}
+        >
+          Tasks
+        </SectionLabel>
         {pendingTodos.length === 0 && completedTodos.length === 0 ? (
           <DayDetailEmpty>No tasks on this day</DayDetailEmpty>
         ) : (


### PR DESCRIPTION
Use the same DrawerHeader/DrawerIconBox/DrawerTitle pattern as other drawers
(BirthdayPreviewDrawer, ToDoItemPreviewDrawer) for a polished, consistent look.
Adds a gradient icon box, gradient title, and subtitle for the date. Removes
the awkward border-top on the first section label.

https://claude.ai/code/session_012UShkV3ZAzFG5z3rJoVBB4