### PR TITLE
fix: show error state instead of empty lists when offline

### DIFF
--- a/packages/web/src/components/ShopList/index.test.tsx
+++ b/packages/web/src/components/ShopList/index.test.tsx
@@ -51,15 +51,31 @@ describe("Given the ShopList component", () => {
   });
 
   describe("When the shops list is empty", () => {
-    it("should render without errors", () => {
+    it("should show empty state message", () => {
       mockShopContext();
       const mockNavigate = vi.fn();
       (useNavigate as Mock).mockReturnValue(mockNavigate);
-      
+
       render(<ShopList shops={[]} onDelete={vi.fn()} onEdit={vi.fn()} />);
-      
-      expect(screen.getByTestId("swipeable-list")).toBeVisible();
-      expect(screen.queryAllByTestId("shop-item")).toHaveLength(0);
+
+      expect(screen.getByText('No shops found')).toBeVisible();
+    });
+  });
+
+  describe("When the shops list failed to load", () => {
+    it("should show error state message", () => {
+      (useShopContext as Mock).mockReturnValue({
+        currentShop: null,
+        setCurrentShop: vi.fn(),
+        isLoading: false,
+        isError: true,
+      });
+      const mockNavigate = vi.fn();
+      (useNavigate as Mock).mockReturnValue(mockNavigate);
+
+      render(<ShopList shops={[]} onDelete={vi.fn()} onEdit={vi.fn()} />);
+
+      expect(screen.getByText('Unable to load shops')).toBeVisible();
     });
   });
 
@@ -94,6 +110,7 @@ const mockShopContext = () => {
     currentShop: null,
     setCurrentShop: vi.fn(),
     isLoading: false,
+    isError: false,
   });
 };
 

--- a/packages/web/src/components/ShopList/index.tsx
+++ b/packages/web/src/components/ShopList/index.tsx
@@ -1,15 +1,24 @@
 import ShopItem from '../ShopItem'
 import SwipeableList from '../SwipeableList'
+import EmptyState from '../EmptyState'
 import { Container } from './index.styled'
 import { IShopListProps } from './types'
 import Placeholder from './Placeholder'
 import { useShopContext } from '../../providers/ShopProvider'
 
 const ShopList = ({ shops, onDelete, onEdit }: IShopListProps) => {
-  const { isLoading } = useShopContext()
+  const { isLoading, isError } = useShopContext()
 
   if (isLoading) {
     return <Placeholder />
+  }
+
+  if (shops.length === 0) {
+    return (
+      <EmptyState>
+        {isError ? 'Unable to load shops' : 'No shops found'}
+      </EmptyState>
+    )
   }
 
   return (

--- a/packages/web/src/providers/AdventureProvider/index.tsx
+++ b/packages/web/src/providers/AdventureProvider/index.tsx
@@ -7,6 +7,7 @@ import { useEntityCrud } from '../../hooks/useEntityCrud'
 const initialState: IState = {
   adventures: [],
   isLoading: false,
+  isError: false,
   refetchAdventures: async () => {},
   addAdventure: async () => {},
   updateAdventure: async () => {},
@@ -18,7 +19,7 @@ export const AdventureContext = createContext<IState>(initialState)
 export const useAdventureContext = () => useContext(AdventureContext)
 
 export const AdventureProvider = ({ children }: IAdventureProviderProps) => {
-  const { items: adventures, isLoading, currentProject, refetch, addToCache, update, remove } = useEntityCrud<IAdventure, IUpdateAdventureRequest>({
+  const { items: adventures, isLoading, isError, currentProject, refetch, addToCache, update, remove } = useEntityCrud<IAdventure, IUpdateAdventureRequest>({
     queryKey: 'adventures',
     fetchFn: getAdventures,
     updateFn: (id, fields, projectId) => updateAdventureApi(id, fields, projectId),
@@ -40,12 +41,13 @@ export const AdventureProvider = ({ children }: IAdventureProviderProps) => {
     () => ({
       adventures,
       isLoading,
+      isError,
       refetchAdventures: refetch,
       addAdventure,
       updateAdventure: update,
       removeAdventure: remove,
     }),
-    [adventures, isLoading, refetch, addAdventure, update, remove]
+    [adventures, isLoading, isError, refetch, addAdventure, update, remove]
   )
 
   return (

--- a/packages/web/src/providers/AdventureProvider/types.ts
+++ b/packages/web/src/providers/AdventureProvider/types.ts
@@ -6,6 +6,7 @@ export type { IAddAdventureRequest, IUpdateAdventureRequest }
 export interface IState {
   adventures: IAdventure[]
   isLoading: boolean
+  isError: boolean
   refetchAdventures: () => Promise<void>
   addAdventure: (adventure: IAddAdventureRequest) => Promise<void>
   updateAdventure: (id: string, fields: IUpdateAdventureRequest) => Promise<void>

--- a/packages/web/src/providers/MealPlanProvider/index.tsx
+++ b/packages/web/src/providers/MealPlanProvider/index.tsx
@@ -8,6 +8,7 @@ import { useEntityCrud } from '../../hooks/useEntityCrud'
 const initialState: IState = {
   mealPlans: [],
   isLoading: false,
+  isError: false,
   fetchMealPlans: async () => {},
   addMealPlan: async () => {},
   updateMealPlan: async () => {},
@@ -19,7 +20,7 @@ export const MealPlanContext = createContext<IState>(initialState)
 export const useMealPlanContext = () => useContext(MealPlanContext)
 
 export const MealPlanProvider = ({ children }: IMealPlanProviderProps) => {
-  const { items: mealPlans, isLoading, currentProject, refetch, addToCache, update, remove } = useEntityCrud<IMealPlan>({
+  const { items: mealPlans, isLoading, isError, currentProject, refetch, addToCache, update, remove } = useEntityCrud<IMealPlan>({
     queryKey: 'mealPlans',
     fetchFn: getMealPlans,
     updateFn: (id, fields, projectId) => updateMealPlanApi(id, fields, projectId),
@@ -46,12 +47,13 @@ export const MealPlanProvider = ({ children }: IMealPlanProviderProps) => {
     () => ({
       mealPlans,
       isLoading,
+      isError,
       fetchMealPlans: refetch,
       addMealPlan,
       updateMealPlan: update,
       removeMealPlan: remove,
     }),
-    [mealPlans, isLoading, refetch, addMealPlan, update, remove]
+    [mealPlans, isLoading, isError, refetch, addMealPlan, update, remove]
   )
 
   return (

--- a/packages/web/src/providers/MealPlanProvider/types.ts
+++ b/packages/web/src/providers/MealPlanProvider/types.ts
@@ -5,6 +5,7 @@ import { MealType } from '../../enums/mealType'
 export interface IState {
   mealPlans: IMealPlan[]
   isLoading: boolean
+  isError: boolean
   fetchMealPlans: () => Promise<void>
   addMealPlan: (date: string, recipeName: string, recipeId?: string, mealType?: MealType, imagePath?: string, isPrivate?: boolean) => Promise<void>
   updateMealPlan: (id: string, fields: { date?: string; recipeName?: string; recipeId?: string | null; mealType?: MealType | null; imagePath?: string | null }) => Promise<void>

--- a/packages/web/src/providers/NoiseTrackingProvider/index.tsx
+++ b/packages/web/src/providers/NoiseTrackingProvider/index.tsx
@@ -7,6 +7,7 @@ import { useProjectContext } from '../ProjectProvider'
 export const initialState: IState = {
   noiseTrackingItems: [],
   isLoading: false,
+  isError: false,
   refetchNoiseTrackingItems: async () => {},
   addItemToCache: (_item: INoiseTrackingItem) => {},
   removeItemFromCache: (_timestamp: number) => {},
@@ -53,11 +54,12 @@ export const NoiseTrackingProvider = ({ children }: INoiseTrackingProviderProps)
     () => ({
       noiseTrackingItems,
       isLoading: query.isLoading,
+      isError: query.isError,
       refetchNoiseTrackingItems,
       addItemToCache,
       removeItemFromCache,
     }),
-    [noiseTrackingItems, query.isLoading, refetchNoiseTrackingItems, addItemToCache, removeItemFromCache]
+    [noiseTrackingItems, query.isLoading, query.isError, refetchNoiseTrackingItems, addItemToCache, removeItemFromCache]
   )
 
   return (

--- a/packages/web/src/providers/NoiseTrackingProvider/types.ts
+++ b/packages/web/src/providers/NoiseTrackingProvider/types.ts
@@ -8,6 +8,7 @@ export interface INoiseTrackingProviderProps {
 export interface IState {
     noiseTrackingItems: Array<INoiseTrackingItem>
     isLoading: boolean
+    isError: boolean
     refetchNoiseTrackingItems: () => Promise<void>
     addItemToCache: (item: INoiseTrackingItem) => void
     removeItemFromCache: (timestamp: number) => void

--- a/packages/web/src/providers/ShopProvider/index.tsx
+++ b/packages/web/src/providers/ShopProvider/index.tsx
@@ -12,6 +12,7 @@ import { useLocation } from 'react-router'
 export const initialState: IShopProviderState = {
   shops: [],
   isLoading: false,
+  isError: false,
   currentShop: null,
   fetchShops: async () => {},
   addShop: async (_shop: ICreateShopRequestBody, _isPrivate?: boolean) => '',
@@ -224,13 +225,14 @@ export const ShopProvider = ({ children }: IShopProviderProps) => {
   const value = useMemo(() => ({
     shops,
     isLoading: query.isLoading,
+    isError: query.isError,
     currentShop,
     fetchShops,
     addShop,
     updateShop,
     deleteShop,
     setCurrentShop,
-  }), [shops, query.isLoading, currentShop, fetchShops, addShop, updateShop, deleteShop, setCurrentShop])
+  }), [shops, query.isLoading, query.isError, currentShop, fetchShops, addShop, updateShop, deleteShop, setCurrentShop])
 
   return (
     <ShopContext.Provider value={value}>

--- a/packages/web/src/providers/ShopProvider/types.ts
+++ b/packages/web/src/providers/ShopProvider/types.ts
@@ -9,6 +9,7 @@ export interface IShopProviderProps {
 export interface IShopProviderState {
     shops: Array<IShop>
     isLoading: boolean
+    isError: boolean
     currentShop: IShop | null
     fetchShops: () => Promise<void>
     addShop: (shop: ICreateShopRequestBody, isPrivate?: boolean) => Promise<string>

--- a/packages/web/src/routes/HomeRoute/components/NoiseSection/index.test.tsx
+++ b/packages/web/src/routes/HomeRoute/components/NoiseSection/index.test.tsx
@@ -49,6 +49,7 @@ describe('NoiseSection component', () => {
           noiseTrackingItems={[]}
           noiseCounts={noiseCounts}
           isLoading={true}
+          isError={false}
           noiseView="overview"
           onNoiseViewChange={mockOnNoiseViewChange}
         />
@@ -62,18 +63,38 @@ describe('NoiseSection component', () => {
   describe('when no noise items exist', () => {
     it('should show empty state message in overview', () => {
       const noiseCounts = createMockNoiseCounts()
-      
+
       renderWithTheme(
         <NoiseSection
           noiseTrackingItems={[]}
           noiseCounts={noiseCounts}
           isLoading={false}
+          isError={false}
           noiseView="overview"
           onNoiseViewChange={mockOnNoiseViewChange}
         />
       )
-      
+
       expect(screen.getByText('No noise recordings found')).toBeInTheDocument()
+    })
+  })
+
+  describe('when loading noise items fails', () => {
+    it('should show error state message in overview', () => {
+      const noiseCounts = createMockNoiseCounts()
+
+      renderWithTheme(
+        <NoiseSection
+          noiseTrackingItems={[]}
+          noiseCounts={noiseCounts}
+          isLoading={false}
+          isError={true}
+          noiseView="overview"
+          onNoiseViewChange={mockOnNoiseViewChange}
+        />
+      )
+
+      expect(screen.getByText('Unable to load noise recordings')).toBeInTheDocument()
     })
   })
 
@@ -91,6 +112,7 @@ describe('NoiseSection component', () => {
           noiseTrackingItems={[]}
           noiseCounts={noiseCounts}
           isLoading={false}
+          isError={false}
           noiseView="overview"
           onNoiseViewChange={mockOnNoiseViewChange}
         />
@@ -118,6 +140,7 @@ describe('NoiseSection component', () => {
           noiseTrackingItems={[]}
           noiseCounts={noiseCounts}
           isLoading={false}
+          isError={false}
           noiseView="overview"
           onNoiseViewChange={mockOnNoiseViewChange}
         />
@@ -154,6 +177,7 @@ describe('NoiseSection component', () => {
           noiseTrackingItems={noiseItems}
           noiseCounts={noiseCounts}
           isLoading={false}
+          isError={false}
           noiseView="today"
           onNoiseViewChange={mockOnNoiseViewChange}
         />
@@ -187,6 +211,7 @@ describe('NoiseSection component', () => {
           noiseTrackingItems={noiseItems}
           noiseCounts={noiseCounts}
           isLoading={false}
+          isError={false}
           noiseView="last7days"
           onNoiseViewChange={mockOnNoiseViewChange}
         />
@@ -212,6 +237,7 @@ describe('NoiseSection component', () => {
           noiseTrackingItems={noiseItems}
           noiseCounts={noiseCounts}
           isLoading={false}
+          isError={false}
           noiseView="today"
           onNoiseViewChange={mockOnNoiseViewChange}
         />
@@ -229,6 +255,7 @@ describe('NoiseSection component', () => {
           noiseTrackingItems={[]}
           noiseCounts={noiseCounts}
           isLoading={false}
+          isError={false}
           noiseView="today"
           onNoiseViewChange={mockOnNoiseViewChange}
         />
@@ -259,6 +286,7 @@ describe('NoiseSection component', () => {
           noiseTrackingItems={noiseItems}
           noiseCounts={noiseCounts}
           isLoading={false}
+          isError={false}
           noiseView="today"
           onNoiseViewChange={mockOnNoiseViewChange}
         />

--- a/packages/web/src/routes/HomeRoute/components/NoiseSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/NoiseSection/index.tsx
@@ -52,6 +52,7 @@ export const NoiseSection: React.FC<INoiseSectionProps> = ({
   noiseTrackingItems,
   noiseCounts,
   isLoading,
+  isError,
   noiseView,
   onNoiseViewChange,
   onNavigate
@@ -69,7 +70,7 @@ export const NoiseSection: React.FC<INoiseSectionProps> = ({
 
     if (noiseView === 'overview') {
       if (noiseCounts.totalCount === 0) {
-        return <EmptyState>No noise recordings found</EmptyState>
+        return <EmptyState>{isError ? 'Unable to load noise recordings' : 'No noise recordings found'}</EmptyState>
       }
 
       return (

--- a/packages/web/src/routes/HomeRoute/components/NoiseSection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/NoiseSection/types.ts
@@ -6,6 +6,7 @@ export interface INoiseSectionProps {
   noiseTrackingItems: INoiseTrackingItem[]
   noiseCounts: INoiseCounts
   isLoading: boolean
+  isError: boolean
   noiseView: NoiseView
   onNoiseViewChange: (view: NoiseView) => void
   onNavigate?: () => void

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -62,7 +62,7 @@ const getUpcomingDateStrings = (days = 7): string[] => {
 const HomeDataContent = () => {
   const { groceryList, isLoading: isGroceryLoading, isError: isGroceryError } = useGroceryListContext()
   const { toDoList, isLoading: isToDoLoading, isError: isToDoError, removeFromToDoList, updateToDoItemFields } = usePlannerContext()
-  const { noiseTrackingItems, isLoading: isNoiseLoading } = useNoiseTrackingContext()
+  const { noiseTrackingItems, isLoading: isNoiseLoading, isError: isNoiseError } = useNoiseTrackingContext()
   const { birthdays, isError: isBirthdayError } = useBirthdayContext()
   const { mealPlans, isLoading: isMealLoading } = useMealPlanContext()
   const { adventures, isLoading: isAdventureLoading, removeAdventure } = useAdventureContext()
@@ -210,6 +210,7 @@ const HomeDataContent = () => {
           noiseTrackingItems={noiseTrackingItems}
           noiseCounts={homeData.noiseCounts}
           isLoading={isNoiseLoading}
+          isError={isNoiseError}
           noiseView={interactions.noiseView}
           onNoiseViewChange={interactions.handleNoiseViewChange}
           onNavigate={handleNoiseNavigate}


### PR DESCRIPTION
Expose isError from NoiseTrackingProvider, MealPlanProvider,
AdventureProvider, and ShopProvider so Home Screen widgets and the
Shops page display "Unable to load..." messages instead of misleading
"No items found" when data fetching fails (e.g. offline).

https://claude.ai/code/session_01TZ6bAL59Acht2GBsbXBQtM