### PR TITLE
Add quick action buttons for adventures and tasks in weekly planner day drawer

### DIFF
--- a/packages/web/src/components/DayPreviewDrawer/index.tsx
+++ b/packages/web/src/components/DayPreviewDrawer/index.tsx
@@ -20,6 +20,7 @@ import {
   AdventureDayDetailItem,
   AdventuresSectionHeader,
   TasksAddButton,
+  AdventuresAddButton,
 } from '../Planner/CalendarView/index.styled'
 import {
   DAY_PREVIEW_GRADIENT,
@@ -51,6 +52,7 @@ interface IDayPreviewDrawerProps {
   onAddMealPlan?: (date: string) => void
   onMealPlanClick?: (mealPlan: IMealPlan) => void
   onAdventureClick?: (id: string) => void
+  onAddAdventure?: (date: string) => void
   onAddTask?: (date: string) => void
 }
 
@@ -83,6 +85,7 @@ const DayPreviewDrawer = ({
   onAddMealPlan,
   onMealPlanClick,
   onAdventureClick,
+  onAddAdventure,
   onAddTask,
 }: IDayPreviewDrawerProps) => {
   return (
@@ -184,21 +187,26 @@ const DayPreviewDrawer = ({
           ))
         )}
 
-        {adventures.length > 0 && (
-          <>
-            <AdventuresSectionHeader>Adventures</AdventuresSectionHeader>
-            {adventures.map(adventure => {
-              const time = formatAdventureTime(adventure.time)
-              return (
-                <AdventureDayDetailItem key={adventure.id} onClick={() => onAdventureClick?.(adventure.id)}>
-                  <ExploreIcon sx={{ fontSize: '0.9rem', color: '#06b6d4', flexShrink: 0 }} />
-                  {time && <TimeBadge>{time}</TimeBadge>}
-                  <span style={{ flex: 1 }}>{adventure.name}</span>
-                  {adventure.visibility === 'private' && <PrivateItemBadge />}
-                </AdventureDayDetailItem>
-              )
-            })}
-          </>
+        <AdventuresSectionHeader>
+          Adventures
+          {onAddAdventure && selectedDay && (
+            <AdventuresAddButton onClick={(e) => { e.stopPropagation(); onAddAdventure(selectedDay) }}>+</AdventuresAddButton>
+          )}
+        </AdventuresSectionHeader>
+        {adventures.length === 0 ? (
+          <DayDetailEmpty>No adventures planned</DayDetailEmpty>
+        ) : (
+          adventures.map(adventure => {
+            const time = formatAdventureTime(adventure.time)
+            return (
+              <AdventureDayDetailItem key={adventure.id} onClick={() => onAdventureClick?.(adventure.id)}>
+                <ExploreIcon sx={{ fontSize: '0.9rem', color: '#06b6d4', flexShrink: 0 }} />
+                {time && <TimeBadge>{time}</TimeBadge>}
+                <span style={{ flex: 1 }}>{adventure.name}</span>
+                {adventure.visibility === 'private' && <PrivateItemBadge />}
+              </AdventureDayDetailItem>
+            )
+          })
         )}
       </DrawerContent>
     </DraggableBottomDrawer>

--- a/packages/web/src/components/Planner/CalendarView/index.styled.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.styled.tsx
@@ -474,3 +474,21 @@ export const TasksAddButton = styled('span')({
     borderStyle: 'solid',
   },
 })
+
+export const AdventuresAddButton = styled('span')({
+  fontSize: '0.85rem',
+  fontWeight: 700,
+  color: '#0891b2',
+  backgroundColor: 'rgba(6, 182, 212, 0.12)',
+  border: '1.5px dashed #06b6d4',
+  borderRadius: '6px',
+  padding: '1px 8px',
+  cursor: 'pointer',
+  marginLeft: 'auto',
+  transition: 'all 0.12s ease',
+  lineHeight: 1.4,
+  '&:hover': {
+    backgroundColor: 'rgba(6, 182, 212, 0.22)',
+    borderStyle: 'solid',
+  },
+})

--- a/packages/web/src/components/Planner/WeeklyView/index.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.tsx
@@ -43,6 +43,8 @@ interface IWeeklyViewProps {
   onMealPlanClick?: (mealPlan: IMealPlan) => void
   adventures?: IAdventure[]
   onAdventureClick?: (id: string) => void
+  onAddAdventure?: (date: string) => void
+  onAddTask?: (date: string) => void
 }
 
 const getWeekStart = (d: Dayjs): Dayjs => {
@@ -61,6 +63,8 @@ const WeeklyView = ({
   onMealPlanClick,
   adventures = [],
   onAdventureClick,
+  onAddAdventure,
+  onAddTask,
 }: IWeeklyViewProps) => {
   const [currentWeek, setCurrentWeek] = useState<Dayjs>(() => getWeekStart(dayjs()))
   const [animationDirection, setAnimationDirection] = useState<'left' | 'right' | null>(null)
@@ -315,6 +319,8 @@ const WeeklyView = ({
         onAddMealPlan={_onAddMealPlan}
         onMealPlanClick={onMealPlanClick}
         onAdventureClick={onAdventureClick}
+        onAddAdventure={onAddAdventure}
+        onAddTask={onAddTask}
       />
     </WeeklyContainer>
   )

--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -34,6 +34,8 @@ export const Planner = ({
   mealPlans = [],
   onAddMealPlan,
   onMealPlanClick,
+  onAddAdventure,
+  onAddTask: _onAddTask,
 }: IToDoListProps = {}) => {
   const { dispatch } = useAppState();
   const { user } = useAuth();
@@ -123,6 +125,11 @@ export const Planner = ({
     navigate(Route.AddPlannerItem)
   }, [dispatch, navigate])
 
+  const handleAddAdventure = useCallback((date: string) => {
+    dispatch({ type: ActionName.SET_SELECTED_CALENDAR_DATE, payload: date })
+    navigate(Route.AddPlannerItem, { state: { itemType: 'adventure' } })
+  }, [dispatch, navigate])
+
   const handleStepToggle = useCallback(async (todoId: string, stepId: string, isDone: boolean) => {
     const item = toDoList.find(t => t.id === todoId)
     if (!item?.steps) return
@@ -201,6 +208,8 @@ export const Planner = ({
             onMealPlanClick={onMealPlanClick}
             adventures={adventures}
             onAdventureClick={handleAdventurePreview}
+            onAddAdventure={onAddAdventure ?? handleAddAdventure}
+            onAddTask={_onAddTask ?? handleAddTask}
           />
         )}
         {drawers}

--- a/packages/web/src/components/Planner/types.ts
+++ b/packages/web/src/components/Planner/types.ts
@@ -8,4 +8,6 @@ export interface IToDoListProps {
   mealPlans?: IMealPlan[];
   onAddMealPlan?: (date: string) => void;
   onMealPlanClick?: (mealPlan: IMealPlan) => void;
+  onAddAdventure?: (date: string) => void;
+  onAddTask?: (date: string) => void;
 };

--- a/packages/web/src/routes/PlannerRoute/index.tsx
+++ b/packages/web/src/routes/PlannerRoute/index.tsx
@@ -135,6 +135,16 @@ const PlannerContent = () => {
     navigate(Route.AddPlannerItem, { state: { itemType: 'meal' } })
   }, [dispatch, navigate])
 
+  const handleAddAdventure = useCallback((date: string) => {
+    dispatch({ type: ActionName.SET_SELECTED_CALENDAR_DATE, payload: date })
+    navigate(Route.AddPlannerItem, { state: { itemType: 'adventure' } })
+  }, [dispatch, navigate])
+
+  const handleAddTask = useCallback((date: string) => {
+    dispatch({ type: ActionName.SET_SELECTED_CALENDAR_DATE, payload: date })
+    navigate(Route.AddPlannerItem)
+  }, [dispatch, navigate])
+
   const handleMealPlanClick = useCallback((mealPlan: IMealPlan) => {
     setPreviewMealPlan(mealPlan)
   }, [])
@@ -188,6 +198,8 @@ const PlannerContent = () => {
             mealPlans={mealPlans}
             onAddMealPlan={handleAddMealPlan}
             onMealPlanClick={handleMealPlanClick}
+            onAddAdventure={handleAddAdventure}
+            onAddTask={handleAddTask}
           />
         </ScrollableContainer>
       </Container>


### PR DESCRIPTION
When selecting a day in the weekly view, the day preview drawer now shows
+ buttons for Adventures and Tasks sections (alongside the existing Meals button),
navigating to the add planner item form with the correct type and date pre-filled.
The Adventures section is now always visible in the drawer (showing empty state
when no adventures are planned).

https://claude.ai/code/session_011r4j2qSTBKtJwRgQNt2qBL