### PR TITLE
feat: add collapsible/expandable days to weekly planner

### DIFF
--- a/packages/web/src/components/Planner/WeeklyView/ExpandedDayView.styled.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/ExpandedDayView.styled.tsx
@@ -1,0 +1,111 @@
+import { styled } from '@mui/material/styles'
+
+const TODAY_COLOR = '#6366f1'
+const BORDER_COLOR = '#f1f5f9'
+
+export const ExpandedDayContainer = styled('div')<{ isToday?: boolean }>(({ isToday }) => ({
+  backgroundColor: isToday ? '#f5f3ff' : '#fafbfc',
+  borderLeft: `2px solid ${isToday ? TODAY_COLOR : '#e2e8f0'}`,
+  borderRight: `1.5px solid ${isToday ? '#a5b4fc' : BORDER_COLOR}`,
+  borderBottom: `1.5px solid ${isToday ? '#a5b4fc' : BORDER_COLOR}`,
+  borderRadius: '0 0 12px 12px',
+  marginTop: '-2px',
+  overflow: 'hidden',
+}))
+
+export const AllDaySection = styled('div')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '5px',
+  padding: '8px 10px 8px 58px',
+  borderBottom: `1px solid ${BORDER_COLOR}`,
+  minHeight: '32px',
+  alignItems: 'center',
+})
+
+export const AllDayLabel = styled('div')({
+  fontSize: '0.6rem',
+  fontWeight: 700,
+  color: '#94a3b8',
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  width: '48px',
+  marginLeft: '-48px',
+  textAlign: 'right',
+  paddingRight: '8px',
+  flexShrink: 0,
+})
+
+export const HourBlocksContainer = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+export const HourBlock = styled('div')<{ hasItems?: boolean }>(({ hasItems }) => ({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'flex-start',
+  minHeight: hasItems ? '36px' : '28px',
+  borderBottom: `1px solid ${BORDER_COLOR}`,
+  '&:last-child': {
+    borderBottom: 'none',
+  },
+}))
+
+export const HourLabel = styled('div')({
+  width: '48px',
+  flexShrink: 0,
+  fontSize: '0.6rem',
+  fontWeight: 600,
+  color: '#94a3b8',
+  textAlign: 'right',
+  paddingRight: '10px',
+  paddingTop: '6px',
+  lineHeight: 1,
+})
+
+export const HourContent = styled('div')({
+  flex: 1,
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: '4px',
+  padding: '4px 8px',
+  alignContent: 'flex-start',
+})
+
+export const CurrentTimeIndicator = styled('div')({
+  position: 'relative',
+  height: '2px',
+  backgroundColor: TODAY_COLOR,
+  margin: '0 8px 0 48px',
+  borderRadius: '1px',
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    left: '-4px',
+    top: '-3px',
+    width: '8px',
+    height: '8px',
+    borderRadius: '50%',
+    backgroundColor: TODAY_COLOR,
+  },
+})
+
+export const EmptyHourDot = styled('div')({
+  width: '4px',
+  height: '4px',
+  borderRadius: '50%',
+  backgroundColor: '#e2e8f0',
+  marginTop: '4px',
+})
+
+export const ExpandIndicator = styled('div')<{ expanded: boolean }>(({ expanded }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  transition: 'transform 0.15s ease',
+  transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+  color: '#94a3b8',
+  fontSize: '0.9rem',
+  marginTop: '2px',
+}))

--- a/packages/web/src/components/Planner/WeeklyView/ExpandedDayView.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/ExpandedDayView.tsx
@@ -1,0 +1,212 @@
+import { useMemo } from 'react'
+import dayjs, { Dayjs } from 'dayjs'
+import { Collapse } from '@mui/material'
+import CakeIcon from '@mui/icons-material/Cake'
+import RestaurantIcon from '@mui/icons-material/Restaurant'
+import ExploreIcon from '@mui/icons-material/Explore'
+import { ITodoItem } from '../../../api/toDoList/retrieve/types'
+import { IBirthdayItem } from '../../../api/birthdays/retrieve/types'
+import { IMealPlan } from '../../../types/mealPlan'
+import { IAdventure } from '../../../types/adventure'
+import { buildTimeSlots, formatHour, HOUR_SLOTS, IExpandedItem } from './expandedDayUtils'
+import {
+  DayItem,
+  OverdueDayItem,
+  CompletedDayItem,
+  BirthdayItem,
+  BirthdayIconStyled,
+  MealItem,
+  MealIconStyled,
+} from './index.styled'
+import {
+  ExpandedDayContainer,
+  AllDaySection,
+  AllDayLabel,
+  HourBlocksContainer,
+  HourBlock,
+  HourLabel,
+  HourContent,
+  CurrentTimeIndicator,
+} from './ExpandedDayView.styled'
+import PrivateItemBadge from '../../PrivateItemBadge'
+
+interface IExpandedDayViewProps {
+  day: Dayjs
+  isExpanded: boolean
+  pendingTodos: ITodoItem[]
+  completedTodos: ITodoItem[]
+  birthdays: IBirthdayItem[]
+  meals: IMealPlan[]
+  adventures: IAdventure[]
+  isOverdue: boolean
+  isToday: boolean
+  onItemClick: (id: string) => void
+  onBirthdayClick?: (id: string) => void
+  onMealPlanClick?: (mealPlan: IMealPlan) => void
+  onAdventureClick?: (id: string) => void
+}
+
+const renderItem = (
+  item: IExpandedItem,
+  onItemClick: (id: string) => void,
+  onBirthdayClick?: (id: string) => void,
+  onMealPlanClick?: (mealPlan: IMealPlan) => void,
+  onAdventureClick?: (id: string) => void,
+) => {
+  const badge = item.isPrivate ? <PrivateItemBadge /> : null
+
+  switch (item.type) {
+    case 'todo':
+      return (
+        <DayItem key={item.id} onClick={() => onItemClick(item.id)}>
+          {item.time && <TimeTag>{item.time}</TimeTag>}
+          {item.label}
+          {badge}
+        </DayItem>
+      )
+    case 'overdueTodo':
+      return (
+        <OverdueDayItem key={item.id} onClick={() => onItemClick(item.id)}>
+          {item.time && <TimeTag>{item.time}</TimeTag>}
+          {item.label}
+          {badge}
+        </OverdueDayItem>
+      )
+    case 'completedTodo':
+      return (
+        <CompletedDayItem key={item.id} onClick={() => onItemClick(item.id)}>
+          {item.time && <TimeTag>{item.time}</TimeTag>}
+          {item.label}
+          {badge}
+        </CompletedDayItem>
+      )
+    case 'birthday':
+      return (
+        <BirthdayItem key={item.id} onClick={() => onBirthdayClick?.(item.id)}>
+          <BirthdayIconStyled />
+          {item.label}
+          {badge}
+        </BirthdayItem>
+      )
+    case 'meal':
+      return (
+        <MealItem key={item.id} onClick={() => onMealPlanClick?.(item.raw as IMealPlan)}>
+          <MealIconStyled />
+          {item.label}
+          {badge}
+        </MealItem>
+      )
+    case 'adventure':
+      return (
+        <AdventureExpandedItem key={item.id} onClick={() => onAdventureClick?.(item.id)}>
+          <ExploreIcon sx={{ fontSize: '0.7rem', color: '#06b6d4', flexShrink: 0, marginTop: '2px' }} />
+          {item.time && <TimeTag>{item.time}</TimeTag>}
+          {item.label}
+          {badge}
+        </AdventureExpandedItem>
+      )
+    default:
+      return null
+  }
+}
+
+const ExpandedDayView = ({
+  day: _day,
+  isExpanded,
+  pendingTodos,
+  completedTodos,
+  birthdays,
+  meals,
+  adventures,
+  isOverdue,
+  isToday,
+  onItemClick,
+  onBirthdayClick,
+  onMealPlanClick,
+  onAdventureClick,
+}: IExpandedDayViewProps) => {
+  const timeSlots = useMemo(
+    () => buildTimeSlots(pendingTodos, completedTodos, birthdays, meals, adventures, isOverdue),
+    [pendingTodos, completedTodos, birthdays, meals, adventures, isOverdue],
+  )
+
+  const currentHour = isToday ? dayjs().hour() : -1
+  const currentMinute = isToday ? dayjs().minute() : 0
+
+  return (
+    <Collapse in={isExpanded} timeout={150}>
+      <ExpandedDayContainer isToday={isToday}>
+        {timeSlots.allDay.length > 0 && (
+          <AllDaySection>
+            <AllDayLabel>All day</AllDayLabel>
+            {timeSlots.allDay.map(item =>
+              renderItem(item, onItemClick, onBirthdayClick, onMealPlanClick, onAdventureClick),
+            )}
+          </AllDaySection>
+        )}
+
+        <HourBlocksContainer>
+          {HOUR_SLOTS.map(hour => {
+            const items = timeSlots.hourly.get(hour) ?? []
+            const showTimeLine = isToday && hour === currentHour
+
+            return (
+              <div key={hour}>
+                {showTimeLine && (
+                  <CurrentTimeIndicator
+                    style={{ marginTop: `${(currentMinute / 60) * 100}%` }}
+                  />
+                )}
+                <HourBlock hasItems={items.length > 0}>
+                  <HourLabel>{formatHour(hour)}</HourLabel>
+                  <HourContent>
+                    {items.map(item =>
+                      renderItem(item, onItemClick, onBirthdayClick, onMealPlanClick, onAdventureClick),
+                    )}
+                  </HourContent>
+                </HourBlock>
+              </div>
+            )
+          })}
+        </HourBlocksContainer>
+      </ExpandedDayContainer>
+    </Collapse>
+  )
+}
+
+// Small inline styled components used only here
+import { styled } from '@mui/material/styles'
+
+const TimeTag = styled('span')({
+  fontSize: '0.6rem',
+  fontWeight: 600,
+  color: '#6366f1',
+  backgroundColor: '#eef2ff',
+  padding: '1px 5px',
+  borderRadius: '4px',
+  marginRight: '4px',
+  flexShrink: 0,
+  whiteSpace: 'nowrap',
+})
+
+const AdventureExpandedItem = styled('div')({
+  fontSize: '0.72rem',
+  padding: '5px 7px 5px 9px',
+  borderRadius: '8px',
+  cursor: 'pointer',
+  wordBreak: 'break-word',
+  lineHeight: 1.4,
+  transition: 'all 0.12s ease',
+  flexShrink: 0,
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '4px',
+  color: '#0e7490',
+  backgroundColor: '#ecfeff',
+  borderLeft: '3px solid #06b6d4',
+  '&:hover': {
+    backgroundColor: '#cffafe',
+  },
+})
+
+export default ExpandedDayView

--- a/packages/web/src/components/Planner/WeeklyView/expandedDayUtils.ts
+++ b/packages/web/src/components/Planner/WeeklyView/expandedDayUtils.ts
@@ -1,0 +1,147 @@
+import dayjs from 'dayjs'
+import { ITodoItem } from '../../../api/toDoList/retrieve/types'
+import { IBirthdayItem } from '../../../api/birthdays/retrieve/types'
+import { IMealPlan } from '../../../types/mealPlan'
+import { IAdventure } from '../../../types/adventure'
+import { MealType } from '../../../enums/mealType'
+
+export const HOUR_START = 6
+export const HOUR_END = 22
+export const HOUR_SLOTS = Array.from({ length: HOUR_END - HOUR_START + 1 }, (_, i) => HOUR_START + i)
+
+export type ExpandedItemType = 'todo' | 'completedTodo' | 'overdueTodo' | 'birthday' | 'meal' | 'adventure'
+
+export interface IExpandedItem {
+  type: ExpandedItemType
+  id: string
+  label: string
+  isPrivate: boolean
+  time?: string
+  raw: ITodoItem | IBirthdayItem | IMealPlan | IAdventure
+}
+
+const MEAL_TYPE_HOUR: Partial<Record<MealType, number>> = {
+  [MealType.Breakfast]: 8,
+  [MealType.Brunch]: 10,
+  [MealType.Lunch]: 12,
+  [MealType.Snack]: 15,
+  [MealType.Dinner]: 19,
+}
+
+export interface ITimeSlotResult {
+  allDay: IExpandedItem[]
+  hourly: Map<number, IExpandedItem[]>
+}
+
+export const buildTimeSlots = (
+  pendingTodos: ITodoItem[],
+  completedTodos: ITodoItem[],
+  birthdays: IBirthdayItem[],
+  meals: IMealPlan[],
+  adventures: IAdventure[],
+  isOverdue: boolean,
+): ITimeSlotResult => {
+  const allDay: IExpandedItem[] = []
+  const hourly = new Map<number, IExpandedItem[]>()
+
+  const addToHour = (hour: number, item: IExpandedItem) => {
+    const existing = hourly.get(hour)
+    if (existing) {
+      existing.push(item)
+    } else {
+      hourly.set(hour, [item])
+    }
+  }
+
+  const categorizeTodo = (todo: ITodoItem, type: ExpandedItemType) => {
+    const item: IExpandedItem = {
+      type,
+      id: todo.id,
+      label: todo.name,
+      isPrivate: todo.visibility === 'private',
+      raw: todo,
+    }
+
+    if (todo.dueDate) {
+      const d = dayjs(todo.dueDate)
+      const hour = d.hour()
+      const minute = d.minute()
+      // Midnight (00:00) likely means no specific time was set
+      if (hour === 0 && minute === 0) {
+        allDay.push(item)
+      } else if (hour >= HOUR_START && hour <= HOUR_END) {
+        item.time = d.format('h:mm A')
+        addToHour(hour, item)
+      } else {
+        allDay.push(item)
+      }
+    } else {
+      allDay.push(item)
+    }
+  }
+
+  for (const todo of pendingTodos) {
+    categorizeTodo(todo, isOverdue ? 'overdueTodo' : 'todo')
+  }
+
+  for (const todo of completedTodos) {
+    categorizeTodo(todo, 'completedTodo')
+  }
+
+  for (const birthday of birthdays) {
+    allDay.push({
+      type: 'birthday',
+      id: birthday.id,
+      label: birthday.name,
+      isPrivate: birthday.visibility === 'private',
+      raw: birthday,
+    })
+  }
+
+  for (const meal of meals) {
+    const item: IExpandedItem = {
+      type: 'meal',
+      id: meal.id,
+      label: meal.recipeName,
+      isPrivate: meal.visibility === 'private',
+      raw: meal,
+    }
+    const mealHour = meal.mealType ? MEAL_TYPE_HOUR[meal.mealType] : undefined
+    if (mealHour !== undefined && mealHour >= HOUR_START && mealHour <= HOUR_END) {
+      item.time = meal.mealType
+      addToHour(mealHour, item)
+    } else {
+      allDay.push(item)
+    }
+  }
+
+  for (const adventure of adventures) {
+    const item: IExpandedItem = {
+      type: 'adventure',
+      id: adventure.id,
+      label: adventure.name,
+      isPrivate: adventure.visibility === 'private',
+      raw: adventure,
+    }
+    if (adventure.time) {
+      const hour = parseInt(adventure.time.split(':')[0], 10)
+      if (!isNaN(hour) && hour >= HOUR_START && hour <= HOUR_END) {
+        item.time = dayjs(`2000-01-01 ${adventure.time}`).format('h:mm A')
+        addToHour(hour, item)
+      } else {
+        allDay.push(item)
+      }
+    } else {
+      allDay.push(item)
+    }
+  }
+
+  return { allDay, hourly }
+}
+
+export const formatHour = (hour: number): string => {
+  if (hour === 0) return '12 AM'
+  if (hour < 12) return `${hour} AM`
+  if (hour === 12) return '12 PM'
+  return `${hour - 12} PM`
+}

--- a/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
@@ -103,23 +103,27 @@ const getDayRowBorderRadius = (toNext?: boolean, fromPrev?: boolean) => {
   return `${topLeft} ${topRight} ${bottomRight} ${bottomLeft}`
 }
 
-export const DayRow = styled('div')<IDayRowProps>(({ isToday, adventureContinuesToNext, adventureContinuesFromPrev }) => {
+export const DayRow = styled('div')<IDayRowProps & { isExpanded?: boolean }>(({ isToday, adventureContinuesToNext, adventureContinuesFromPrev, isExpanded }) => {
   const isSpanning = adventureContinuesToNext || adventureContinuesFromPrev
   const borderColor = isToday ? TODAY_BORDER : isSpanning ? ADVENTURE_COLOR : BORDER_COLOR
   return {
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'stretch',
-    borderRadius: getDayRowBorderRadius(adventureContinuesToNext, adventureContinuesFromPrev),
+    borderRadius: isExpanded
+      ? getDayRowBorderRadius(true, adventureContinuesFromPrev)
+      : getDayRowBorderRadius(adventureContinuesToNext, adventureContinuesFromPrev),
     borderLeft: `1.5px solid ${borderColor}`,
     borderRight: `1.5px solid ${borderColor}`,
-    borderBottom: `1.5px solid ${borderColor}`,
+    borderBottom: isExpanded ? 'none' : `1.5px solid ${borderColor}`,
     borderTop: adventureContinuesFromPrev ? 'none' : `1.5px solid ${borderColor}`,
     backgroundColor: isToday ? TODAY_BG : '#ffffff',
     boxShadow: isToday ? '0 2px 8px rgba(99,102,241,0.12)' : '0 1px 3px rgba(0,0,0,0.04)',
     overflow: 'hidden',
     minHeight: '40px',
     transition: 'box-shadow 0.15s ease',
+    cursor: 'pointer',
+    userSelect: 'none',
   }
 })
 

--- a/packages/web/src/components/Planner/WeeklyView/index.test.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.test.tsx
@@ -77,21 +77,23 @@ describe('Given the WeeklyView component', () => {
   it('should render a pending todo on the correct day', () => {
     const todo = makeTodo({ name: 'Buy groceries' })
     render(<WeeklyView visibleToDoItems={[todo]} onItemClick={vi.fn()} />)
-    expect(screen.getByText('Buy groceries')).toBeVisible()
+    // Today is auto-expanded, so item appears in both collapsed row and expanded view
+    expect(screen.getAllByText('Buy groceries')[0]).toBeVisible()
   })
 
   it('should call onItemClick when a todo item is clicked', () => {
     const onItemClick = vi.fn()
     const todo = makeTodo({ id: 'todo-abc', name: 'Test task' })
     render(<WeeklyView visibleToDoItems={[todo]} onItemClick={onItemClick} />)
-    fireEvent.click(screen.getByText('Test task'))
+    fireEvent.click(screen.getAllByText('Test task')[0])
     expect(onItemClick).toHaveBeenCalledWith('todo-abc')
   })
 
   it('should render a birthday item', () => {
     const birthday = makeBirthday({ name: 'Alice' })
     render(<WeeklyView visibleToDoItems={[]} onItemClick={vi.fn()} birthdayItems={[birthday]} />)
-    expect(screen.getByText('Alice')).toBeVisible()
+    // Today is auto-expanded, so item appears in both collapsed row and expanded view
+    expect(screen.getAllByText('Alice')[0]).toBeVisible()
   })
 
   it('should call onBirthdayClick when a birthday item is clicked', () => {
@@ -105,14 +107,15 @@ describe('Given the WeeklyView component', () => {
         onBirthdayClick={onBirthdayClick}
       />
     )
-    fireEvent.click(screen.getByText('Alice'))
+    fireEvent.click(screen.getAllByText('Alice')[0])
     expect(onBirthdayClick).toHaveBeenCalledWith('bday-xyz')
   })
 
   it('should render a meal plan item', () => {
     const meal = makeMeal({ recipeName: 'Pasta' })
     render(<WeeklyView visibleToDoItems={[]} onItemClick={vi.fn()} mealPlans={[meal]} />)
-    expect(screen.getByText('Pasta')).toBeVisible()
+    // Today is auto-expanded, so item appears in both collapsed row and expanded view
+    expect(screen.getAllByText('Pasta')[0]).toBeVisible()
   })
 
   it('should call onMealPlanClick when a meal is clicked', () => {
@@ -126,7 +129,7 @@ describe('Given the WeeklyView component', () => {
         onMealPlanClick={onMealPlanClick}
       />
     )
-    fireEvent.click(screen.getByText('Pasta'))
+    fireEvent.click(screen.getAllByText('Pasta')[0])
     expect(onMealPlanClick).toHaveBeenCalledWith(meal)
   })
 

--- a/packages/web/src/components/Planner/WeeklyView/index.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.tsx
@@ -1,8 +1,9 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { useSwipeToNavigate } from '../../../hooks/useSwipeToNavigate'
 import { IconButton } from '@mui/material'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import dayjs, { Dayjs } from 'dayjs'
 import { ITodoItem } from '../../../api/toDoList/retrieve/types'
 import { IBirthdayItem } from '../../../api/birthdays/retrieve/types'
@@ -29,8 +30,10 @@ import {
   MealIconStyled,
   AdventureConnectedDayWrapper,
 } from './index.styled'
+import { ExpandIndicator } from './ExpandedDayView.styled'
 import PrivateItemBadge from '../../PrivateItemBadge'
 import AdventureWeeklyItem from './AdventureWeeklyItem'
+import ExpandedDayView from './ExpandedDayView'
 
 interface IWeeklyViewProps {
   visibleToDoItems: ITodoItem[]
@@ -50,6 +53,8 @@ const getWeekStart = (d: Dayjs): Dayjs => {
   return d.startOf('day').add(diff, 'day')
 }
 
+const getTodayKey = (): string => dayjs().format('YYYY-MM-DD')
+
 const WeeklyView = ({
   visibleToDoItems,
   onItemClick,
@@ -65,6 +70,8 @@ const WeeklyView = ({
   const [animationDirection, setAnimationDirection] = useState<'left' | 'right' | null>(null)
   const today = dayjs()
   const [adventureWidths, setAdventureWidths] = useState<Map<string, number>>(() => new Map())
+  const [expandedDay, setExpandedDay] = useState<string | null>(() => getTodayKey())
+  const dayRefs = useRef<Map<string, HTMLDivElement>>(new Map())
 
   const handleAdventureMeasure = useCallback((id: string, width: number) => {
     setAdventureWidths(prev => {
@@ -80,7 +87,30 @@ const WeeklyView = ({
     [currentWeek]
   )
 
-const goToPrevWeek = useCallback(() => {
+  // Reset expanded day when week changes
+  useEffect(() => {
+    const todayKey = getTodayKey()
+    const weekContainsToday = weekDays.some(d => d.format('YYYY-MM-DD') === todayKey)
+    setExpandedDay(weekContainsToday ? todayKey : null)
+  }, [currentWeek])
+
+  // Scroll expanded day into view
+  useEffect(() => {
+    if (expandedDay) {
+      const el = dayRefs.current.get(expandedDay)
+      if (el) {
+        setTimeout(() => {
+          ;(el as any).scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+        }, 160)
+      }
+    }
+  }, [expandedDay])
+
+  const handleDayToggle = useCallback((dayKey: string) => {
+    setExpandedDay(prev => prev === dayKey ? null : dayKey)
+  }, [])
+
+  const goToPrevWeek = useCallback(() => {
     setCurrentWeek(prev => prev.subtract(1, 'week'))
     setAnimationDirection('right')
   }, [])
@@ -199,6 +229,7 @@ const goToPrevWeek = useCallback(() => {
           const dayBirthdays = birthdaysByDay.get(birthdayKey) ?? []
           const dayMeals = mealPlansByDay.get(key) ?? []
           const dayAdventures = adventuresByDay.get(key) ?? []
+          const isDayExpanded = expandedDay === key
 
           const hasAdventureContinuingToNext = dayAdventures.some(
             a => {
@@ -215,16 +246,34 @@ const goToPrevWeek = useCallback(() => {
 
           const Wrapper = hasAdventureContinuingFromPrev ? AdventureConnectedDayWrapper : 'div'
 
+          const singleDayAdventures = dayAdventures.filter(
+            a => getAdventurePosition(a, key) === AdventurePosition.Single
+          )
+
           return (
-            <Wrapper key={key}>
+            <Wrapper
+              key={key}
+              ref={(el: HTMLDivElement | null) => {
+                if (el) {
+                  dayRefs.current.set(key, el)
+                } else {
+                  dayRefs.current.delete(key)
+                }
+              }}
+            >
               <DayRow
                 isToday={isToday}
+                isExpanded={isDayExpanded}
                 adventureContinuesToNext={hasAdventureContinuingToNext}
                 adventureContinuesFromPrev={hasAdventureContinuingFromPrev}
+                onClick={() => handleDayToggle(key)}
               >
                 <DayRowHeader isToday={isToday}>
                   <DayName isToday={isToday}>{day.format('ddd')}</DayName>
                   <DayNumber isToday={isToday}>{day.date()}</DayNumber>
+                  <ExpandIndicator expanded={isDayExpanded}>
+                    <ExpandMoreIcon sx={{ fontSize: '0.85rem' }} />
+                  </ExpandIndicator>
                 </DayRowHeader>
 
                 {dayAdventures
@@ -243,49 +292,63 @@ const goToPrevWeek = useCallback(() => {
                 <DayRowItems>
                   {pendingTodos.map(todo =>
                     isOverdue ? (
-                      <OverdueDayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                      <OverdueDayItem key={todo.id} onClick={(e) => { e.stopPropagation(); onItemClick(todo.id) }}>
                         {todo.name}
                         {todo.visibility === 'private' && <PrivateItemBadge />}
                       </OverdueDayItem>
                     ) : (
-                      <DayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                      <DayItem key={todo.id} onClick={(e) => { e.stopPropagation(); onItemClick(todo.id) }}>
                         {todo.name}
                         {todo.visibility === 'private' && <PrivateItemBadge />}
                       </DayItem>
                     )
                   )}
                   {completedTodos.map(todo => (
-                    <CompletedDayItem key={todo.id} onClick={() => onItemClick(todo.id)}>
+                    <CompletedDayItem key={todo.id} onClick={(e) => { e.stopPropagation(); onItemClick(todo.id) }}>
                       {todo.name}
                       {todo.visibility === 'private' && <PrivateItemBadge />}
                     </CompletedDayItem>
                   ))}
                   {dayBirthdays.map(birthday => (
-                    <BirthdayItem key={birthday.id} onClick={() => onBirthdayClick?.(birthday.id)}>
+                    <BirthdayItem key={birthday.id} onClick={(e) => { e.stopPropagation(); onBirthdayClick?.(birthday.id) }}>
                       <BirthdayIconStyled />
                       {birthday.name}
                       {birthday.visibility === 'private' && <PrivateItemBadge />}
                     </BirthdayItem>
                   ))}
                   {dayMeals.map(plan => (
-                    <MealItem key={plan.id} onClick={() => onMealPlanClick?.(plan)}>
+                    <MealItem key={plan.id} onClick={(e) => { e.stopPropagation(); onMealPlanClick?.(plan) }}>
                       <MealIconStyled />
                       {plan.recipeName}
                       {plan.visibility === 'private' && <PrivateItemBadge />}
                     </MealItem>
                   ))}
-                  {dayAdventures
-                    .filter(a => getAdventurePosition(a, key) === AdventurePosition.Single)
-                    .map(adventure => (
-                      <AdventureWeeklyItem
-                        key={adventure.id}
-                        adventure={adventure}
-                        dayKey={key}
-                        onClick={() => onAdventureClick?.(adventure.id)}
-                      />
-                    ))}
+                  {singleDayAdventures.map(adventure => (
+                    <AdventureWeeklyItem
+                      key={adventure.id}
+                      adventure={adventure}
+                      dayKey={key}
+                      onClick={() => onAdventureClick?.(adventure.id)}
+                    />
+                  ))}
                 </DayRowItems>
               </DayRow>
+
+              <ExpandedDayView
+                day={day}
+                isExpanded={isDayExpanded}
+                pendingTodos={pendingTodos}
+                completedTodos={completedTodos}
+                birthdays={dayBirthdays}
+                meals={dayMeals}
+                adventures={singleDayAdventures}
+                isOverdue={isOverdue}
+                isToday={isToday}
+                onItemClick={onItemClick}
+                onBirthdayClick={onBirthdayClick}
+                onMealPlanClick={onMealPlanClick}
+                onAdventureClick={onAdventureClick}
+              />
             </Wrapper>
           )
         })}

--- a/packages/web/src/components/Planner/WeeklyView/index.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.tsx
@@ -94,7 +94,22 @@ const WeeklyView = ({
     setExpandedDay(weekContainsToday ? todayKey : null)
   }, [currentWeek])
 
-  // Scroll expanded day into view
+  // Scroll today into view on initial mount
+  const hasScrolledOnMount = useRef(false)
+  useEffect(() => {
+    if (hasScrolledOnMount.current) return
+    const todayKey = getTodayKey()
+    const el = dayRefs.current.get(todayKey)
+    if (el) {
+      hasScrolledOnMount.current = true
+      // Use requestAnimationFrame to wait for expanded content to render
+      requestAnimationFrame(() => {
+        ;(el as any).scrollIntoView({ behavior: 'smooth', block: 'start' })
+      })
+    }
+  })
+
+  // Scroll expanded day into view when toggling
   useEffect(() => {
     if (expandedDay) {
       const el = dayRefs.current.get(expandedDay)


### PR DESCRIPTION
Each day in the weekly view can now be tapped to expand into an
hour-by-hour timeline (6 AM – 10 PM). Today auto-expands by default.
Only one day can be expanded at a time — clicking another day collapses
the current and expands the new one. Collapsed days retain the existing
compact layout. Items are mapped to time slots based on their time data
(todo dueDate hour, adventure time field, meal type).

https://claude.ai/code/session_01M2DPTjZKhJzUAUD5xV69gF