### PR TITLE
fix: lift adventure widget text above carousel dots

### DIFF
--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingAdventureCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingAdventureCard/index.styled.tsx
@@ -97,7 +97,7 @@ export const HeroOverlay = styled(Box)({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'flex-end',
-  padding: '1rem 1.1rem 0.9rem',
+  padding: '1rem 1.1rem 1.75rem',
   gap: '0.35rem',
 })
 


### PR DESCRIPTION
Increase HeroOverlay bottom padding from 0.9rem to 1.75rem so the
label, title and meta text sit clearly above the carousel dot
indicators rather than overlapping them.

Note: the date-range label (e.g. "Today – Friday") is already rendered
via getDayLabel when an endDate is set; no logic change was needed.

https://claude.ai/code/session_01RhCy4NaEj3VWqTGm9UxPM4