### PR TITLE
Add in-place expand/collapse to birthdays widget on home page

### DIFF
--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.styled.tsx
@@ -48,3 +48,13 @@ export const MoreCount = styled('div')(({ theme }) => ({
   color: theme.palette.text.secondary,
   fontWeight: 600,
 }))
+
+export const TaskSubLine = styled('div')(({ theme }) => ({
+  fontSize: '0.65rem',
+  color: theme.palette.text.secondary,
+  marginTop: '0.05rem',
+  marginBottom: '0.15rem',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import { Collapse } from '@mui/material'
 import { ITodoItem } from '../../../../../../api/toDoList/retrieve/types'
 import { getDueDateClass } from '../../../../../../utils/dateTime'
-import { TaskRow, TaskDot, TaskName, OverdueBadge, MoreCount } from './index.styled'
+import { TaskRow, TaskDot, TaskName, OverdueBadge, MoreCount, TaskSubLine } from './index.styled'
 
 interface ITodayTasksCardProps {
   sortedItems: ITodoItem[]
+  isExpanded?: boolean
 }
 
 const getTodayBounds = () => {
@@ -14,32 +16,62 @@ const getTodayBounds = () => {
   return { start, end }
 }
 
-export const TodayTasksCard: React.FC<ITodayTasksCardProps> = ({ sortedItems }) => {
+const getTaskSubLine = (item: ITodoItem): string | null => {
+  const parts: string[] = []
+  if (item.description) parts.push(item.description)
+  if (item.steps && item.steps.length > 0) {
+    const doneCount = item.steps.filter(s => s.isDone).length
+    parts.push(`${doneCount} / ${item.steps.length} steps`)
+  }
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
+const TaskEntry: React.FC<{ item: ITodoItem; showDetails: boolean }> = ({ item, showDetails }) => {
+  const subLine = getTaskSubLine(item)
+  return (
+    <div>
+      <TaskRow>
+        <TaskDot $class={getDueDateClass(item.dueDate)} />
+        <TaskName>{item.name}</TaskName>
+      </TaskRow>
+      {showDetails && subLine && <TaskSubLine>{subLine}</TaskSubLine>}
+    </div>
+  )
+}
+
+export const TodayTasksCard: React.FC<ITodayTasksCardProps> = ({ sortedItems, isExpanded = false }) => {
   const { start, end } = getTodayBounds()
 
   const overdueItems = sortedItems.filter(item => item.dueDate && item.dueDate < start)
   const todayItems = sortedItems.filter(item => item.dueDate && item.dueDate >= start && item.dueDate < end)
-  const displayItems = todayItems.slice(0, 3)
-  const moreCount = todayItems.length - displayItems.length
 
   if (todayItems.length === 0 && overdueItems.length === 0) {
     return <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>No tasks for today</span>
   }
+
+  const top3 = todayItems.slice(0, 3)
+  const rest = todayItems.slice(3)
 
   return (
     <>
       {overdueItems.length > 0 && (
         <OverdueBadge>{overdueItems.length} overdue</OverdueBadge>
       )}
-      {displayItems.map(item => (
-        <TaskRow key={item.id}>
-          <TaskDot $class={getDueDateClass(item.dueDate)} />
-          <TaskName>{item.name}</TaskName>
-        </TaskRow>
-      ))}
-      {moreCount > 0 && <MoreCount>+{moreCount} more</MoreCount>}
       {todayItems.length === 0 && overdueItems.length > 0 && (
         <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>No tasks due today</span>
+      )}
+      {top3.map(item => (
+        <TaskEntry key={item.id} item={item} showDetails={isExpanded} />
+      ))}
+      {rest.length > 0 && (
+        <>
+          <Collapse in={isExpanded} timeout={150}>
+            {rest.map(item => (
+              <TaskEntry key={item.id} item={item} showDetails={isExpanded} />
+            ))}
+          </Collapse>
+          {!isExpanded && <MoreCount>+{rest.length} more</MoreCount>}
+        </>
       )}
     </>
   )

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TodayTasksCard/index.tsx
@@ -65,7 +65,7 @@ export const TodayTasksCard: React.FC<ITodayTasksCardProps> = ({ sortedItems, is
       ))}
       {rest.length > 0 && (
         <>
-          <Collapse in={isExpanded} timeout={150}>
+          <Collapse in={isExpanded} timeout={150} unmountOnExit>
             {rest.map(item => (
               <TaskEntry key={item.id} item={item} showDetails={isExpanded} />
             ))}

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.styled.tsx
@@ -24,3 +24,19 @@ export const DaysUntil = styled('span')<{ $isToday?: boolean }>(({ theme, $isTod
   color: $isToday ? '#f093fb' : theme.palette.text.secondary,
   whiteSpace: 'nowrap',
 }))
+
+export const BirthdaySubLine = styled('div')(({ theme }) => ({
+  fontSize: '0.65rem',
+  color: theme.palette.text.secondary,
+  marginTop: '0.05rem',
+  marginBottom: '0.15rem',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}))
+
+export const MoreCount = styled('div')(({ theme }) => ({
+  fontSize: '0.7rem',
+  color: theme.palette.text.secondary,
+  fontWeight: 600,
+}))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
+import { Collapse } from '@mui/material'
 import { IBirthdayItem } from '../../../../../../api/birthdays/retrieve/types'
-import { BirthdayRow, BirthdayName, DaysUntil } from './index.styled'
+import { BirthdayRow, BirthdayName, DaysUntil, BirthdaySubLine, MoreCount } from './index.styled'
 
 interface IUpcomingBirthdaysCardProps {
   birthdays: IBirthdayItem[]
+  isExpanded?: boolean
 }
 
 const getNextBirthdayDate = (birthday: IBirthdayItem): Date => {
@@ -27,7 +29,37 @@ const getDaysUntilLabel = (nextDate: Date): { label: string; isToday: boolean } 
   return { label: `in ${diffDays}d`, isToday: false }
 }
 
-export const UpcomingBirthdaysCard: React.FC<IUpcomingBirthdaysCardProps> = ({ birthdays }) => {
+const getAgeLabel = (birthday: IBirthdayItem): string | null => {
+  if (!birthday.birthYear) return null
+  const today = new Date()
+  const thisYear = today.getFullYear()
+  const todayMidnight = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+  const birthdayThisYear = new Date(thisYear, birthday.month - 1, birthday.day)
+  const age = thisYear - birthday.birthYear
+  if (birthdayThisYear.getTime() === todayMidnight.getTime()) return `${age} today! 🎉`
+  if (birthdayThisYear.getTime() < todayMidnight.getTime()) return `${age} years old`
+  return `turns ${age}`
+}
+
+type SortedBirthday = IBirthdayItem & { nextDate: Date }
+
+const BirthdayEntry: React.FC<{ b: SortedBirthday; showDetails: boolean }> = ({ b, showDetails }) => {
+  const { label, isToday } = getDaysUntilLabel(b.nextDate)
+  const ageLabel = getAgeLabel(b)
+  const subLine = [ageLabel, b.notes].filter(Boolean).join(' · ')
+
+  return (
+    <div>
+      <BirthdayRow>
+        <BirthdayName>{b.name}</BirthdayName>
+        <DaysUntil $isToday={isToday}>{label}</DaysUntil>
+      </BirthdayRow>
+      {showDetails && subLine && <BirthdaySubLine>{subLine}</BirthdaySubLine>}
+    </div>
+  )
+}
+
+export const UpcomingBirthdaysCard: React.FC<IUpcomingBirthdaysCardProps> = ({ birthdays, isExpanded = false }) => {
   if (birthdays.length === 0) {
     return <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>No birthdays saved</span>
   }
@@ -35,19 +67,25 @@ export const UpcomingBirthdaysCard: React.FC<IUpcomingBirthdaysCardProps> = ({ b
   const sorted = [...birthdays]
     .map(b => ({ ...b, nextDate: getNextBirthdayDate(b) }))
     .sort((a, b) => a.nextDate.getTime() - b.nextDate.getTime())
-    .slice(0, 3)
+
+  const top3 = sorted.slice(0, 3)
+  const rest = sorted.slice(3)
 
   return (
     <>
-      {sorted.map(b => {
-        const { label, isToday } = getDaysUntilLabel(b.nextDate)
-        return (
-          <BirthdayRow key={b.id}>
-            <BirthdayName>{b.name}</BirthdayName>
-            <DaysUntil $isToday={isToday}>{label}</DaysUntil>
-          </BirthdayRow>
-        )
-      })}
+      {top3.map(b => (
+        <BirthdayEntry key={b.id} b={b} showDetails={isExpanded} />
+      ))}
+      {rest.length > 0 && (
+        <>
+          <Collapse in={isExpanded} timeout={150}>
+            {rest.map(b => (
+              <BirthdayEntry key={b.id} b={b} showDetails={isExpanded} />
+            ))}
+          </Collapse>
+          {!isExpanded && <MoreCount>+{rest.length} more</MoreCount>}
+        </>
+      )}
     </>
   )
 }

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
@@ -78,7 +78,7 @@ export const UpcomingBirthdaysCard: React.FC<IUpcomingBirthdaysCardProps> = ({ b
       ))}
       {rest.length > 0 && (
         <>
-          <Collapse in={isExpanded} timeout={150}>
+          <Collapse in={isExpanded} timeout={150} unmountOnExit>
             {rest.map(b => (
               <BirthdayEntry key={b.id} b={b} showDetails={isExpanded} />
             ))}

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { Box } from '@mui/material'
 import ChecklistIcon from '@mui/icons-material/Checklist'
 import CakeIcon from '@mui/icons-material/Cake'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { IToDoSectionProps } from './types'
 import TodayTasksCard from './components/TodayTasksCard'
 import TodayMealCard from './components/TodayMealCard'
@@ -23,6 +25,8 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
   isLoading,
   onMealClick,
 }) => {
+  const [isBirthdaysExpanded, setIsBirthdaysExpanded] = useState(false)
+
   return (
     <MiniCardsGrid>
       <MiniCard sx={{ gridColumn: '1 / 3', gridRow: 1, minHeight: 'unset' }}>
@@ -41,14 +45,29 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
         </MiniCardContent>
       </MiniCard>
 
-      <MiniCard sx={{ gridColumn: 2, gridRow: 2 }}>
+      <MiniCard
+        sx={{ gridColumn: 2, gridRow: 2, cursor: 'pointer' }}
+        onClick={() => setIsBirthdaysExpanded(v => !v)}
+      >
         <MiniCardContent>
           <MiniCardHeader>
             <MiniCardIcon><CakeIcon /></MiniCardIcon>
             <MiniCardTitle>Birthdays</MiniCardTitle>
+            <Box
+              sx={{
+                ml: 'auto',
+                display: 'flex',
+                alignItems: 'center',
+                transition: 'transform 150ms ease',
+                transform: isBirthdaysExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                opacity: 0.6,
+              }}
+            >
+              <ExpandMoreIcon sx={{ fontSize: '0.9rem' }} />
+            </Box>
           </MiniCardHeader>
           <MiniCardBody>
-            <UpcomingBirthdaysCard birthdays={birthdays} />
+            <UpcomingBirthdaysCard birthdays={birthdays} isExpanded={isBirthdaysExpanded} />
           </MiniCardBody>
         </MiniCardContent>
       </MiniCard>

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -26,6 +26,7 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
   onMealClick,
 }) => {
   const [isBirthdaysExpanded, setIsBirthdaysExpanded] = useState(false)
+  const [isTodayTasksExpanded, setIsTodayTasksExpanded] = useState(false)
 
   return (
     <MiniCardsGrid>
@@ -33,14 +34,29 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
         <TodayMealCard todayMeals={todayMeals} isLoading={isLoading} onMealClick={onMealClick} />
       </MiniCard>
 
-      <MiniCard sx={{ gridColumn: 1, gridRow: 2 }}>
+      <MiniCard
+        sx={{ gridColumn: 1, gridRow: 2, cursor: 'pointer' }}
+        onClick={() => setIsTodayTasksExpanded(v => !v)}
+      >
         <MiniCardContent>
           <MiniCardHeader>
             <MiniCardIcon><ChecklistIcon /></MiniCardIcon>
             <MiniCardTitle>Today's Tasks</MiniCardTitle>
+            <Box
+              sx={{
+                ml: 'auto',
+                display: 'flex',
+                alignItems: 'center',
+                transition: 'transform 150ms ease',
+                transform: isTodayTasksExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                opacity: 0.6,
+              }}
+            >
+              <ExpandMoreIcon sx={{ fontSize: '0.9rem' }} />
+            </Box>
           </MiniCardHeader>
           <MiniCardBody>
-            <TodayTasksCard sortedItems={toDoStats.sortedItems} />
+            <TodayTasksCard sortedItems={toDoStats.sortedItems} isExpanded={isTodayTasksExpanded} />
           </MiniCardBody>
         </MiniCardContent>
       </MiniCard>


### PR DESCRIPTION
Clicking the birthday card expands it vertically to reveal all birthdays
beyond the top 3, with age info and notes shown for each entry. A
rotating chevron in the card header indicates the expandable state.

https://claude.ai/code/session_018WYv4qW5UTKBbwxZwSdAor