### PR TITLE
Close recipe modal after adding ingredients, including on error

### DIFF
--- a/packages/web/src/components/RecipeItem/index.tsx
+++ b/packages/web/src/components/RecipeItem/index.tsx
@@ -111,6 +111,7 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
       onUseRecipe()
     } catch (error) {
       showAlert({ description: 'Failed to add ingredients', severity: 'error' }, dispatch)
+      onUseRecipe()
     } finally {
       setIsAdding(false)
     }


### PR DESCRIPTION
When adding ingredients from a recipe, the modal now closes on both
success and failure so the user can see the result (items added or
error alert) on the grocery list page.

https://claude.ai/code/session_01Jv3qfFjhSzZZwyn6bNyAHJ