### PR TITLE
Add swipe navigation to weekly planner view and reduce header padding

### DIFF
--- a/packages/web/src/components/ModernPageHeader/index.styled.tsx
+++ b/packages/web/src/components/ModernPageHeader/index.styled.tsx
@@ -37,7 +37,7 @@ export const HeaderCard = styled(Card)<{ accentgradient?: string }>(({ accentgra
 }))
 
 export const HeaderContent = styled('div')({
-  padding: '1rem 1.25rem',
+  padding: '1rem 0.75rem',
   display: 'flex',
   flexDirection: 'column',
   gap: '0.75rem',

--- a/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
@@ -59,16 +59,35 @@ export const TodayButton = styled(Button)({
   },
 })
 
-export const WeekRowsWrapper = styled('div')({
+export const WeekRowsWrapper = styled('div')<{
+  $animationDirection: 'left' | 'right' | null
+}>(({ $animationDirection }) => ({
   flex: 1,
   overflowY: 'auto',
   padding: '0 12px 16px',
   display: 'flex',
   flexDirection: 'column',
   gap: '4px',
+  touchAction: 'pan-y',
+  userSelect: 'none',
+  willChange: $animationDirection ? 'transform, opacity' : 'auto',
+  ...($animationDirection && {
+    animation: `${$animationDirection === 'left' ? 'weekSlideInFromRight' : 'weekSlideInFromLeft'} 0.2s ease-out`,
+  }),
+  '@keyframes weekSlideInFromRight': {
+    from: { transform: 'translateX(30px)', opacity: 0.5 },
+    to: { transform: 'translateX(0)', opacity: 1 },
+  },
+  '@keyframes weekSlideInFromLeft': {
+    from: { transform: 'translateX(-30px)', opacity: 0.5 },
+    to: { transform: 'translateX(0)', opacity: 1 },
+  },
+  '@media (prefers-reduced-motion: reduce)': {
+    animation: 'none !important',
+  },
   '&::-webkit-scrollbar': { width: '4px' },
   '&::-webkit-scrollbar-thumb': { background: '#cbd5e1', borderRadius: '4px' },
-})
+}))
 
 interface IDayRowProps {
   isToday?: boolean

--- a/packages/web/src/components/Planner/WeeklyView/index.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback } from 'react'
+import { useSwipeToNavigate } from '../../../hooks/useSwipeToNavigate'
 import { IconButton } from '@mui/material'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
@@ -61,6 +62,7 @@ const WeeklyView = ({
   onAdventureClick,
 }: IWeeklyViewProps) => {
   const [currentWeek, setCurrentWeek] = useState<Dayjs>(() => getWeekStart(dayjs()))
+  const [animationDirection, setAnimationDirection] = useState<'left' | 'right' | null>(null)
   const today = dayjs()
   const [adventureWidths, setAdventureWidths] = useState<Map<string, number>>(() => new Map())
 
@@ -78,9 +80,20 @@ const WeeklyView = ({
     [currentWeek]
   )
 
-const goToPrevWeek = () => setCurrentWeek(prev => prev.subtract(1, 'week'))
-  const goToNextWeek = () => setCurrentWeek(prev => prev.add(1, 'week'))
+const goToPrevWeek = useCallback(() => {
+    setCurrentWeek(prev => prev.subtract(1, 'week'))
+    setAnimationDirection('right')
+  }, [])
+  const goToNextWeek = useCallback(() => {
+    setCurrentWeek(prev => prev.add(1, 'week'))
+    setAnimationDirection('left')
+  }, [])
   const goToToday = () => setCurrentWeek(getWeekStart(dayjs()))
+
+  const { handlers: swipeHandlers } = useSwipeToNavigate({
+    onSwipeLeft: goToNextWeek,
+    onSwipeRight: goToPrevWeek,
+  })
 
   const weekRangeLabel = useMemo(() => {
     const start = weekDays[0]
@@ -175,7 +188,7 @@ const goToPrevWeek = () => setCurrentWeek(prev => prev.subtract(1, 'week'))
         </IconButton>
       </WeekHeader>
 
-      <WeekRowsWrapper>
+      <WeekRowsWrapper $animationDirection={animationDirection} {...swipeHandlers}>
         {weekDays.map(day => {
           const key = day.format('YYYY-MM-DD')
           const isToday = day.isSame(today, 'day')


### PR DESCRIPTION
- Wire up useSwipeToNavigate in WeeklyView with left/right slide animations matching CalendarView behaviour
- Reduce ModernPageHeader horizontal padding from 1.25rem to 0.75rem to align with page layout

https://claude.ai/code/session_0179FWeorVb1fsu9pJ7QDR9c