### PR TITLE
Fix meal edit 400 error caused by recipeId being null

### DIFF
--- a/packages/infra/modules/api_gateway/openapi/meal_plans.yml
+++ b/packages/infra/modules/api_gateway/openapi/meal_plans.yml
@@ -252,6 +252,10 @@ components:
           type: string
           nullable: true
           example: "recipe-789"
+        mealType:
+          type: string
+          nullable: true
+          example: "Dinner"
   securitySchemes:
     CognitoAuthorizer:
       type: apiKey

--- a/packages/web/src/routes/PlannerRoute/index.tsx
+++ b/packages/web/src/routes/PlannerRoute/index.tsx
@@ -135,7 +135,8 @@ const PlannerContent = () => {
   const handleMealPlanSave = useCallback(async (date: string, recipeName: string, recipeId?: string, mealType?: MealType) => {
     try {
       if (editingMealPlan) {
-        await updateMealPlan(editingMealPlan.id, { date, recipeName, recipeId: recipeId ?? null, mealType: mealType ?? null })
+        const recipeIdUpdate = recipeId !== undefined ? recipeId : (editingMealPlan.recipeId ? null : undefined)
+        await updateMealPlan(editingMealPlan.id, { date, recipeName, recipeId: recipeIdUpdate, mealType: mealType ?? null })
       } else {
         await addMealPlan(date, recipeName, recipeId, mealType)
       }


### PR DESCRIPTION
- Only send recipeId: null when switching a meal from recipe to custom
  mode (i.e. intentionally clearing a previously set recipeId). Custom
  meals that never had a recipeId no longer send recipeId: null in the
  update request, which caused API Gateway to reject it with 400.
- Add missing mealType field to updateMealPlanRequest OpenAPI schema so
  the request body is correctly defined.