### PR TITLE
fix: show multi-day adventures on all days between start and end date

### DIFF
--- a/packages/web/src/components/Planner/CalendarView/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.tsx
@@ -173,11 +173,17 @@ const CalendarView = ({
   const adventuresByDay = useMemo(() => {
     const map = new Map<string, IAdventure[]>()
     for (const adventure of adventures) {
-      const existing = map.get(adventure.date)
-      if (existing) {
-        existing.push(adventure)
-      } else {
-        map.set(adventure.date, [adventure])
+      let current = dayjs(adventure.date)
+      const end = adventure.endDate ? dayjs(adventure.endDate) : current
+      while (!current.isAfter(end, 'day')) {
+        const key = current.format('YYYY-MM-DD')
+        const existing = map.get(key)
+        if (existing) {
+          existing.push(adventure)
+        } else {
+          map.set(key, [adventure])
+        }
+        current = current.add(1, 'day')
       }
     }
     return map

--- a/packages/web/src/components/Planner/WeeklyView/index.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.tsx
@@ -145,11 +145,17 @@ const goToPrevWeek = () => setCurrentWeek(prev => prev.subtract(1, 'week'))
   const adventuresByDay = useMemo(() => {
     const map = new Map<string, IAdventure[]>()
     for (const adventure of adventures) {
-      const existing = map.get(adventure.date)
-      if (existing) {
-        existing.push(adventure)
-      } else {
-        map.set(adventure.date, [adventure])
+      let current = dayjs(adventure.date)
+      const end = adventure.endDate ? dayjs(adventure.endDate) : current
+      while (!current.isAfter(end, 'day')) {
+        const key = current.format('YYYY-MM-DD')
+        const existing = map.get(key)
+        if (existing) {
+          existing.push(adventure)
+        } else {
+          map.set(key, [adventure])
+        }
+        current = current.add(1, 'day')
       }
     }
     return map


### PR DESCRIPTION
Adventures with an endDate now appear on every day from the start date
through the end date in both CalendarView and WeeklyView.

https://claude.ai/code/session_014imzFj3B59GPsuUC7U7Lk4