### PR TITLE
Add navigation from home page widgets to their respective pages

### DIFF
--- a/packages/web/src/components/SectionCard/index.tsx
+++ b/packages/web/src/components/SectionCard/index.tsx
@@ -2,12 +2,12 @@ import React from 'react'
 import { SectionCardProps } from './types'
 import { FullWidthSection, SectionCard as StyledSectionCard, SectionHeader, SectionContent, HeaderContent, StyledIcon, ItemCount } from './index.styled'
 
-const SectionCard: React.FC<SectionCardProps> = ({ icon: Icon, title, count, children, accentGradient, accentBadgeColor }) => {
+const SectionCard: React.FC<SectionCardProps> = ({ icon: Icon, title, count, children, accentGradient, accentBadgeColor, onHeaderClick }) => {
   return (
     <FullWidthSection>
       <StyledSectionCard accentGradient={accentGradient}>
         <SectionContent>
-          <SectionHeader>
+          <SectionHeader onClick={onHeaderClick} style={onHeaderClick ? { cursor: 'pointer' } : undefined}>
             <HeaderContent>
               <StyledIcon accentGradient={accentGradient}>
                 <Icon />

--- a/packages/web/src/components/SectionCard/types.ts
+++ b/packages/web/src/components/SectionCard/types.ts
@@ -8,4 +8,5 @@ export interface SectionCardProps {
   children: ReactNode
   accentGradient?: string
   accentBadgeColor?: string
+  onHeaderClick?: () => void
 }

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/index.tsx
@@ -10,7 +10,8 @@ import { SECTION_GRADIENTS } from '../../../../constants/sectionColors'
 export const GrocerySection: React.FC<IGrocerySectionProps> = ({
   groceryStats,
   isLoading,
-  onGroceryItemClick
+  onGroceryItemClick,
+  onNavigate
 }) => {
   return (
     <SectionCard
@@ -19,6 +20,7 @@ export const GrocerySection: React.FC<IGrocerySectionProps> = ({
       count={groceryStats.totalItems}
       accentGradient={SECTION_GRADIENTS.grocery}
       accentBadgeColor="rgba(17, 153, 142, 0.12)"
+      onHeaderClick={onNavigate}
     >
       {isLoading ? (
         <HomeGroceryItemPlaceholder />

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/types.ts
@@ -5,4 +5,5 @@ export interface IGrocerySectionProps {
   groceryStats: IGroceryStats
   isLoading: boolean
   onGroceryItemClick: (item: IGroceryItem, event: React.MouseEvent<HTMLDivElement>) => void
+  onNavigate?: () => void
 }

--- a/packages/web/src/routes/HomeRoute/components/NoiseSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/NoiseSection/index.tsx
@@ -53,7 +53,8 @@ export const NoiseSection: React.FC<INoiseSectionProps> = ({
   noiseCounts,
   isLoading,
   noiseView,
-  onNoiseViewChange
+  onNoiseViewChange,
+  onNavigate
 }) => {
   const renderContent = () => {
     if (isLoading) {
@@ -100,6 +101,7 @@ export const NoiseSection: React.FC<INoiseSectionProps> = ({
       count={noiseCounts.totalCount}
       accentGradient={SECTION_GRADIENTS.noise}
       accentBadgeColor="rgba(247, 151, 30, 0.12)"
+      onHeaderClick={onNavigate}
     >
       {renderContent()}
     </SectionCard>

--- a/packages/web/src/routes/HomeRoute/components/NoiseSection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/NoiseSection/types.ts
@@ -8,4 +8,5 @@ export interface INoiseSectionProps {
   isLoading: boolean
   noiseView: NoiseView
   onNoiseViewChange: (view: NoiseView) => void
+  onNavigate?: () => void
 }

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -8,6 +8,7 @@ import { useMealPlanContext, MealPlanProvider } from '../../providers/MealPlanPr
 import { useRecipeContext, RecipeProvider } from '../../providers/RecipeProvider'
 import { useAppState } from '../../providers/AppStateProvider'
 import { useProjectContext } from '../../providers/ProjectProvider'
+import { useShopContext } from '../../providers/ShopProvider'
 import { AgentChatProvider } from '../../providers/AgentChatProvider'
 import { IRecipe } from '../../types/recipe'
 import { updateToDoItems } from '../../api/toDoList'
@@ -53,6 +54,7 @@ const HomeDataContent = () => {
   const { recipes } = useRecipeContext()
   const { state: { purchasedItems }, dispatch } = useAppState()
   const { currentProject } = useProjectContext()
+  const { currentShop } = useShopContext()
   const navigate = useNavigate()
 
   const interactions = useHomeInteractions()
@@ -95,6 +97,18 @@ const HomeDataContent = () => {
     navigate(Route.EditPlannerItem.replace(':id', id))
   }, [navigate])
 
+  const handleGroceryNavigate = useCallback(() => {
+    if (currentShop) {
+      navigate(Route.GroceryList.replace(':shopId', currentShop.id))
+    } else {
+      navigate(Route.Shops)
+    }
+  }, [currentShop, navigate])
+
+  const handleNoiseNavigate = useCallback(() => {
+    navigate(Route.NoiseTracking)
+  }, [navigate])
+
   const handleStepToggle = useCallback(async (todoId: string, stepId: string, isDone: boolean) => {
     const item = toDoList.find(t => t.id === todoId)
     if (!item?.steps) return
@@ -127,6 +141,7 @@ const HomeDataContent = () => {
           groceryStats={homeData.groceryStats}
           isLoading={isGroceryLoading}
           onGroceryItemClick={interactions.handleGroceryItemClick}
+          onNavigate={handleGroceryNavigate}
         />
 
         <NoiseSection
@@ -135,6 +150,7 @@ const HomeDataContent = () => {
           isLoading={isNoiseLoading}
           noiseView={interactions.noiseView}
           onNoiseViewChange={interactions.handleNoiseViewChange}
+          onNavigate={handleNoiseNavigate}
         />
 
         <AgentMessageButton />


### PR DESCRIPTION
Clicking the header of the Grocery List widget navigates to the grocery
list (or shop selector if no shop is selected). Clicking the Noise
Recordings widget header navigates to the noise tracking page.

https://claude.ai/code/session_01HgxU6kJgA2Qison4LHHvZM