### PR TITLE
Sort adventures by time within each day

### DIFF
--- a/packages/web/src/utils/adventure/index.ts
+++ b/packages/web/src/utils/adventure/index.ts
@@ -8,6 +8,14 @@ export enum AdventurePosition {
   End = 'end',
 }
 
+const sortAdventuresByTime = (adventures: IAdventure[]): IAdventure[] =>
+  adventures.sort((a, b) => {
+    if (a.time && b.time) return a.time.localeCompare(b.time)
+    if (a.time) return -1
+    if (b.time) return 1
+    return 0
+  })
+
 export const buildAdventuresByDay = (adventures: IAdventure[]): Map<string, IAdventure[]> => {
   const map = new Map<string, IAdventure[]>()
   for (const adventure of adventures) {
@@ -23,6 +31,9 @@ export const buildAdventuresByDay = (adventures: IAdventure[]): Map<string, IAdv
       }
       current = current.add(1, 'day')
     }
+  }
+  for (const [, dayAdventures] of map) {
+    sortAdventuresByTime(dayAdventures)
   }
   return map
 }


### PR DESCRIPTION
Adventures grouped by day were not sorted by time, so multiple
adventures on the same day appeared in arbitrary order. Added
time-based sorting in buildAdventuresByDay so all views (Calendar,
Weekly, DayPreview) display adventures chronologically.

https://claude.ai/code/session_011v5SBgwzhBjK7psW7mzRMb