### PR TITLE
feat: show purchased items in a dedicated section at the bottom of the grocery list

### DIFF
--- a/packages/web/src/components/GroceryList/PurchasedItemsSection/index.tsx
+++ b/packages/web/src/components/GroceryList/PurchasedItemsSection/index.tsx
@@ -1,0 +1,50 @@
+import GroceryItem from '../../GroceryItem';
+import CollapsibleSection from '../../CollapsibleSection';
+import SwipeableList from '../../SwipeableList';
+import { IGroceryItem } from '../../../providers/AppStateProvider/types';
+
+interface IPurchasedItemsSectionProps {
+  purchasedList: IGroceryItem[];
+  allExpanded?: boolean;
+  expandKey?: number;
+  onDelete: (id: string) => void;
+  onEdit: (id: string) => void;
+}
+
+const PURCHASED_ICON = {
+  emoji: '✅',
+  backgroundColor: '#f0fdf4',
+  foregroundColor: '#15803d',
+};
+
+const PurchasedItemsSection = ({
+  purchasedList,
+  allExpanded,
+  expandKey,
+  onDelete,
+  onEdit,
+}: IPurchasedItemsSectionProps) => {
+  if (purchasedList.length === 0) {
+    return null;
+  }
+
+  return (
+    <CollapsibleSection
+      title="Purchased Items"
+      icon={PURCHASED_ICON}
+      items={purchasedList}
+      expandTo={allExpanded}
+      expandKey={expandKey}
+    >
+      <SwipeableList
+        component={GroceryItem}
+        list={purchasedList}
+        onSwipeAction={onDelete}
+        onEditAction={onEdit}
+        threshold={0.3}
+      />
+    </CollapsibleSection>
+  );
+};
+
+export default PurchasedItemsSection;

--- a/packages/web/src/components/GroceryList/index.tsx
+++ b/packages/web/src/components/GroceryList/index.tsx
@@ -8,9 +8,11 @@ import { Route } from '../../enums/route';
 import { useGroceryCategories } from '../../hooks/useGroceryCategories';
 import UncategorizedView from './UncategorizedView';
 import CategorizedView from './CategorizedView';
+import PurchasedItemsSection from './PurchasedItemsSection';
 import Placeholder from './Placeholder';
 import EmptyGroceryList from './EmptyGroceryList';
 import { IGroceryListProps } from './types';
+import { Container } from './index.styled';
 
 export const GroceryList = ({
   allExpanded = true,
@@ -22,6 +24,10 @@ export const GroceryList = ({
   const { groceryList, isLoading, removeGroceryItem, viewMode } = useGroceryListContext();
   const visibleList = useMemo(
     () => groceryList.filter((item) => !purchasedItems.has(item.id)),
+    [groceryList, purchasedItems]
+  )
+  const purchasedList = useMemo(
+    () => groceryList.filter((item) => purchasedItems.has(item.id)),
     [groceryList, purchasedItems]
   )
   const { categorizedGroups } = useGroceryCategories(visibleList, viewMode)
@@ -51,22 +57,40 @@ export const GroceryList = ({
 
   if (viewMode === GroceryViewMode.UNCATEGORIZED) {
     return (
-      <UncategorizedView
-        groceryList={visibleList}
-        onDelete={handleDelete}
-        onEdit={handleEdit}
-      />
+      <Container>
+        <UncategorizedView
+          groceryList={visibleList}
+          onDelete={handleDelete}
+          onEdit={handleEdit}
+        />
+        <PurchasedItemsSection
+          purchasedList={purchasedList}
+          allExpanded={allExpanded}
+          expandKey={expandKey}
+          onDelete={handleDelete}
+          onEdit={handleEdit}
+        />
+      </Container>
     )
   }
 
   return (
-    <CategorizedView
-      categorizedGroups={categorizedGroups}
-      allExpanded={allExpanded}
-      expandKey={expandKey}
-      onDelete={handleDelete}
-      onEdit={handleEdit}
-    />
+    <Container>
+      <CategorizedView
+        categorizedGroups={categorizedGroups}
+        allExpanded={allExpanded}
+        expandKey={expandKey}
+        onDelete={handleDelete}
+        onEdit={handleEdit}
+      />
+      <PurchasedItemsSection
+        purchasedList={purchasedList}
+        allExpanded={allExpanded}
+        expandKey={expandKey}
+        onDelete={handleDelete}
+        onEdit={handleEdit}
+      />
+    </Container>
   );
 };
 


### PR DESCRIPTION
Purchased items no longer disappear from view — they move to a collapsible
"Purchased Items" section at the bottom of the list (all view modes). Clicking
a purchased item unmarks it and returns it to the regular list. The section is
removed when "Remove Purchased Items" is clicked.

https://claude.ai/code/session_01PEYNtucxnEgZdPivxX3gqU