### PR TITLE
feat: make adventure location clickable to open Google Maps

### DIFF
--- a/packages/web/src/components/AdventurePreviewDrawer/index.tsx
+++ b/packages/web/src/components/AdventurePreviewDrawer/index.tsx
@@ -131,7 +131,14 @@ const AdventurePreviewDrawer = ({ item, onClose, onEdit, onDelete }: AdventurePr
             {item?.location && (
               <DetailRow>
                 <LocationOnIcon />
-                {item.location}
+                <a
+                  href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(item.location)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: 'inherit', textDecoration: 'underline' }}
+                >
+                  {item.location}
+                </a>
               </DetailRow>
             )}
           </Box>

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingAdventureCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingAdventureCard/index.tsx
@@ -194,7 +194,15 @@ export const UpcomingAdventureCard: React.FC<IUpcomingAdventureCardProps> = ({ a
                         <>
                           {adventure.time && <span>·</span>}
                           <LocationOnIcon />
-                          {adventure.location}
+                          <a
+                            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(adventure.location)}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={(e) => e.stopPropagation()}
+                            style={{ color: 'inherit', textDecoration: 'underline' }}
+                          >
+                            {adventure.location}
+                          </a>
                         </>
                       )}
                     </HeroMeta>


### PR DESCRIPTION
Wrap location text in both the AdventurePreviewDrawer and
UpcomingAdventureCard with anchor tags that open Google Maps
search for the location. Uses stopPropagation on the card link
to prevent triggering the adventure click handler.

https://claude.ai/code/session_012MCTC8t97V3KQewnrHDFNG