### PR TITLE
Remember last selected planner item type across sessions

### DIFF
--- a/packages/web/src/components/NavigationBar/AddItemButton/index.tsx
+++ b/packages/web/src/components/NavigationBar/AddItemButton/index.tsx
@@ -1,6 +1,7 @@
 
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import { Route } from "../../../enums/route";
+import { getLastItemType } from '../../../routes/AddPlannerItemRoute';
 import { useLocation, useNavigate } from "react-router";
 import { useCallback, useMemo } from "react";
 import { IconButton } from '@mui/material';
@@ -123,6 +124,8 @@ const AddItemButton = () => {
                 // Special case: grocery list - open add drawer via query param
                 const shopId = location.pathname.split('/')[2];
                 navigate(`/groceries/${shopId}?openAdd=true`);
+            } else if (addItemRoute === Route.AddPlannerItem) {
+                navigate(addItemRoute, { state: { itemType: getLastItemType() } });
             } else {
                 navigate(addItemRoute);
             }

--- a/packages/web/src/routes/AddPlannerItemRoute/index.tsx
+++ b/packages/web/src/routes/AddPlannerItemRoute/index.tsx
@@ -34,6 +34,26 @@ import PrivateToggle from '../../components/PrivateToggle'
 
 type ItemType = 'task' | 'birthday' | 'meal' | 'adventure'
 
+const LAST_PLANNER_ITEM_TYPE_KEY = 'kairos_last_planner_item_type'
+
+const getLastItemType = (): ItemType => {
+  try {
+    const stored = localStorage.getItem(LAST_PLANNER_ITEM_TYPE_KEY)
+    if (stored === 'task' || stored === 'birthday' || stored === 'meal' || stored === 'adventure') {
+      return stored
+    }
+  } catch {}
+  return 'task'
+}
+
+const saveLastItemType = (type: ItemType): void => {
+  try {
+    localStorage.setItem(LAST_PLANNER_ITEM_TYPE_KEY, type)
+  } catch {}
+}
+
+export { getLastItemType }
+
 const PLANNER_TABS: Array<SegmentedControlTab<ItemType>> = [
   {
     id: 'task',
@@ -76,7 +96,12 @@ export const AddPlannerItemContent = () => {
   const location = useLocation()
   const { toDoList: _toDoList } = usePlannerContext()
   const { user } = useAuth()
-  const [itemType, setItemType] = useState<ItemType>((location.state as { itemType?: ItemType } | null)?.itemType ?? 'task')
+  const [itemType, setItemType] = useState<ItemType>((location.state as { itemType?: ItemType } | null)?.itemType ?? getLastItemType())
+
+  const handleItemTypeChange = useCallback((type: ItemType) => {
+    saveLastItemType(type)
+    setItemType(type)
+  }, [])
   const [steps, setSteps] = useState<IStep[]>([])
   const [isPrivate, setIsPrivate] = useState(false)
 
@@ -163,7 +188,7 @@ export const AddPlannerItemContent = () => {
         <SegmentedControl
           tabs={PLANNER_TABS}
           activeTab={itemType}
-          onChange={setItemType}
+          onChange={handleItemTypeChange}
           collapseInactive
         />
       </Box>


### PR DESCRIPTION
When the user selects a type (task, meal, adventure, birthday) in the
add planner form, it is persisted to localStorage. The next time they
tap the add button from the planner view, the form opens pre-selected
to their last used type.

https://claude.ai/code/session_01XLLTqEmWrTDZt2ouEx5Yed