### PR TITLE
Show fetch error messages instead of empty defaults on home page

### DIFF
--- a/packages/web/src/api/birthdays/retrieve/index.ts
+++ b/packages/web/src/api/birthdays/retrieve/index.ts
@@ -9,5 +9,5 @@ export const retrieveBirthdays = async (projectId?: string): Promise<Array<IBirt
     return await response.json()
   }
 
-  return []
+  throw new Error(`Failed to fetch birthdays: ${response.status}`)
 }

--- a/packages/web/src/api/groceryList/retrieve/index.ts
+++ b/packages/web/src/api/groceryList/retrieve/index.ts
@@ -14,7 +14,7 @@ export const retrieveGroceryList = async (projectId?: string, shopId?: string): 
     return await response.json()
   }
 
-  return []
+  throw new Error(`Failed to fetch grocery list: ${response.status}`)
 }
 
 export const retrieveGroceryListDefaults = async (projectId?: string): Promise<Array<IDBGroceryItemDefault>> => {

--- a/packages/web/src/api/toDoList/retrieve/index.ts
+++ b/packages/web/src/api/toDoList/retrieve/index.ts
@@ -9,6 +9,6 @@ export const retrieveToDoList = async (projectId?: string): Promise<Array<ITodoI
     return await response.json()
   }
 
-  return []
+  throw new Error(`Failed to fetch to do list: ${response.status}`)
 }
 

--- a/packages/web/src/providers/BirthdayProvider/index.tsx
+++ b/packages/web/src/providers/BirthdayProvider/index.tsx
@@ -11,6 +11,7 @@ import { useProjectContext } from '../ProjectProvider'
 interface IBirthdayContext {
   birthdays: IBirthdayItem[]
   isLoading: boolean
+  isError: boolean
   addBirthdayItem: (item: Omit<IBirthdayItem, 'id'>) => Promise<void>
   updateBirthdayItem: (id: string, fields: BirthdayUpdateFields) => Promise<void>
   removeBirthdayItem: (id: string) => Promise<void>
@@ -20,6 +21,7 @@ interface IBirthdayContext {
 const initialState: IBirthdayContext = {
   birthdays: [],
   isLoading: false,
+  isError: false,
   addBirthdayItem: async () => {},
   updateBirthdayItem: async () => {},
   removeBirthdayItem: async () => {},
@@ -81,11 +83,12 @@ export const BirthdayProvider = ({ children }: StateComponentProps) => {
   const value = useMemo(() => ({
     birthdays,
     isLoading: query.isLoading,
+    isError: query.isError,
     addBirthdayItem,
     updateBirthdayItem,
     removeBirthdayItem,
     refetchBirthdays,
-  }), [birthdays, query.isLoading, addBirthdayItem, updateBirthdayItem, removeBirthdayItem, refetchBirthdays])
+  }), [birthdays, query.isLoading, query.isError, addBirthdayItem, updateBirthdayItem, removeBirthdayItem, refetchBirthdays])
 
   return (
     <BirthdayContext.Provider value={value}>

--- a/packages/web/src/providers/GroceryListProvider/index.tsx
+++ b/packages/web/src/providers/GroceryListProvider/index.tsx
@@ -10,6 +10,7 @@ import { useProjectContext } from '../ProjectProvider'
 export const initialState: IState = {
   groceryList: [],
   isLoading: false,
+  isError: false,
   isAllItemsView: false,
   viewMode: GroceryViewMode.CATEGORIZED,
   refetchGroceryList: async () => {},
@@ -117,6 +118,7 @@ export const GroceryListProvider = ({ children, shopId }: IGroceryListProviderPr
     () => ({
       groceryList,
       isLoading: query.isLoading,
+      isError: query.isError,
       isAllItemsView,
       viewMode,
       refetchGroceryList,
@@ -125,7 +127,7 @@ export const GroceryListProvider = ({ children, shopId }: IGroceryListProviderPr
       updateGroceryItemFields: updateGroceryItemWithFields,
       setViewMode: handleSetViewMode,
     }),
-    [groceryList, query.isLoading, isAllItemsView, viewMode, refetchGroceryList, removeGroceryItem, updateGroceryItemQuantity, updateGroceryItemWithFields, handleSetViewMode]
+    [groceryList, query.isLoading, query.isError, isAllItemsView, viewMode, refetchGroceryList, removeGroceryItem, updateGroceryItemQuantity, updateGroceryItemWithFields, handleSetViewMode]
   )
 
   return (

--- a/packages/web/src/providers/GroceryListProvider/types.ts
+++ b/packages/web/src/providers/GroceryListProvider/types.ts
@@ -11,6 +11,7 @@ export interface IGroceryListProviderProps {
 export interface IState {
     groceryList: Array<IGroceryItem>
     isLoading: boolean
+    isError: boolean
     isAllItemsView: boolean
     viewMode: GroceryViewMode
     refetchGroceryList: () => Promise<void>

--- a/packages/web/src/providers/PlannerProvider/index.tsx
+++ b/packages/web/src/providers/PlannerProvider/index.tsx
@@ -9,6 +9,7 @@ import { useProjectContext } from '../ProjectProvider'
 export const initialState: IState = {
   toDoList: [],
   isLoading: false,
+  isError: false,
   refetchToDoList: async () => {},
   removeFromToDoList: () => {},
   updateToDoItemFields: async () => {},
@@ -65,11 +66,12 @@ export const PlannerProvider = ({ children }: StateComponentProps) => {
     () => ({
       toDoList,
       isLoading: query.isLoading,
+      isError: query.isError,
       refetchToDoList,
       removeFromToDoList,
       updateToDoItemFields: updateToDoItemFieldsHandler,
     }),
-    [toDoList, query.isLoading, refetchToDoList, removeFromToDoList, updateToDoItemFieldsHandler]
+    [toDoList, query.isLoading, query.isError, refetchToDoList, removeFromToDoList, updateToDoItemFieldsHandler]
   )
 
   return (

--- a/packages/web/src/providers/PlannerProvider/types.ts
+++ b/packages/web/src/providers/PlannerProvider/types.ts
@@ -9,6 +9,7 @@ export interface IGroceryListProviderProps {
 export interface IState {
     toDoList: Array<ITodoItem>
     isLoading: boolean
+    isError: boolean
     refetchToDoList: () => Promise<void>
     removeFromToDoList: (id: string) => void
     updateToDoItemFields: (id: string, fields: ToDoItemUpdateFields) => Promise<void>

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/index.tsx
@@ -11,6 +11,7 @@ export const GrocerySection: React.FC<IGrocerySectionProps> = ({
   groceryStats,
   shops,
   isLoading,
+  isError,
   onGroceryItemClick,
   onNavigate
 }) => {
@@ -34,7 +35,7 @@ export const GrocerySection: React.FC<IGrocerySectionProps> = ({
               onGroceryItemClick={onGroceryItemClick}
             />
           ) : (
-            <EmptyState>No grocery items found</EmptyState>
+            <EmptyState>{isError ? 'Unable to load grocery items' : 'No grocery items found'}</EmptyState>
           )}
         </>
       )}

--- a/packages/web/src/routes/HomeRoute/components/GrocerySection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/GrocerySection/types.ts
@@ -5,6 +5,7 @@ export interface IGrocerySectionProps {
   groceryStats: IGroceryStats
   shops: IShop[]
   isLoading: boolean
+  isError: boolean
   onGroceryItemClick: (item: IGroceryItem, event: React.MouseEvent<HTMLDivElement>) => void
   onNavigate?: () => void
 }

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskList/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskList/index.tsx
@@ -10,15 +10,16 @@ const DEFAULT_VISIBLE = 2
 
 interface TaskListProps {
   items: ITodoItem[]
+  isError?: boolean
   onStepToggle: (todoId: string, stepId: string, isDone: boolean) => void
   onCardClick: (item: ITodoItem) => void
 }
 
-const TaskList: React.FC<TaskListProps> = ({ items, onStepToggle, onCardClick }) => {
+const TaskList: React.FC<TaskListProps> = ({ items, isError, onStepToggle, onCardClick }) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
   if (items.length === 0) {
-    return <EmptyMessage>No tasks planned — enjoy the day!</EmptyMessage>
+    return <EmptyMessage>{isError ? 'Unable to load tasks' : 'No tasks planned — enjoy the day!'}</EmptyMessage>
   }
 
   const visibleItems = items.slice(0, DEFAULT_VISIBLE)

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
@@ -18,6 +18,7 @@ import {
 interface IUpcomingBirthdaysCardProps {
   birthdays: IBirthdayItem[]
   isExpanded?: boolean
+  isError?: boolean
 }
 
 const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' })
@@ -66,9 +67,9 @@ const BirthdayEntry: React.FC<{ b: SortedBirthday; showDetails: boolean }> = ({ 
   )
 }
 
-export const UpcomingBirthdaysCard: React.FC<IUpcomingBirthdaysCardProps> = ({ birthdays, isExpanded = false }) => {
+export const UpcomingBirthdaysCard: React.FC<IUpcomingBirthdaysCardProps> = ({ birthdays, isExpanded = false, isError = false }) => {
   if (birthdays.length === 0) {
-    return <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>No birthdays saved</span>
+    return <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>{isError ? 'Unable to load birthdays' : 'No birthdays saved'}</span>
   }
 
   const sorted = [...birthdays]

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -13,6 +13,7 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
   todayMeals,
   upcomingAdventures,
   isLoading,
+  isError,
   onStepToggle,
   onCardClick,
   onMealClick,
@@ -40,6 +41,7 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
       >
         <TaskList
           items={toDoStats.sortedItems}
+          isError={isError}
           onStepToggle={onStepToggle}
           onCardClick={onCardClick}
         />

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
@@ -12,6 +12,7 @@ export interface IToDoSectionProps {
   todayMeals: ITodayMealItem[]
   upcomingAdventures: IAdventure[]
   isLoading: boolean
+  isError: boolean
   onStepToggle: (todoId: string, stepId: string, isDone: boolean) => void
   onCardClick: (item: ITodoItem) => void
   onMealClick?: (meal: ITodayMealItem) => void

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -58,10 +58,10 @@ const getUpcomingDateStrings = (days = 7): string[] => {
 }
 
 const HomeDataContent = () => {
-  const { groceryList, isLoading: isGroceryLoading } = useGroceryListContext()
-  const { toDoList, isLoading: isToDoLoading, removeFromToDoList, updateToDoItemFields } = usePlannerContext()
+  const { groceryList, isLoading: isGroceryLoading, isError: isGroceryError } = useGroceryListContext()
+  const { toDoList, isLoading: isToDoLoading, isError: isToDoError, removeFromToDoList, updateToDoItemFields } = usePlannerContext()
   const { noiseTrackingItems, isLoading: isNoiseLoading } = useNoiseTrackingContext()
-  const { birthdays } = useBirthdayContext()
+  const { birthdays, isError: isBirthdayError } = useBirthdayContext()
   const { mealPlans, isLoading: isMealLoading } = useMealPlanContext()
   const { adventures, isLoading: isAdventureLoading, removeAdventure } = useAdventureContext()
   const { recipes } = useRecipeContext()
@@ -161,6 +161,7 @@ const HomeDataContent = () => {
           todayMeals={todayMeals}
           upcomingAdventures={upcomingAdventures}
           isLoading={isToDoLoading || isMealLoading || isAdventureLoading}
+          isError={isToDoError}
           onStepToggle={handleStepToggle}
           onCardClick={interactions.handleToDoItemSelect}
           onMealClick={handleMealClick}
@@ -171,6 +172,7 @@ const HomeDataContent = () => {
           groceryStats={homeData.groceryStats}
           shops={shops}
           isLoading={isGroceryLoading}
+          isError={isGroceryError}
           onGroceryItemClick={interactions.handleGroceryItemClick}
           onNavigate={handleGroceryNavigate}
         />
@@ -196,7 +198,7 @@ const HomeDataContent = () => {
               </Box>
             </MiniCardHeader>
             <MiniCardBody>
-              <UpcomingBirthdaysCard birthdays={birthdays} isExpanded={isBirthdaysExpanded} />
+              <UpcomingBirthdaysCard birthdays={birthdays} isExpanded={isBirthdaysExpanded} isError={isBirthdayError} />
             </MiniCardBody>
           </MiniCardContent>
         </BirthdayCard>


### PR DESCRIPTION
When offline or a request fails, the home page now shows "Unable to load
birthdays/tasks/grocery items" instead of the misleading empty-state messages
that implied the data didn't exist.

- API fetch functions now throw on non-ok responses instead of returning []
- BirthdayProvider, PlannerProvider, and GroceryListProvider now expose isError
- GrocerySection, TaskList, and UpcomingBirthdaysCard use isError to show
  appropriate error messages vs genuine empty-state messages

https://claude.ai/code/session_01PsyyZbimvi5rWpxEff6ogt