### PR TITLE
fix: prevent pull-to-refresh when scrolling planner weekly view

### DIFF
--- a/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/index.styled.tsx
@@ -64,6 +64,7 @@ export const WeekRowsWrapper = styled('div')<{
 }>(({ $animationDirection }) => ({
   flex: 1,
   overflowY: 'auto',
+  overscrollBehavior: 'contain',
   padding: '0 12px 16px',
   display: 'flex',
   flexDirection: 'column',


### PR DESCRIPTION
Add overscrollBehavior: 'contain' to WeekRowsWrapper so vertical scroll
events don't leak to the parent page when the inner list reaches its
top boundary, which was triggering the browser pull-to-refresh indicator.

https://claude.ai/code/session_01QF1MjFNAdRfYc5hDhxy7Z3