### PR TITLE
Add quick-add task button to day preview drawer

### DIFF
--- a/packages/web/src/components/DayPreviewDrawer/index.tsx
+++ b/packages/web/src/components/DayPreviewDrawer/index.tsx
@@ -15,6 +15,7 @@ import {
   MealPlanIcon,
   MealsSectionHeader,
   MealsAddButton,
+  TasksAddButton,
 } from '../Planner/CalendarView/index.styled'
 import {
   DrawerContent,
@@ -41,6 +42,7 @@ interface IDayPreviewDrawerProps {
   onBirthdayClick?: (id: string) => void
   onAddMealPlan?: (date: string) => void
   onMealPlanClick?: (mealPlan: IMealPlan) => void
+  onAddTask?: (date: string) => void
 }
 
 const DayPreviewDrawer = ({
@@ -56,6 +58,7 @@ const DayPreviewDrawer = ({
   onBirthdayClick,
   onAddMealPlan,
   onMealPlanClick,
+  onAddTask,
 }: IDayPreviewDrawerProps) => {
   return (
     <DraggableBottomDrawer
@@ -86,6 +89,9 @@ const DayPreviewDrawer = ({
           sx={{ mt: 0, pt: 0, borderTop: 'none' }}
         >
           Tasks
+          {onAddTask && selectedDay && (
+            <TasksAddButton onClick={(e) => { e.stopPropagation(); onAddTask(selectedDay) }}>+</TasksAddButton>
+          )}
         </SectionLabel>
         {pendingTodos.length === 0 && completedTodos.length === 0 ? (
           <DayDetailEmpty>No tasks on this day</DayDetailEmpty>

--- a/packages/web/src/components/Planner/CalendarView/index.styled.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.styled.tsx
@@ -373,3 +373,21 @@ export const MealsAddButton = styled('span')({
     borderStyle: 'solid',
   },
 })
+
+export const TasksAddButton = styled('span')({
+  fontSize: '0.85rem',
+  fontWeight: 700,
+  color: '#1d4ed8',
+  backgroundColor: 'rgba(59, 130, 246, 0.12)',
+  border: '1.5px dashed #3b82f6',
+  borderRadius: '6px',
+  padding: '1px 8px',
+  cursor: 'pointer',
+  marginLeft: 'auto',
+  transition: 'all 0.12s ease',
+  lineHeight: 1.4,
+  '&:hover': {
+    backgroundColor: 'rgba(59, 130, 246, 0.22)',
+    borderStyle: 'solid',
+  },
+})

--- a/packages/web/src/components/Planner/CalendarView/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.tsx
@@ -38,6 +38,7 @@ interface ICalendarViewProps {
   mealPlans?: IMealPlan[]
   onAddMealPlan?: (date: string) => void
   onMealPlanClick?: (mealPlan: IMealPlan) => void
+  onAddTask?: (date: string) => void
 }
 
 const CalendarView = ({
@@ -48,6 +49,7 @@ const CalendarView = ({
   mealPlans = [],
   onAddMealPlan,
   onMealPlanClick,
+  onAddTask,
 }: ICalendarViewProps) => {
   const { dispatch } = useAppState()
   const [currentMonth, setCurrentMonth] = useState<Dayjs>(() => dayjs().startOf('month'))
@@ -252,6 +254,7 @@ const CalendarView = ({
         onBirthdayClick={onBirthdayClick}
         onAddMealPlan={onAddMealPlan}
         onMealPlanClick={onMealPlanClick}
+        onAddTask={onAddTask}
       />
 
       {itemsWithoutDueDate.length > 0 && (

--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -100,6 +100,11 @@ export const Planner = ({
     await removeBirthdayItem(id);
   }, [removeBirthdayItem]);
 
+  const handleAddTask = useCallback((date: string) => {
+    dispatch({ type: ActionName.SET_SELECTED_CALENDAR_DATE, payload: date })
+    navigate(Route.AddPlannerItem)
+  }, [dispatch, navigate])
+
   const handleStepToggle = useCallback(async (todoId: string, stepId: string, isDone: boolean) => {
     const item = toDoList.find(t => t.id === todoId)
     if (!item?.steps) return
@@ -148,6 +153,7 @@ export const Planner = ({
             mealPlans={mealPlans}
             onAddMealPlan={onAddMealPlan}
             onMealPlanClick={onMealPlanClick}
+            onAddTask={handleAddTask}
           />
         )}
         {drawers}


### PR DESCRIPTION
Adds a small '+' button next to the 'Tasks' section label in the
DayPreviewDrawer, mirroring the existing add-meal button. Clicking it
sets the selected calendar date and navigates to the add task form.