### PR TITLE
Fix week start to Monday in all planner views

### DIFF
--- a/packages/web/src/components/Planner/CalendarView/Placeholder/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/Placeholder/index.tsx
@@ -10,7 +10,7 @@ import {
   DayNumberPlaceholder,
 } from './index.styled'
 
-const WEEK_DAYS = ['Thu', 'Fri', 'Sat', 'Sun', 'Mon', 'Tue', 'Wed']
+const WEEK_DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 const TOTAL_CELLS = 35
 
 const CalendarViewPlaceholder = () => (

--- a/packages/web/src/components/Planner/CalendarView/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.tsx
@@ -31,9 +31,9 @@ import {
 } from './index.styled'
 import AdventureCellItem from './AdventureCellItem'
 
-// Jan 7 2021 was a Thursday — generate Thu-first weekday labels via browser locale
+// Jan 4 2021 was a Monday — generate Mon-first weekday labels via browser locale
 const WEEK_DAYS = Array.from({ length: 7 }, (_, i) =>
-  new Intl.DateTimeFormat(undefined, { weekday: 'short' }).format(new Date(2021, 0, 7 + i))
+  new Intl.DateTimeFormat(undefined, { weekday: 'short' }).format(new Date(2021, 0, 4 + i))
 )
 
 interface ICalendarViewProps {
@@ -182,8 +182,8 @@ const CalendarView = ({
   const calendarDays = useMemo(() => {
     const startOfMonth = currentMonth.startOf('month')
     const endOfMonth = currentMonth.endOf('month')
-    const startPad = (startOfMonth.day() + 3) % 7
-    const endPad = 6 - (endOfMonth.day() + 3) % 7
+    const startPad = (startOfMonth.day() + 6) % 7
+    const endPad = 6 - (endOfMonth.day() + 6) % 7
 
     const days: Dayjs[] = []
     for (let i = startPad - 1; i >= 0; i--) {

--- a/packages/web/src/components/Planner/WeeklyView/index.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.tsx
@@ -44,7 +44,7 @@ interface IWeeklyViewProps {
 
 const getWeekStart = (d: Dayjs): Dayjs => {
   const day = d.day()
-  const diff = -((day - 4 + 7) % 7)
+  const diff = -((day - 1 + 7) % 7)
   return d.startOf('day').add(diff, 'day')
 }
 

--- a/packages/web/src/components/Planner/utils/timeGrouping.ts
+++ b/packages/web/src/components/Planner/utils/timeGrouping.ts
@@ -46,9 +46,9 @@ const isTomorrow = (date: Date): boolean => {
 const isThisWeek = (date: Date): boolean => {
   const today = new Date()
   const startOfWeek = new Date(today)
-  startOfWeek.setDate(today.getDate() - ((today.getDay() - 4 + 7) % 7)) // Thursday
+  startOfWeek.setDate(today.getDate() - ((today.getDay() - 1 + 7) % 7)) // Monday
   const endOfWeek = new Date(startOfWeek)
-  endOfWeek.setDate(startOfWeek.getDate() + 6) // Wednesday
+  endOfWeek.setDate(startOfWeek.getDate() + 6) // Sunday
 
   return date >= startOfWeek && date <= endOfWeek
 }
@@ -56,9 +56,9 @@ const isThisWeek = (date: Date): boolean => {
 const isNextWeek = (date: Date): boolean => {
   const today = new Date()
   const startOfNextWeek = new Date(today)
-  startOfNextWeek.setDate(today.getDate() - ((today.getDay() - 4 + 7) % 7) + 7) // Next Thursday
+  startOfNextWeek.setDate(today.getDate() - ((today.getDay() - 1 + 7) % 7) + 7) // Next Monday
   const endOfNextWeek = new Date(startOfNextWeek)
-  endOfNextWeek.setDate(startOfNextWeek.getDate() + 6) // Next Wednesday
+  endOfNextWeek.setDate(startOfNextWeek.getDate() + 6) // Next Sunday
 
   return date >= startOfNextWeek && date <= endOfNextWeek
 }


### PR DESCRIPTION
Updated week start day from Thursday to Monday across WeeklyView,
CalendarView, CalendarView Placeholder, and timeGrouping utilities.

https://claude.ai/code/session_01TA2WuYVqs9PpBy2ioE96Lk