### PR TITLE
fix: remove autoFocus from meal name input in MealPlanDrawer

### DIFF
--- a/packages/web/src/components/MealPlanDrawer/index.tsx
+++ b/packages/web/src/components/MealPlanDrawer/index.tsx
@@ -191,7 +191,6 @@ const MealPlanDrawer = ({ open, date, mealPlan, onClose, onSave, onDelete }: IMe
               value={customName}
               onChange={(e) => setCustomName(e.target.value)}
               fullWidth
-              autoFocus
               onKeyDown={(e) => { if (e.key === 'Enter' && canSave) handleSave() }}
             />
           )}


### PR DESCRIPTION
Prevents keyboard from automatically opening when the edit meal drawer
is opened on mobile, which was obscuring the drawer content.

https://claude.ai/code/session_01XCCGUtZSHKsZaHafsQvYi9