### PR TITLE
fix: pass defaults to RecipeViewDrawer on home page to show ingredient icons

### DIFF
--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -38,6 +38,8 @@ import {
 } from './components/PlannerSection/index.styled'
 import { useHomeData } from '../../hooks/useHomeData'
 import { useHomeInteractions } from '../../hooks/useHomeInteractions'
+import { useItemDefaults } from '../../hooks/useItemDefaults'
+import { retrieveGroceryListDefaults } from '../../api/groceryList'
 
 import { Container } from './index.styled'
 
@@ -69,6 +71,7 @@ const HomeDataContent = () => {
   const { currentProject } = useProjectContext()
   const { currentShop, shops } = useShopContext()
   const navigate = useNavigate()
+  const { defaults } = useItemDefaults({ fetchMethod: retrieveGroceryListDefaults })
 
   const interactions = useHomeInteractions()
   const [selectedRecipe, setSelectedRecipe] = useState<IRecipe | null>(null)
@@ -233,6 +236,7 @@ const HomeDataContent = () => {
         recipe={selectedRecipe}
         onClose={() => setSelectedRecipe(null)}
         onEdit={() => {}}
+        defaults={defaults}
       />
 
       <AdventurePreviewDrawer


### PR DESCRIPTION
The RecipeViewDrawer was rendered without the `defaults` prop on the home
page, causing ingredient icons to not appear when clicking a recipe banner.
Fetch defaults using useItemDefaults and pass them to the drawer, matching
the pattern used in other views.

https://claude.ai/code/session_014Pm3W5jukfEgJksHcfh8Ae