### PR TITLE
feat: support Google Maps URLs in the adventure location field

### DIFF
--- a/packages/web/src/components/AdventurePreviewDrawer/index.tsx
+++ b/packages/web/src/components/AdventurePreviewDrawer/index.tsx
@@ -9,6 +9,7 @@ import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import LocationOnIcon from '@mui/icons-material/LocationOn'
 import CloseIcon from '@mui/icons-material/Close'
 import { IAdventure } from '../../types/adventure'
+import { getLocationLink } from '../../utils/location'
 import { usePreviewDrawerActions } from '../../hooks/usePreviewDrawerActions'
 import DraggableBottomDrawer from '../DraggableBottomDrawer'
 import {
@@ -128,19 +129,22 @@ const AdventurePreviewDrawer = ({ item, onClose, onEdit, onDelete }: AdventurePr
               </DetailRow>
             )}
 
-            {item?.location && (
-              <DetailRow>
-                <LocationOnIcon />
-                <a
-                  href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(item.location)}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ color: 'inherit', textDecoration: 'underline' }}
-                >
-                  {item.location}
-                </a>
-              </DetailRow>
-            )}
+            {item?.location && (() => {
+              const { label, href } = getLocationLink(item.location)
+              return (
+                <DetailRow>
+                  <LocationOnIcon />
+                  <a
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: 'inherit', textDecoration: 'underline' }}
+                  >
+                    {label}
+                  </a>
+                </DetailRow>
+              )
+            })()}
           </Box>
         </Box>
 

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingAdventureCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingAdventureCard/index.tsx
@@ -3,6 +3,7 @@ import ExploreIcon from '@mui/icons-material/Explore'
 import AccessTimeIcon from '@mui/icons-material/AccessTime'
 import LocationOnIcon from '@mui/icons-material/LocationOn'
 import { IAdventure } from '../../../../../../types/adventure'
+import { getLocationLink } from '../../../../../../utils/location'
 import {
   CarouselContainer,
   CarouselTrack,
@@ -190,21 +191,24 @@ export const UpcomingAdventureCard: React.FC<IUpcomingAdventureCardProps> = ({ a
                           {adventure.time}
                         </>
                       )}
-                      {adventure.location && (
-                        <>
-                          {adventure.time && <span>·</span>}
-                          <LocationOnIcon />
-                          <a
-                            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(adventure.location)}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            onClick={(e) => e.stopPropagation()}
-                            style={{ color: 'inherit', textDecoration: 'underline' }}
-                          >
-                            {adventure.location}
-                          </a>
-                        </>
-                      )}
+                      {adventure.location && (() => {
+                        const { label, href } = getLocationLink(adventure.location)
+                        return (
+                          <>
+                            {adventure.time && <span>·</span>}
+                            <LocationOnIcon />
+                            <a
+                              href={href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              onClick={(e) => e.stopPropagation()}
+                              style={{ color: 'inherit', textDecoration: 'underline' }}
+                            >
+                              {label}
+                            </a>
+                          </>
+                        )
+                      })()}
                     </HeroMeta>
                   )}
                 </HeroOverlay>

--- a/packages/web/src/utils/location/index.test.ts
+++ b/packages/web/src/utils/location/index.test.ts
@@ -1,0 +1,90 @@
+import { getLocationLink } from '.'
+
+describe('Given the getLocationLink function', () => {
+  describe('when the location is plain text', () => {
+    it('should return the text as label and a Google Maps search link as href', () => {
+      const result = getLocationLink('Heathrow T5')
+
+      expect(result).toEqual({
+        label: 'Heathrow T5',
+        href: 'https://www.google.com/maps/search/?api=1&query=Heathrow%20T5',
+      })
+    })
+  })
+
+  describe('when the location is a Google Maps place URL', () => {
+    it('should extract the place name as label and use the URL as href', () => {
+      const url = 'https://www.google.com/maps/place/O2+Arena/@51.5030,-0.0029,17z'
+
+      const result = getLocationLink(url)
+
+      expect(result).toEqual({
+        label: 'O2 Arena',
+        href: url,
+      })
+    })
+
+    it('should handle percent-encoded place names', () => {
+      const url = 'https://www.google.com/maps/place/Heathrow%20Terminal%205/@51.4775,-0.4614,15z'
+
+      const result = getLocationLink(url)
+
+      expect(result).toEqual({
+        label: 'Heathrow Terminal 5',
+        href: url,
+      })
+    })
+  })
+
+  describe('when the location is a Google Maps search URL with a query param', () => {
+    it('should use the query value as label', () => {
+      const url = 'https://www.google.com/maps/search/?api=1&query=Eiffel+Tower'
+
+      const result = getLocationLink(url)
+
+      expect(result).toEqual({
+        label: 'Eiffel Tower',
+        href: url,
+      })
+    })
+  })
+
+  describe('when the location is a maps.google.com URL without a recognisable label', () => {
+    it('should fall back to "Google Maps" as label', () => {
+      const url = 'https://maps.google.com/?ll=51.5,-0.1'
+
+      const result = getLocationLink(url)
+
+      expect(result).toEqual({
+        label: 'Google Maps',
+        href: url,
+      })
+    })
+  })
+
+  describe('when the location is a goo.gl short URL', () => {
+    it('should fall back to "Google Maps" as label', () => {
+      const url = 'https://goo.gl/maps/abc123'
+
+      const result = getLocationLink(url)
+
+      expect(result).toEqual({
+        label: 'Google Maps',
+        href: url,
+      })
+    })
+  })
+
+  describe('when the location is a maps.app.goo.gl short URL', () => {
+    it('should fall back to "Google Maps" as label', () => {
+      const url = 'https://maps.app.goo.gl/xyz789'
+
+      const result = getLocationLink(url)
+
+      expect(result).toEqual({
+        label: 'Google Maps',
+        href: url,
+      })
+    })
+  })
+})

--- a/packages/web/src/utils/location/index.ts
+++ b/packages/web/src/utils/location/index.ts
@@ -1,0 +1,44 @@
+const isGoogleMapsUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value)
+    return (
+      (url.hostname === 'www.google.com' && url.pathname.startsWith('/maps')) ||
+      url.hostname === 'maps.google.com' ||
+      (url.hostname === 'goo.gl' && url.pathname.startsWith('/maps')) ||
+      url.hostname === 'maps.app.goo.gl'
+    )
+  } catch {
+    return false
+  }
+}
+
+const extractGoogleMapsLabel = (value: string): string => {
+  try {
+    const url = new URL(value)
+
+    const placeMatch = url.pathname.match(/\/maps\/place\/([^/]+)/)
+    if (placeMatch) {
+      return decodeURIComponent(placeMatch[1].replace(/\+/g, ' '))
+    }
+
+    const query = url.searchParams.get('q') ?? url.searchParams.get('query')
+    if (query) return query
+
+    return 'Google Maps'
+  } catch {
+    return 'Google Maps'
+  }
+}
+
+export const getLocationLink = (location: string): { label: string; href: string } => {
+  if (isGoogleMapsUrl(location)) {
+    return {
+      label: extractGoogleMapsLabel(location),
+      href: location,
+    }
+  }
+  return {
+    label: location,
+    href: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`,
+  }
+}


### PR DESCRIPTION
When a Google Maps URL is entered as the location, the display now shows
a human-readable label (place name extracted from URL, or "Google Maps"
for short links) instead of the raw URL, and clicking links directly to
that URL rather than a new search.

Plain-text locations continue to work as before (Google Maps search link).

https://claude.ai/code/session_01VsVKwkkXvxno1hAGmZybNe