### PR TITLE
Add optional end time to adventures for time range display

### DIFF
--- a/packages/lambdas/libs/dynamodb/types/adventures/index.ts
+++ b/packages/lambdas/libs/dynamodb/types/adventures/index.ts
@@ -7,6 +7,7 @@ export interface IAdventure extends IPrivateItemFields {
   date: string        // YYYY-MM-DD
   endDate?: string    // YYYY-MM-DD (optional, for multi-day events)
   time?: string       // HH:MM
+  endTime?: string    // HH:MM (optional, for time range)
   location?: string
   notes?: string
   imagePath?: string

--- a/packages/lambdas/sources/add_adventure/body/index.ts
+++ b/packages/lambdas/sources/add_adventure/body/index.ts
@@ -13,6 +13,10 @@ const validateBody = (body: any): body is IRequestBody => {
     return false;
   }
 
+  if (body.endTime !== undefined && typeof body.endTime !== 'string') {
+    return false;
+  }
+
   if (body.location !== undefined && typeof body.location !== 'string') {
     return false;
   }

--- a/packages/lambdas/sources/add_adventure/body/types.ts
+++ b/packages/lambdas/sources/add_adventure/body/types.ts
@@ -3,6 +3,7 @@ export interface IRequestBody {
   date: string
   endDate?: string
   time?: string
+  endTime?: string
   location?: string
   notes?: string
   imagePath?: string

--- a/packages/lambdas/sources/add_adventure/database/index.ts
+++ b/packages/lambdas/sources/add_adventure/database/index.ts
@@ -7,6 +7,7 @@ export const createAdventure = async (adventure: {
   date: string;
   endDate?: string;
   time?: string;
+  endTime?: string;
   location?: string;
   notes?: string;
   imagePath?: string;
@@ -31,6 +32,10 @@ export const createAdventure = async (adventure: {
 
   if (adventure.time) {
     item.time = adventure.time.trim();
+  }
+
+  if (adventure.endTime) {
+    item.endTime = adventure.endTime.trim();
   }
 
   if (adventure.location) {

--- a/packages/lambdas/sources/add_adventure/index.ts
+++ b/packages/lambdas/sources/add_adventure/index.ts
@@ -23,9 +23,9 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
       });
     }
 
-    const { name, date, endDate, time, location, notes, imagePath, isPrivate } = body;
+    const { name, date, endDate, time, endTime, location, notes, imagePath, isPrivate } = body;
 
-    const id = await createAdventure({ projectId, name, date, endDate, time, location, notes, imagePath, isPrivate, userId });
+    const id = await createAdventure({ projectId, name, date, endDate, time, endTime, location, notes, imagePath, isPrivate, userId });
 
     return createResponse({
       statusCode: 201,

--- a/packages/lambdas/sources/update_adventure/body/index.ts
+++ b/packages/lambdas/sources/update_adventure/body/index.ts
@@ -17,6 +17,10 @@ const validateBody = (body: any): body is IRequestBody => {
     return false;
   }
 
+  if (body.endTime !== undefined && body.endTime !== null && typeof body.endTime !== 'string') {
+    return false;
+  }
+
   if (body.location !== undefined && body.location !== null && typeof body.location !== 'string') {
     return false;
   }

--- a/packages/lambdas/sources/update_adventure/body/types.ts
+++ b/packages/lambdas/sources/update_adventure/body/types.ts
@@ -4,6 +4,7 @@ export interface IRequestBody {
   date?: string
   endDate?: string | null
   time?: string | null
+  endTime?: string | null
   location?: string | null
   notes?: string | null
   imagePath?: string | null

--- a/packages/lambdas/sources/update_adventure/database/index.ts
+++ b/packages/lambdas/sources/update_adventure/database/index.ts
@@ -2,7 +2,7 @@ import { DynamoDBTable, updateItem } from "@kairos-lambdas-libs/dynamodb";
 
 export const updateAdventure = async (
   id: string,
-  fields: { name?: string; date?: string; endDate?: string | null; time?: string | null; location?: string | null; notes?: string | null; imagePath?: string | null; isPrivate?: boolean; userId?: string }
+  fields: { name?: string; date?: string; endDate?: string | null; time?: string | null; endTime?: string | null; location?: string | null; notes?: string | null; imagePath?: string | null; isPrivate?: boolean; userId?: string }
 ): Promise<void> => {
   const updatedFields: Record<string, any> = {
     updatedAt: new Date().toISOString(),
@@ -30,6 +30,10 @@ export const updateAdventure = async (
 
   if (fields.time !== undefined) {
     updatedFields.time = fields.time || null;
+  }
+
+  if (fields.endTime !== undefined) {
+    updatedFields.endTime = fields.endTime || null;
   }
 
   if (fields.location !== undefined) {

--- a/packages/lambdas/sources/update_adventure/index.ts
+++ b/packages/lambdas/sources/update_adventure/index.ts
@@ -24,7 +24,7 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
       });
     }
 
-    const { id, name, date, endDate, time, location, notes, imagePath, isPrivate } = body;
+    const { id, name, date, endDate, time, endTime, location, notes, imagePath, isPrivate } = body;
 
     const existingItem = await getItem({
       tableName: DynamoDBTable.ADVENTURES,
@@ -38,7 +38,7 @@ export const handler: Handler<APIGatewayProxyEvent> = middleware(
       });
     }
 
-    await updateAdventure(id, { name, date, endDate, time, location, notes, imagePath, isPrivate, userId });
+    await updateAdventure(id, { name, date, endDate, time, endTime, location, notes, imagePath, isPrivate, userId });
 
     return createResponse({
       statusCode: 200,

--- a/packages/web/src/api/adventures/types.ts
+++ b/packages/web/src/api/adventures/types.ts
@@ -3,6 +3,7 @@ export interface IAddAdventureRequest {
   date: string
   endDate?: string
   time?: string
+  endTime?: string
   location?: string
   notes?: string
   imagePath?: string
@@ -14,6 +15,7 @@ export interface IUpdateAdventureRequest {
   date?: string
   endDate?: string | null
   time?: string | null
+  endTime?: string | null
   location?: string | null
   notes?: string | null
   imagePath?: string | null

--- a/packages/web/src/components/AdventurePreviewDrawer/index.tsx
+++ b/packages/web/src/components/AdventurePreviewDrawer/index.tsx
@@ -122,10 +122,10 @@ const AdventurePreviewDrawer = ({ item, onClose, onEdit, onDelete }: AdventurePr
               {item && formatDateRange(item.date, item.endDate)}
             </DetailRow>
 
-            {item?.time && (
+            {(item?.time || item?.endTime) && (
               <DetailRow>
                 <AccessTimeIcon />
-                {item.time}
+                {item.time && item.endTime ? `${item.time} - ${item.endTime}` : item.time ?? item.endTime}
               </DetailRow>
             )}
 

--- a/packages/web/src/routes/AddPlannerItemRoute/AdventureForm/index.tsx
+++ b/packages/web/src/routes/AddPlannerItemRoute/AdventureForm/index.tsx
@@ -115,6 +115,7 @@ const AdventureForm = () => {
   )
   const [endDate, setEndDate] = useState<Dayjs | null>(null)
   const [time, setTime] = useState('')
+  const [endTime, setEndTime] = useState('')
   const [location, setLocation] = useState('')
   const [notes, setNotes] = useState('')
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
@@ -182,6 +183,7 @@ const AdventureForm = () => {
         date: date!.format('YYYY-MM-DD'),
         endDate: endDate?.isValid() ? endDate.format('YYYY-MM-DD') : undefined,
         time: time.trim() || undefined,
+        endTime: endTime.trim() || undefined,
         location: location.trim() || undefined,
         notes: notes.trim() || undefined,
         imagePath,
@@ -193,7 +195,7 @@ const AdventureForm = () => {
     } finally {
       setIsLoading(false)
     }
-  }, [canSave, name, date, endDate, time, location, notes, imagePath, isPrivate, addAdventure, navigate])
+  }, [canSave, name, date, endDate, time, endTime, location, notes, imagePath, isPrivate, addAdventure, navigate])
 
   return (
     <FormContainer>
@@ -344,6 +346,16 @@ const AdventureForm = () => {
                 type="time"
                 value={time}
                 onChange={e => setTime(e.target.value)}
+                disabled={isLoading}
+                InputLabelProps={{ shrink: true }}
+              />
+
+              <AdventureTextField
+                fullWidth
+                label="End time (optional)"
+                type="time"
+                value={endTime}
+                onChange={e => setEndTime(e.target.value)}
                 disabled={isLoading}
                 InputLabelProps={{ shrink: true }}
               />

--- a/packages/web/src/routes/EditAdventureRoute/index.tsx
+++ b/packages/web/src/routes/EditAdventureRoute/index.tsx
@@ -128,6 +128,7 @@ const EditAdventureContent = () => {
   const [date, setDate] = useState<Dayjs | null>(null)
   const [endDate, setEndDate] = useState<Dayjs | null>(null)
   const [time, setTime] = useState('')
+  const [endTime, setEndTime] = useState('')
   const [location, setLocation] = useState('')
   const [notes, setNotes] = useState('')
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
@@ -145,6 +146,7 @@ const EditAdventureContent = () => {
       setDate(dayjs(adventure.date))
       setEndDate(adventure.endDate ? dayjs(adventure.endDate) : null)
       setTime(adventure.time ?? '')
+      setEndTime(adventure.endTime ?? '')
       setLocation(adventure.location ?? '')
       setNotes(adventure.notes ?? '')
       setImagePath(adventure.imagePath)
@@ -213,6 +215,7 @@ const EditAdventureContent = () => {
         date: date!.format('YYYY-MM-DD'),
         endDate: endDate?.isValid() ? endDate.format('YYYY-MM-DD') : null,
         time: time.trim() || null,
+        endTime: endTime.trim() || null,
         location: location.trim() || null,
         notes: notes.trim() || null,
         imagePath: imagePath ?? null,
@@ -225,7 +228,7 @@ const EditAdventureContent = () => {
     } finally {
       setIsLoading(false)
     }
-  }, [canSave, id, name, date, endDate, time, location, notes, imagePath, isPrivate, updateAdventure, dispatch, navigate])
+  }, [canSave, id, name, date, endDate, time, endTime, location, notes, imagePath, isPrivate, updateAdventure, dispatch, navigate])
 
   const displayImageUrl = previewUrl ?? (adventure?.imagePath ? adventure.imagePath : null)
 
@@ -355,6 +358,16 @@ const EditAdventureContent = () => {
                   type="time"
                   value={time}
                   onChange={e => setTime(e.target.value)}
+                  disabled={isLoading}
+                  InputLabelProps={{ shrink: true }}
+                />
+
+                <AdventureTextField
+                  fullWidth
+                  label="End time (optional)"
+                  type="time"
+                  value={endTime}
+                  onChange={e => setEndTime(e.target.value)}
                   disabled={isLoading}
                   InputLabelProps={{ shrink: true }}
                 />

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingAdventureCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingAdventureCard/index.tsx
@@ -183,19 +183,21 @@ export const UpcomingAdventureCard: React.FC<IUpcomingAdventureCardProps> = ({ a
                     {dayLabel}
                   </HeroLabel>
                   <HeroTitle>{adventure.name}</HeroTitle>
-                  {(adventure.time || adventure.location) && (
+                  {(adventure.time || adventure.endTime || adventure.location) && (
                     <HeroMeta>
-                      {adventure.time && (
+                      {(adventure.time || adventure.endTime) && (
                         <>
                           <AccessTimeIcon />
-                          {adventure.time}
+                          {adventure.time && adventure.endTime
+                            ? `${adventure.time} - ${adventure.endTime}`
+                            : adventure.time ?? adventure.endTime}
                         </>
                       )}
                       {adventure.location && (() => {
                         const { label, href } = getLocationLink(adventure.location)
                         return (
                           <>
-                            {adventure.time && <span>·</span>}
+                            {(adventure.time || adventure.endTime) && <span>·</span>}
                             <LocationOnIcon />
                             <a
                               href={href}

--- a/packages/web/src/types/adventure.ts
+++ b/packages/web/src/types/adventure.ts
@@ -5,6 +5,7 @@ export interface IAdventure {
   date: string        // YYYY-MM-DD
   endDate?: string    // YYYY-MM-DD (optional, for multi-day events)
   time?: string       // HH:MM
+  endTime?: string    // HH:MM (optional, for time range)
   location?: string
   notes?: string
   imagePath?: string


### PR DESCRIPTION
Adds an `endTime` field (HH:MM, optional) to adventures across the full stack.
When both start and end times are set, views display a time range (e.g. "10:00 - 12:00").

https://claude.ai/code/session_01RCjTqR5qaUSRoqQcMuCeGU