### PR TITLE
ci: restore push trigger to unit test pipelines

### DIFF
--- a/.github/workflows/test-lambdas.yml
+++ b/.github/workflows/test-lambdas.yml
@@ -1,6 +1,13 @@
 name: Test Lambdas
 
 on:
+  push:
+    paths:
+      - "packages/lambdas/**"
+      - ".github/workflows/test-lambdas.yml"
+    paths-ignore:
+      - "packages/lambdas/**/*.md"
+      - "packages/lambdas/LICENSE"
   pull_request:
     paths:
       - "packages/lambdas/**"

--- a/.github/workflows/test-web.yml
+++ b/.github/workflows/test-web.yml
@@ -1,6 +1,13 @@
 name: Test Website
 
 on:
+  push:
+    paths:
+      - "packages/web/**"
+      - ".github/workflows/test-web.yml"
+    paths-ignore:
+      - "packages/web/**/*.md"
+      - "packages/web/LICENSE"
   pull_request:
     paths:
       - "packages/web/**"


### PR DESCRIPTION
Re-add push event trigger to test-lambdas and test-web workflows so
tests run on every commit push, not only on pull requests.

https://claude.ai/code/session_01RrtihL7TGnneCnCL6o6sRC