### PR TITLE
Optimize CI workflows to reduce GitHub Actions minutes

### DIFF
--- a/.github/workflows/publish-lambdas.yml
+++ b/.github/workflows/publish-lambdas.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "packages/lambdas/**"
 
+concurrency:
+  group: publish-lambdas
+  cancel-in-progress: false
+
 jobs:
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -7,6 +7,10 @@ on:
       - "packages/web/**"
       - ".github/workflows/publish-web.yml"
 
+concurrency:
+  group: publish-web
+  cancel-in-progress: false
+
 jobs:
   upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-lambdas.yml
+++ b/.github/workflows/test-lambdas.yml
@@ -1,9 +1,17 @@
-name: Test Website
+name: Test Lambdas
 
 on:
-  push:
+  pull_request:
     paths:
       - "packages/lambdas/**"
+      - ".github/workflows/test-lambdas.yml"
+    paths-ignore:
+      - "packages/lambdas/**/*.md"
+      - "packages/lambdas/LICENSE"
+
+concurrency:
+  group: test-lambdas-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -1,9 +1,17 @@
 name: Test Website
 
 on:
-  push:
+  pull_request:
     paths:
       - "packages/web/**"
+      - ".github/workflows/test-web.yml"
+    paths-ignore:
+      - "packages/web/**/*.md"
+      - "packages/web/LICENSE"
+
+concurrency:
+  group: test-web-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
- Switch test workflows from push to pull_request triggers only
- Add paths-ignore for markdown/LICENSE files
- Add concurrency groups with cancel-in-progress for test workflows
- Add concurrency groups for publish workflows (no cancel)
- Fix test-lambdas workflow name (was "Test Website")