### PR TITLE
fix: make recipe modal scrollable and auto-scroll to shop input on use recipe

### DIFF
--- a/packages/web/src/components/RecipeDrawer/index.styled.tsx
+++ b/packages/web/src/components/RecipeDrawer/index.styled.tsx
@@ -44,6 +44,8 @@ export const DrawerTitle = styled('span')({
 export const ContentContainer = styled(Box)({
   flex: 1,
   overflowY: 'auto',
+  WebkitOverflowScrolling: 'touch',
+  overscrollBehavior: 'contain',
   padding: '1rem 1.25rem',
   display: 'flex',
   flexDirection: 'column',

--- a/packages/web/src/components/RecipeItem/index.tsx
+++ b/packages/web/src/components/RecipeItem/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { Typography, Button, Chip, Tooltip, Box, Checkbox, IconButton, FormControl, InputLabel, Select, MenuItem } from '@mui/material'
 import AddShoppingCartIcon from '@mui/icons-material/AddShoppingCart'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
@@ -48,6 +48,7 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
   const [deselectedIndices, setDeselectedIndices] = useState<Set<number>>(new Set())
   const [showAllIngredients, setShowAllIngredients] = useState(false)
   const [showInstructions, setShowInstructions] = useState(false)
+  const interactiveSectionRef = useRef<HTMLDivElement>(null)
 
   const handleToggleIngredient = useCallback((index: number) => {
     setDeselectedIndices((prev) => {
@@ -76,7 +77,21 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
     if (!localShopId) return
     setIsSelectingShop(false)
     setIsSelectingIngredients(true)
+    setTimeout(() => {
+      interactiveSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }, 50)
   }, [localShopId])
+
+  const handleClickUseRecipe = useCallback(() => {
+    if (needsShopSelection) {
+      setIsSelectingShop(true)
+    } else {
+      setIsSelectingIngredients(true)
+    }
+    setTimeout(() => {
+      interactiveSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }, 50)
+  }, [needsShopSelection])
 
   const handleUseRecipe = useCallback(async () => {
     const effectiveShopId = localShopId || shopId
@@ -283,6 +298,7 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
           </Box>
         )}
 
+        <Box ref={interactiveSectionRef}>
         {isSelectingShop ? (
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', mt: 0.5 }}>
             <FormControl size="small" fullWidth>
@@ -374,7 +390,7 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
                 variant="contained"
                 size="small"
                 startIcon={<AddShoppingCartIcon />}
-                onClick={() => needsShopSelection ? setIsSelectingShop(true) : setIsSelectingIngredients(true)}
+                onClick={handleClickUseRecipe}
                 disabled={!canUseRecipe}
                 sx={{
                   mt: 0.5,
@@ -390,6 +406,7 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
             </span>
           </Tooltip>
         )}
+        </Box>
       </RecipeInteractiveArea>
     </RecipeCard>
   )

--- a/packages/web/src/components/RecipeItem/index.tsx
+++ b/packages/web/src/components/RecipeItem/index.tsx
@@ -49,6 +49,8 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
   const [showAllIngredients, setShowAllIngredients] = useState(false)
   const [showInstructions, setShowInstructions] = useState(false)
   const interactiveSectionRef = useRef<HTMLDivElement>(null)
+  const needsShopSelection = !shopId || shopId === 'all'
+  const canUseRecipe = !needsShopSelection || shops.length > 0
 
   const handleToggleIngredient = useCallback((index: number) => {
     setDeselectedIndices((prev) => {
@@ -78,7 +80,7 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
     setIsSelectingShop(false)
     setIsSelectingIngredients(true)
     setTimeout(() => {
-      interactiveSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      interactiveSectionRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' })
     }, 50)
   }, [localShopId])
 
@@ -89,7 +91,7 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
       setIsSelectingIngredients(true)
     }
     setTimeout(() => {
-      interactiveSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+      interactiveSectionRef.current?.scrollIntoView?.({ behavior: 'smooth', block: 'nearest' })
     }, 50)
   }, [needsShopSelection])
 
@@ -129,8 +131,6 @@ const RecipeItem = ({ recipe, onEdit, onUseRecipe, shopId, defaults }: RecipeIte
     }
   }, [currentProject, shopId, localShopId, recipe, deselectedIndices, dispatch, onUseRecipe])
 
-  const needsShopSelection = !shopId || shopId === 'all'
-  const canUseRecipe = !needsShopSelection || shops.length > 0
   const hasMoreIngredients = recipe.ingredients.length > INGREDIENTS_PREVIEW_COUNT
   const visibleIngredients =
     showAllIngredients || isSelectingIngredients


### PR DESCRIPTION
- Add WebkitOverflowScrolling and overscrollBehavior to ContentContainer for proper mobile scroll support
- Auto-scroll interactive section into view when clicking Use Recipe or Continue (shop → ingredient transition)

https://claude.ai/code/session_01JV9r5Fnn2JzcDpGY26vww9