### PR TITLE
Make recipe form action buttons sticky at bottom of drawer

### DIFF
--- a/packages/web/src/components/RecipeForm/index.styled.tsx
+++ b/packages/web/src/components/RecipeForm/index.styled.tsx
@@ -22,10 +22,20 @@ export const IngredientsSection = styled(Box)({
 })
 
 export const FormActions = styled(Box)({
+  position: 'sticky',
+  bottom: 0,
   display: 'flex',
   gap: '0.75rem',
   justifyContent: 'flex-end',
-  paddingTop: '0.5rem',
+  paddingTop: '0.75rem',
+  paddingBottom: '0.75rem',
+  marginTop: 'auto',
+  background: 'white',
+  borderTop: '1px solid rgba(0, 0, 0, 0.08)',
+  marginLeft: '-1.25rem',
+  marginRight: '-1.25rem',
+  paddingLeft: '1.25rem',
+  paddingRight: '1.25rem',
 })
 
 export const ImageUploadBox = styled(Box)({


### PR DESCRIPTION
Scrolling long recipes no longer requires reaching the bottom to save. FormActions uses position:sticky so Save/Cancel/Delete remain visible at all times inside the scrollable ContentContainer.