### PR TITLE
Add shop icons to home page grocery items and extract reusable ShopIconBadge component

### DIFF
--- a/packages/web/src/components/GroceryItem/index.styled.tsx
+++ b/packages/web/src/components/GroceryItem/index.styled.tsx
@@ -136,21 +136,3 @@ export const DeleteButtonIcon = styled('button')({
   border: 'none',
   cursor: 'pointer',
 })
-
-export const ShopIndicatorBadge = styled('div')({
-  position: 'absolute',
-  bottom: '-4px',
-  right: '-4px',
-  width: '20px',
-  height: '20px',
-  borderRadius: '50%',
-  backgroundColor: '#ffffff',
-  border: '2px solid #ffffff',
-  boxShadow: '0 1px 3px rgba(0, 0, 0, 0.2)',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  overflow: 'hidden',
-  zIndex: 1,
-  flexShrink: 0,
-})

--- a/packages/web/src/components/GroceryItem/index.tsx
+++ b/packages/web/src/components/GroceryItem/index.tsx
@@ -1,14 +1,14 @@
-import { Container, ActionArea, Content, Media, Name, ActionContainer, DeleteButtonIcon, QuantityDisplay, QuantityText, UnitText, ShopIndicatorBadge } from './index.styled'
+import { Container, ActionArea, Content, Media, Name, ActionContainer, DeleteButtonIcon, QuantityDisplay, QuantityText, UnitText } from './index.styled'
 import { IGroceryItemProps } from './types'
 import { useAppState } from '../../providers/AppStateProvider';
 import { ActionName } from '../../providers/AppStateProvider/enums';
 import { useMemo, useCallback, memo } from 'react';
 import AddIcon from '@mui/icons-material/Add';
 import RemoveIcon from '@mui/icons-material/Remove';
-import StorefrontIcon from '@mui/icons-material/Storefront';
 import { useGroceryListContext } from '../../providers/GroceryListProvider';
 import { useShopContext } from '../../providers/ShopProvider';
 import { ActionButton } from '../ActionButton';
+import ShopIconBadge from '../ShopIconBadge';
 
 const GroceryItem = memo(({ id, name, quantity, imagePath, unit, shopId }: IGroceryItemProps) => {
   const { state: { purchasedItems }, dispatch } = useAppState()
@@ -65,17 +65,7 @@ const GroceryItem = memo(({ id, name, quantity, imagePath, unit, shopId }: IGroc
       >  
         <Media image={imagePath} sx={imagePath ? { backgroundImage: `url(${imagePath})` } : undefined}>
           {shopForBadge && (
-            <ShopIndicatorBadge>
-              {shopForBadge.icon ? (
-                <img
-                  src={shopForBadge.icon}
-                  alt={shopForBadge.name}
-                  style={{ width: '100%', height: '100%', objectFit: 'contain', borderRadius: '50%' }}
-                />
-              ) : (
-                <StorefrontIcon sx={{ fontSize: '12px', color: 'rgba(0,0,0,0.5)' }} />
-              )}
-            </ShopIndicatorBadge>
+            <ShopIconBadge shop={shopForBadge} size={20} bottom="-4px" right="-4px" />
           )}
         </Media>
         <Content>

--- a/packages/web/src/components/ShopIconBadge/index.tsx
+++ b/packages/web/src/components/ShopIconBadge/index.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import StorefrontIcon from '@mui/icons-material/Storefront'
+import { styled } from '@mui/material/styles'
+import { IShop } from '../../providers/AppStateProvider/types'
+
+interface IShopIconBadgeProps {
+  shop: IShop
+  size?: number
+  bottom?: number | string
+  right?: number | string
+}
+
+const Badge = styled('div')<{ size: number; bottom: number | string; right: number | string }>(
+  ({ size, bottom, right }) => ({
+    position: 'absolute',
+    bottom,
+    right,
+    width: `${size}px`,
+    height: `${size}px`,
+    borderRadius: '50%',
+    backgroundColor: '#ffffff',
+    border: '1.5px solid #ffffff',
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.2)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+    zIndex: 1,
+    flexShrink: 0,
+  })
+)
+
+const ShopIconBadge: React.FC<IShopIconBadgeProps> = ({
+  shop,
+  size = 20,
+  bottom = '-4px',
+  right = '-4px',
+}) => {
+  return (
+    <Badge size={size} bottom={bottom} right={right}>
+      {shop.icon ? (
+        <img
+          src={shop.icon}
+          alt={shop.name}
+          style={{ width: '100%', height: '100%', objectFit: 'contain', borderRadius: '50%' }}
+        />
+      ) : (
+        <StorefrontIcon sx={{ fontSize: `${Math.round(size * 0.6)}px`, color: 'rgba(0,0,0,0.5)' }} />
+      )}
+    </Badge>
+  )
+}
+
+export default ShopIconBadge

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/components/GroceryStatsGrid/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/components/GroceryStatsGrid/index.tsx
@@ -4,28 +4,36 @@ import {
   GroceryStats,
   GroceryImagesGrid,
   GroceryImageItem,
-  GroceryImageOverflow
+  GroceryImageOverflow,
 } from './index.styled'
+import ShopIconBadge from '../../../../../../components/ShopIconBadge'
 
 export const GroceryStatsGrid: React.FC<IGroceryStatsGridProps> = ({
   groceryStats,
+  shops,
   onGroceryItemClick
 }) => {
   return (
     <GroceryStats>
       <GroceryImagesGrid itemCount={groceryStats.displayItems.length}>
-        {groceryStats.displayItems.map((item) => (
-          <GroceryImageItem
-            key={item.id}
-            style={{
-              backgroundImage: item.imagePath ? `url(${item.imagePath})` : 'none'
-            }}
-            title={`${item.name} (${item.quantity} ${item.unit})`}
-            onClick={(event) => onGroceryItemClick(item, event)}
-          >
-            {!item.imagePath && item.name.charAt(0).toUpperCase()}
-          </GroceryImageItem>
-        ))}
+        {groceryStats.displayItems.map((item) => {
+          const shop = shops.find(s => s.id === item.shopId) ?? null
+          return (
+            <GroceryImageItem
+              key={item.id}
+              style={{
+                backgroundImage: item.imagePath ? `url(${item.imagePath})` : 'none'
+              }}
+              title={`${item.name} (${item.quantity} ${item.unit})`}
+              onClick={(event) => onGroceryItemClick(item, event)}
+            >
+              {!item.imagePath && item.name.charAt(0).toUpperCase()}
+              {shop && (
+                <ShopIconBadge shop={shop} size={16} bottom="2px" right="2px" />
+              )}
+            </GroceryImageItem>
+          )
+        })}
         {groceryStats.hasOverflow && (
           <GroceryImageOverflow title={`+${groceryStats.unpurchasedItems.length - 9} more items`}>
             +{groceryStats.unpurchasedItems.length - 9}

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/components/GroceryStatsGrid/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/components/GroceryStatsGrid/types.ts
@@ -1,7 +1,8 @@
-import { IGroceryItem } from '../../../../../../providers/AppStateProvider/types'
+import { IGroceryItem, IShop } from '../../../../../../providers/AppStateProvider/types'
 import { IGroceryStats } from '../../../../../../hooks/useHomeData/types'
 
 export interface IGroceryStatsGridProps {
   groceryStats: IGroceryStats
+  shops: IShop[]
   onGroceryItemClick: (item: IGroceryItem, event: React.MouseEvent<HTMLDivElement>) => void
 }

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/index.test.tsx
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/index.test.tsx
@@ -48,6 +48,7 @@ describe('GrocerySection component', () => {
       renderWithTheme(
         <GrocerySection
           groceryStats={groceryStats}
+          shops={[]}
           isLoading={true}
           onGroceryItemClick={mockOnGroceryItemClick}
         />
@@ -65,11 +66,13 @@ describe('GrocerySection component', () => {
       renderWithTheme(
         <GrocerySection
           groceryStats={groceryStats}
+          shops={[]}
+          shops={[]}
           isLoading={false}
           onGroceryItemClick={mockOnGroceryItemClick}
         />
       )
-      
+
       expect(screen.getByText('No grocery items found')).toBeInTheDocument()
     })
   })
@@ -92,6 +95,7 @@ describe('GrocerySection component', () => {
       renderWithTheme(
         <GrocerySection
           groceryStats={groceryStats}
+          shops={[]}
           isLoading={false}
           onGroceryItemClick={mockOnGroceryItemClick}
         />
@@ -119,6 +123,7 @@ describe('GrocerySection component', () => {
       renderWithTheme(
         <GrocerySection
           groceryStats={groceryStats}
+          shops={[]}
           isLoading={false}
           onGroceryItemClick={mockOnGroceryItemClick}
         />
@@ -139,6 +144,7 @@ describe('GrocerySection component', () => {
       renderWithTheme(
         <GrocerySection
           groceryStats={groceryStats}
+          shops={[]}
           isLoading={false}
           onGroceryItemClick={mockOnGroceryItemClick}
         />
@@ -166,6 +172,7 @@ describe('GrocerySection component', () => {
       renderWithTheme(
         <GrocerySection
           groceryStats={groceryStats}
+          shops={[]}
           isLoading={false}
           onGroceryItemClick={mockOnGroceryItemClick}
         />
@@ -195,6 +202,7 @@ describe('GrocerySection component', () => {
       renderWithTheme(
         <GrocerySection
           groceryStats={groceryStats}
+          shops={[]}
           isLoading={false}
           onGroceryItemClick={mockOnGroceryItemClick}
         />

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/index.tsx
@@ -9,6 +9,7 @@ import { SECTION_GRADIENTS } from '../../../../constants/sectionColors'
 
 export const GrocerySection: React.FC<IGrocerySectionProps> = ({
   groceryStats,
+  shops,
   isLoading,
   onGroceryItemClick,
   onNavigate
@@ -29,6 +30,7 @@ export const GrocerySection: React.FC<IGrocerySectionProps> = ({
           {groceryStats.totalItems > 0 ? (
             <GroceryStatsGrid
               groceryStats={groceryStats}
+              shops={shops}
               onGroceryItemClick={onGroceryItemClick}
             />
           ) : (

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/types.ts
@@ -1,8 +1,9 @@
-import { IGroceryItem } from '../../../../providers/AppStateProvider/types'
+import { IGroceryItem, IShop } from '../../../../providers/AppStateProvider/types'
 import { IGroceryStats } from '../../../../hooks/useHomeData/types'
 
 export interface IGrocerySectionProps {
   groceryStats: IGroceryStats
+  shops: IShop[]
   isLoading: boolean
   onGroceryItemClick: (item: IGroceryItem, event: React.MouseEvent<HTMLDivElement>) => void
   onNavigate?: () => void

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -54,7 +54,7 @@ const HomeDataContent = () => {
   const { recipes } = useRecipeContext()
   const { state: { purchasedItems }, dispatch } = useAppState()
   const { currentProject } = useProjectContext()
-  const { currentShop } = useShopContext()
+  const { currentShop, shops } = useShopContext()
   const navigate = useNavigate()
 
   const interactions = useHomeInteractions()
@@ -139,6 +139,7 @@ const HomeDataContent = () => {
 
         <GrocerySection
           groceryStats={homeData.groceryStats}
+          shops={shops}
           isLoading={isGroceryLoading}
           onGroceryItemClick={interactions.handleGroceryItemClick}
           onNavigate={handleGroceryNavigate}


### PR DESCRIPTION
- Home page item grid now shows a shop icon badge on each item, matching the behaviour in the all-items view
- Created shared ShopIconBadge component (size/position configurable) used by both GroceryItem and GroceryStatsGrid
- Removed duplicated ShopIndicatorBadge styled component from GroceryItem now that the logic lives in the shared component
- Passed full shops list from ShopProvider through GrocerySection down to GroceryStatsGrid

https://claude.ai/code/session_01N8EjgTZ5GtW2UNqb1738sF