### PR TITLE
fix: wire up adventure edit navigation in Planner component

### DIFF
--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -114,6 +114,10 @@ export const Planner = ({
     await removeAdventure(id);
   }, [removeAdventure]);
 
+  const handleAdventureEdit = useCallback((adventure: IAdventure) => {
+    navigate(Route.EditAdventure.replace(':id', adventure.id));
+  }, [navigate]);
+
   const handleAddTask = useCallback((date: string) => {
     dispatch({ type: ActionName.SET_SELECTED_CALENDAR_DATE, payload: date })
     navigate(Route.AddPlannerItem)
@@ -155,7 +159,7 @@ export const Planner = ({
       <AdventurePreviewDrawer
         item={previewAdventure}
         onClose={() => setPreviewAdventure(null)}
-        onEdit={() => {}}
+        onEdit={handleAdventureEdit}
         onDelete={handleAdventureDelete}
       />
     </>


### PR DESCRIPTION
The AdventurePreviewDrawer's onEdit callback in the Planner was set to
an empty function, so clicking Edit from the planner did nothing.
Added handleAdventureEdit that navigates to the EditAdventure route.

https://claude.ai/code/session_018TP58TJSt8qrAoXkwhLYVj