### PR TITLE
Match nav icon selected color to section color scheme

### DIFF
--- a/packages/web/src/components/NavigationBar/NavigationButton/index.styled.ts
+++ b/packages/web/src/components/NavigationBar/NavigationButton/index.styled.ts
@@ -2,8 +2,11 @@ import { styled } from '@mui/material/styles';
 import { IconButton } from '@mui/material';
 
 export const StyledNavigationButton = styled(IconButton, {
-  shouldForwardProp: (prop) => prop !== 'isSelected',
-})<{ isSelected: boolean }>(({ theme, isSelected }) => ({
+  shouldForwardProp: (prop) => prop !== 'isSelected' && prop !== 'accentGradient' && prop !== 'accentRgb',
+})<{ isSelected: boolean; accentGradient?: string; accentRgb?: string }>(({ theme, isSelected, accentGradient, accentRgb }) => {
+  const gradient = accentGradient ?? 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)';
+  const rgb = accentRgb ?? '102, 126, 234';
+  return ({
   width: '48px',
   height: '48px',
   minWidth: '48px',
@@ -18,11 +21,11 @@ export const StyledNavigationButton = styled(IconButton, {
   
   ...(isSelected
     ? {
-        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        background: gradient,
         color: 'white',
         boxShadow: `
-          0 2px 8px rgba(102, 126, 234, 0.3),
-          0 4px 16px rgba(118, 75, 162, 0.2),
+          0 2px 8px rgba(${rgb}, 0.3),
+          0 4px 16px rgba(${rgb}, 0.2),
           inset 0 1px 0 rgba(255, 255, 255, 0.2)
         `,
         '&::before': {
@@ -36,11 +39,11 @@ export const StyledNavigationButton = styled(IconButton, {
           borderRadius: '16px',
         },
         '&:hover': {
-          background: 'linear-gradient(135deg, #5a67d8 0%, #6b46c1 100%)',
+          background: gradient,
           transform: 'translateY(-1px)',
           boxShadow: `
-            0 4px 12px rgba(102, 126, 234, 0.4),
-            0 8px 24px rgba(118, 75, 162, 0.3),
+            0 4px 12px rgba(${rgb}, 0.4),
+            0 8px 24px rgba(${rgb}, 0.3),
             inset 0 1px 0 rgba(255, 255, 255, 0.2)
           `,
         },
@@ -52,7 +55,7 @@ export const StyledNavigationButton = styled(IconButton, {
         background: 'transparent',
         color: theme.palette.text.secondary,
         '&:hover': {
-          background: 'rgba(102, 126, 234, 0.08)',
+          background: `rgba(${rgb}, 0.08)`,
           color: theme.palette.primary.main,
           transform: 'translateY(-1px)',
         },
@@ -61,4 +64,4 @@ export const StyledNavigationButton = styled(IconButton, {
         }
       }
   ),
-}));
+})});

--- a/packages/web/src/components/NavigationBar/NavigationButton/index.tsx
+++ b/packages/web/src/components/NavigationBar/NavigationButton/index.tsx
@@ -8,9 +8,11 @@ export interface INavigationButtonProps {
     UnselectedIcon: React.ElementType<any>;
     route: Route;
     isDisabled?: boolean;
+    accentGradient?: string;
+    accentRgb?: string;
 }
 
-const NavigationButton = ({ SelectedIcon, UnselectedIcon, route, isDisabled }: INavigationButtonProps) => {
+const NavigationButton = ({ SelectedIcon, UnselectedIcon, route, isDisabled, accentGradient, accentRgb }: INavigationButtonProps) => {
     const location = useLocation();
     const navigate = useNavigate();
     const onClick = useCallback(() => {
@@ -20,7 +22,7 @@ const NavigationButton = ({ SelectedIcon, UnselectedIcon, route, isDisabled }: I
     const isSelected = location.pathname === route;
 
     return (
-        <StyledNavigationButton onClick={onClick} disabled={isDisabled} isSelected={isSelected}>
+        <StyledNavigationButton onClick={onClick} disabled={isDisabled} isSelected={isSelected} accentGradient={accentGradient} accentRgb={accentRgb}>
             {isSelected ? <SelectedIcon fontSize="large"/> : <UnselectedIcon fontSize="large"/>}
         </StyledNavigationButton>
     );

--- a/packages/web/src/components/NavigationBar/index.tsx
+++ b/packages/web/src/components/NavigationBar/index.tsx
@@ -8,6 +8,7 @@ import ChecklistIcon from '@mui/icons-material/Checklist';
 import NavigationButton from './NavigationButton';
 import { Route } from '../../enums/route';
 import { Container, Divider, ItemsContainer } from './index.styled';
+import { SECTION_GRADIENTS, SECTION_ACCENT_RGB } from '../../constants/sectionColors';
 import AddItemButton from './AddItemButton';
 import { useShopContext } from '../../providers/ShopProvider';
 import { useCallback } from 'react';
@@ -38,7 +39,7 @@ const NavigationBar = () => {
           UnselectedIcon={HomeOutlinedIcon}
           route={Route.Home}
         />
-        <StyledNavigationButton onClick={handleShoppingCartClick} isSelected={isShoppingCartSelected}>
+        <StyledNavigationButton onClick={handleShoppingCartClick} isSelected={isShoppingCartSelected} accentGradient={SECTION_GRADIENTS.grocery} accentRgb={SECTION_ACCENT_RGB.grocery}>
           <ShoppingCartIcon fontSize="large" />
         </StyledNavigationButton>
         <AddItemButton />
@@ -46,6 +47,8 @@ const NavigationBar = () => {
           SelectedIcon={VolumeUpIcon}
           UnselectedIcon={VolumeUpOutlinedIcon}
           route={Route.NoiseTracking}
+          accentGradient={SECTION_GRADIENTS.noise}
+          accentRgb={SECTION_ACCENT_RGB.noise}
         />
         <NavigationButton
           SelectedIcon={ChecklistIcon}


### PR DESCRIPTION
Selected navigation icons now use the same accent gradient as their
respective section (grocery=green, noise=orange/yellow) instead of
always showing purple. Home and Planner remain purple as their section
color matches the default theme.

https://claude.ai/code/session_01Vf56vTigioG9GwyBVBEvxh