### PR TITLE
Extend section color schemes from home page to detail pages

### DIFF
--- a/packages/web/src/components/ModernPageHeader/index.styled.tsx
+++ b/packages/web/src/components/ModernPageHeader/index.styled.tsx
@@ -5,7 +5,7 @@ export const HeaderWrapper = styled('div')({
   width: '100%',
 })
 
-export const HeaderCard = styled(Card)(({ theme }) => ({
+export const HeaderCard = styled(Card)<{ accentgradient?: string }>(({ accentgradient }) => ({
   borderRadius: '16px',
   boxShadow: '0 2px 12px rgba(0, 0, 0, 0.06)',
   border: 'none',
@@ -23,7 +23,7 @@ export const HeaderCard = styled(Card)(({ theme }) => ({
     left: 0,
     right: 0,
     height: '3px',
-    background: 'linear-gradient(90deg, #667eea 0%, #764ba2 50%, #f093fb 100%)',
+    background: accentgradient ?? 'linear-gradient(90deg, #667eea 0%, #764ba2 50%, #f093fb 100%)',
     opacity: 0.8,
   },
   '&:hover': {
@@ -44,28 +44,28 @@ export const HeaderContent = styled('div')({
   boxSizing: 'border-box',
 })
 
-export const HeaderTitle = styled('h1')(({ theme }) => ({
+export const HeaderTitle = styled('h1')<{ accentgradient?: string }>(({ theme, accentgradient }) => ({
   fontSize: '1.25rem',
   fontWeight: '700',
   color: theme.palette.text.primary,
   margin: 0,
   lineHeight: 1.1,
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  background: accentgradient ?? 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
   WebkitBackgroundClip: 'text',
   WebkitTextFillColor: 'transparent',
   backgroundClip: 'text',
 }))
 
-export const HeaderIcon = styled('div')(({ theme }) => ({
+export const HeaderIcon = styled('div')<{ accentgradient?: string; accentrgb?: string }>(({ accentgradient, accentrgb }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   width: '2.5rem',
   height: '2.5rem',
   borderRadius: '10px',
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  background: accentgradient ?? 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
   color: 'white',
-  boxShadow: '0 2px 8px rgba(102, 126, 234, 0.25)',
+  boxShadow: `0 2px 8px rgba(${accentrgb ?? '102, 126, 234'}, 0.25)`,
   '& .MuiSvgIcon-root': {
     fontSize: '1.25rem',
   },
@@ -91,12 +91,12 @@ export const StatItem = styled('div')<{ wide?: boolean }>(() => ({
   textAlign: 'center',
 }))
 
-export const StatValue = styled('div')(({ theme }) => ({
+export const StatValue = styled('div')<{ accentgradient?: string }>(({ theme, accentgradient }) => ({
   fontSize: '1.1rem',
   fontWeight: '700',
   color: theme.palette.text.primary,
   lineHeight: 1,
-  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  background: accentgradient ?? 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
   WebkitBackgroundClip: 'text',
   WebkitTextFillColor: 'transparent',
   backgroundClip: 'text',

--- a/packages/web/src/components/ModernPageHeader/index.tsx
+++ b/packages/web/src/components/ModernPageHeader/index.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 import { Tooltip } from '@mui/material'
-import { 
+import {
   HeaderWrapper,
-  HeaderCard, 
-  HeaderContent, 
-  HeaderTitle, 
-  HeaderIcon, 
+  HeaderCard,
+  HeaderContent,
+  HeaderTitle,
+  HeaderIcon,
   HeaderStats,
   StatItem,
   StatValue,
-  StatLabel 
+  StatLabel
 } from './index.styled'
 
 export interface ActionButtonProps {
@@ -23,6 +23,8 @@ export interface ActionButtonProps {
 export interface ModernPageHeaderProps {
   title: string
   icon: React.ReactNode
+  accentGradient?: string
+  accentRgb?: string
   stats?: Array<{
     value: string | number
     label: string
@@ -32,78 +34,83 @@ export interface ModernPageHeaderProps {
   secondaryActionButton?: ActionButtonProps
 }
 
-const ActionButtonItem: React.FC<ActionButtonProps> = ({ icon, onClick, tooltip, ariaLabel, label }) => (
-  <Tooltip title={tooltip}>
-    <div
-      onClick={onClick}
-      role="button"
-      aria-label={ariaLabel}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '0.5rem',
-        background: 'rgba(102, 126, 234, 0.08)',
-        borderRadius: '8px',
-        padding: label ? '0.375rem 0.75rem' : '0.375rem',
-        border: '1px solid rgba(102, 126, 234, 0.15)',
-        cursor: 'pointer',
-        transition: 'all 0.2s ease',
-      } as React.CSSProperties}
-      onMouseEnter={(e) => {
-        const target = e.currentTarget as HTMLDivElement
-        target.style.background = 'rgba(102, 126, 234, 0.12)'
-        target.style.borderColor = 'rgba(102, 126, 234, 0.25)'
-      }}
-      onMouseLeave={(e) => {
-        const target = e.currentTarget as HTMLDivElement
-        target.style.background = 'rgba(102, 126, 234, 0.08)'
-        target.style.borderColor = 'rgba(102, 126, 234, 0.15)'
-      }}
-    >
-      <div style={{ fontSize: '1rem', display: 'flex', alignItems: 'center' }}>
-        {icon}
+const ActionButtonItem: React.FC<ActionButtonProps & { accentRgb?: string }> = ({ icon, onClick, tooltip, ariaLabel, label, accentRgb }) => {
+  const rgb = accentRgb ?? '102, 126, 234'
+  return (
+    <Tooltip title={tooltip}>
+      <div
+        onClick={onClick}
+        role="button"
+        aria-label={ariaLabel}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          background: `rgba(${rgb}, 0.08)`,
+          borderRadius: '8px',
+          padding: label ? '0.375rem 0.75rem' : '0.375rem',
+          border: `1px solid rgba(${rgb}, 0.15)`,
+          cursor: 'pointer',
+          transition: 'all 0.2s ease',
+        } as React.CSSProperties}
+        onMouseEnter={(e) => {
+          const target = e.currentTarget as HTMLDivElement
+          target.style.background = `rgba(${rgb}, 0.12)`
+          target.style.borderColor = `rgba(${rgb}, 0.25)`
+        }}
+        onMouseLeave={(e) => {
+          const target = e.currentTarget as HTMLDivElement
+          target.style.background = `rgba(${rgb}, 0.08)`
+          target.style.borderColor = `rgba(${rgb}, 0.15)`
+        }}
+      >
+        <div style={{ fontSize: '1rem', display: 'flex', alignItems: 'center' }}>
+          {icon}
+        </div>
+        {label && (
+          <span style={{ fontSize: '0.75rem', fontWeight: '500', color: `rgb(${rgb})`, whiteSpace: 'nowrap' }}>
+            {label}
+          </span>
+        )}
       </div>
-      {label && (
-        <span style={{ fontSize: '0.75rem', fontWeight: '500', color: '#667eea', whiteSpace: 'nowrap' }}>
-          {label}
-        </span>
-      )}
-    </div>
-  </Tooltip>
-)
+    </Tooltip>
+  )
+}
 
 const ModernPageHeader: React.FC<ModernPageHeaderProps> = ({
   title,
   icon,
+  accentGradient,
+  accentRgb,
   stats,
   actionButton,
   secondaryActionButton,
 }) => {
   return (
     <HeaderWrapper>
-      <HeaderCard>
+      <HeaderCard accentgradient={accentGradient}>
         <HeaderContent>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem', flex: 1 }}>
-              <HeaderIcon>
+              <HeaderIcon accentgradient={accentGradient} accentrgb={accentRgb}>
                 {icon}
               </HeaderIcon>
-              <HeaderTitle>{title}</HeaderTitle>
+              <HeaderTitle accentgradient={accentGradient}>{title}</HeaderTitle>
             </div>
-            
+
             {(actionButton || secondaryActionButton) && (
               <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                {secondaryActionButton && <ActionButtonItem {...secondaryActionButton} />}
-                {actionButton && <ActionButtonItem {...actionButton} />}
+                {secondaryActionButton && <ActionButtonItem {...secondaryActionButton} accentRgb={accentRgb} />}
+                {actionButton && <ActionButtonItem {...actionButton} accentRgb={accentRgb} />}
               </div>
             )}
           </div>
-          
+
           {stats && stats.length > 0 && (
             <HeaderStats>
               {stats.map((stat, index) => (
                 <StatItem key={index} wide={stat.wide}>
-                  <StatValue>{stat.value}</StatValue>
+                  <StatValue accentgradient={accentGradient}>{stat.value}</StatValue>
                   <StatLabel>{stat.label}</StatLabel>
                 </StatItem>
               ))}

--- a/packages/web/src/constants/sectionColors.ts
+++ b/packages/web/src/constants/sectionColors.ts
@@ -1,0 +1,11 @@
+export const SECTION_GRADIENTS = {
+  planner: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+  grocery: 'linear-gradient(135deg, #11998e 0%, #38ef7d 100%)',
+  noise: 'linear-gradient(135deg, #f7971e 0%, #ffd200 100%)',
+}
+
+export const SECTION_ACCENT_RGB = {
+  planner: '102, 126, 234',
+  grocery: '17, 153, 142',
+  noise: '247, 151, 30',
+}

--- a/packages/web/src/routes/GroceryListRoute/index.tsx
+++ b/packages/web/src/routes/GroceryListRoute/index.tsx
@@ -12,6 +12,7 @@ import UnfoldLessIcon from '@mui/icons-material/UnfoldLess'
 import StorefrontIcon from '@mui/icons-material/Storefront'
 import MenuBookIcon from '@mui/icons-material/MenuBook'
 import { Container, ScrollableContainer } from './index.styled'
+import { SECTION_GRADIENTS, SECTION_ACCENT_RGB } from '../../constants/sectionColors'
 import { useState, useCallback, useMemo } from 'react'
 import RecipeDrawer from '../../components/RecipeDrawer'
 import { useParams, useNavigate } from 'react-router'
@@ -102,6 +103,8 @@ const GroceryListContent = () => {
     <StandardLayout>
       <ModernPageHeader
         title={shopId === 'all' ? 'All Grocery Items' : (currentShop ? currentShop.name : "Grocery List")}
+        accentGradient={SECTION_GRADIENTS.grocery}
+        accentRgb={SECTION_ACCENT_RGB.grocery}
         icon={currentShop?.icon ? (
           <img
             src={currentShop.icon}

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/index.tsx
@@ -5,6 +5,7 @@ import GroceryStatsGrid from './components/GroceryStatsGrid'
 import EmptyState from '../shared/EmptyState'
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart'
 import { IGrocerySectionProps } from './types'
+import { SECTION_GRADIENTS } from '../../../../constants/sectionColors'
 
 export const GrocerySection: React.FC<IGrocerySectionProps> = ({
   groceryStats,
@@ -16,7 +17,7 @@ export const GrocerySection: React.FC<IGrocerySectionProps> = ({
       icon={ShoppingCartIcon}
       title="Grocery List"
       count={groceryStats.totalItems}
-      accentGradient="linear-gradient(135deg, #11998e 0%, #38ef7d 100%)"
+      accentGradient={SECTION_GRADIENTS.grocery}
       accentBadgeColor="rgba(17, 153, 142, 0.12)"
     >
       {isLoading ? (

--- a/packages/web/src/routes/HomeRoute/components/NoiseSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/NoiseSection/index.tsx
@@ -8,6 +8,7 @@ import VolumeUpIcon from '@mui/icons-material/VolumeUp'
 import { INoiseSectionProps } from './types'
 import { formatNoiseTimestamp } from '../../../../utils/dateTime'
 import { INoiseTrackingItem } from '../../../../api/noiseTracking'
+import { SECTION_GRADIENTS } from '../../../../constants/sectionColors'
 
 const getFilteredNoiseItems = (noiseTrackingItems: INoiseTrackingItem[], view: string) => {
   const now = new Date()
@@ -97,7 +98,7 @@ export const NoiseSection: React.FC<INoiseSectionProps> = ({
       icon={VolumeUpIcon}
       title="Noise Recordings"
       count={noiseCounts.totalCount}
-      accentGradient="linear-gradient(135deg, #f7971e 0%, #ffd200 100%)"
+      accentGradient={SECTION_GRADIENTS.noise}
       accentBadgeColor="rgba(247, 151, 30, 0.12)"
     >
       {renderContent()}

--- a/packages/web/src/routes/NoiseTrackingRoute/index.tsx
+++ b/packages/web/src/routes/NoiseTrackingRoute/index.tsx
@@ -7,6 +7,7 @@ import VolumeUpIcon from '@mui/icons-material/VolumeUp'
 import ViewModuleIcon from '@mui/icons-material/ViewModule'
 import ViewListIcon from '@mui/icons-material/ViewList'
 import { Container, ScrollableContainer } from './index.styled'
+import { SECTION_GRADIENTS, SECTION_ACCENT_RGB } from '../../constants/sectionColors'
 import { useState, useCallback } from 'react'
 import { ViewMode } from '../../components/NoiseTrackingList/types'
 
@@ -66,6 +67,8 @@ const NoiseTrackingContent = () => {
       <ModernPageHeader
         title="Noise Tracking"
         icon={<VolumeUpIcon />}
+        accentGradient={SECTION_GRADIENTS.noise}
+        accentRgb={SECTION_ACCENT_RGB.noise}
         stats={stats}
       />
       <Container>

--- a/packages/web/src/routes/ShopListRoute/index.tsx
+++ b/packages/web/src/routes/ShopListRoute/index.tsx
@@ -13,6 +13,7 @@ import { Route } from '../../enums/route'
 import StorefrontIcon from '@mui/icons-material/Storefront'
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart'
 import { Container, ScrollableContainer, FormContainer } from './index.styled'
+import { SECTION_GRADIENTS, SECTION_ACCENT_RGB } from '../../constants/sectionColors'
 
 type FormMode = 'none' | 'add' | 'edit'
 
@@ -137,6 +138,8 @@ const ShopListContent = () => {
       <ModernPageHeader
         title="Shops"
         icon={<StorefrontIcon />}
+        accentGradient={SECTION_GRADIENTS.grocery}
+        accentRgb={SECTION_ACCENT_RGB.grocery}
         stats={stats}
       />
       <Container>


### PR DESCRIPTION
Each section (Grocery: teal/green, Noise: orange/yellow, Planner: purple) now
carries its color identity through to the detail page header — icon, top border,
title text, and stat values. A shared sectionColors constants file eliminates
duplicate gradient strings across home widgets and route pages.

https://claude.ai/code/session_01NThMRuu8N37UM8WJv2T1jz