### PR TITLE
feat: redesign tasks widget with rewarding sub-task completion UX

### DIFF
--- a/packages/web/src/components/CompleteTaskBanner/index.styled.tsx
+++ b/packages/web/src/components/CompleteTaskBanner/index.styled.tsx
@@ -1,0 +1,29 @@
+import { styled } from '@mui/material/styles'
+import { slideIn } from '../../utils/styles/stepAnimations'
+
+export const BannerWrapper = styled('button')<{ $compact?: boolean }>(({ $compact }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '0.4rem',
+  width: '100%',
+  padding: $compact ? '0.4rem 0.5rem' : '0.6rem 0.75rem',
+  border: 'none',
+  borderRadius: $compact ? '8px' : '10px',
+  background: 'linear-gradient(135deg, #059669 0%, #047857 100%)',
+  color: 'white',
+  fontSize: $compact ? '0.72rem' : '0.85rem',
+  fontWeight: 600,
+  cursor: 'pointer',
+  animation: `${slideIn} 0.3s ease forwards`,
+  transition: 'transform 0.15s ease, box-shadow 0.15s ease',
+  '&:hover': {
+    boxShadow: '0 2px 8px rgba(5, 150, 105, 0.3)',
+  },
+  '&:active': {
+    transform: 'scale(0.98)',
+  },
+  '& svg': {
+    fontSize: $compact ? '0.85rem' : '1rem',
+  },
+}))

--- a/packages/web/src/components/CompleteTaskBanner/index.test.tsx
+++ b/packages/web/src/components/CompleteTaskBanner/index.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import CompleteTaskBanner from '.'
+
+describe('Given the CompleteTaskBanner component', () => {
+  it('should render the completion text', () => {
+    render(<CompleteTaskBanner onClick={vi.fn()} />)
+    expect(screen.getByText(/all steps done/i)).toBeVisible()
+  })
+
+  it('should call onClick when clicked', async () => {
+    const onClick = vi.fn()
+    render(<CompleteTaskBanner onClick={onClick} />)
+    await userEvent.click(screen.getByText(/all steps done/i))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it('should render in compact mode', () => {
+    render(<CompleteTaskBanner onClick={vi.fn()} compact />)
+    expect(screen.getByText(/all steps done/i)).toBeVisible()
+  })
+})

--- a/packages/web/src/components/CompleteTaskBanner/index.tsx
+++ b/packages/web/src/components/CompleteTaskBanner/index.tsx
@@ -1,0 +1,19 @@
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import { BannerWrapper } from './index.styled'
+import { CompleteTaskBannerProps } from './types'
+
+const CompleteTaskBanner = ({ onClick, compact }: CompleteTaskBannerProps): React.ReactElement => {
+  const handleClick = (e: React.MouseEvent): void => {
+    e.stopPropagation()
+    onClick()
+  }
+
+  return (
+    <BannerWrapper $compact={compact} onClick={handleClick}>
+      <CheckCircleIcon />
+      All steps done — complete this task?
+    </BannerWrapper>
+  )
+}
+
+export default CompleteTaskBanner

--- a/packages/web/src/components/CompleteTaskBanner/types.ts
+++ b/packages/web/src/components/CompleteTaskBanner/types.ts
@@ -1,0 +1,4 @@
+export interface CompleteTaskBannerProps {
+  onClick: () => void
+  compact?: boolean
+}

--- a/packages/web/src/components/ConfettiBurst/index.test.tsx
+++ b/packages/web/src/components/ConfettiBurst/index.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import ConfettiBurst from '.'
+
+describe('Given the ConfettiBurst component', () => {
+  let mockRef: React.RefObject<HTMLDivElement | null>
+
+  beforeEach(() => {
+    const div = document.createElement('div')
+    div.getBoundingClientRect = vi.fn(() => ({
+      top: 100,
+      left: 100,
+      width: 50,
+      height: 50,
+      right: 150,
+      bottom: 150,
+      x: 100,
+      y: 100,
+      toJSON: vi.fn(),
+    }))
+    document.body.appendChild(div)
+    mockRef = { current: div }
+  })
+
+  afterEach(() => {
+    document.querySelectorAll('canvas').forEach(c => c.remove())
+  })
+
+  it('should not create a canvas when trigger is false', () => {
+    render(<ConfettiBurst trigger={false} anchorRef={mockRef} />)
+    expect(document.querySelector('canvas')).toBeNull()
+  })
+
+  it('should create a canvas when trigger becomes true', () => {
+    render(<ConfettiBurst trigger={true} anchorRef={mockRef} />)
+    expect(document.querySelector('canvas')).not.toBeNull()
+  })
+
+  it('should remove canvas on unmount', () => {
+    const { unmount } = render(<ConfettiBurst trigger={true} anchorRef={mockRef} />)
+    expect(document.querySelector('canvas')).not.toBeNull()
+    unmount()
+    expect(document.querySelector('canvas')).toBeNull()
+  })
+})

--- a/packages/web/src/components/ConfettiBurst/index.tsx
+++ b/packages/web/src/components/ConfettiBurst/index.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from 'react'
+import { ConfettiBurstProps } from './types'
+
+const PARTICLE_COUNT = 40
+const DURATION_MS = 1500
+const COLORS = ['#6366f1', '#7c3aed', '#a78bfa', '#c084fc', '#818cf8', '#f59e0b']
+
+interface Particle {
+  x: number
+  y: number
+  vx: number
+  vy: number
+  size: number
+  color: string
+  rotation: number
+  rotationSpeed: number
+  opacity: number
+  isCircle: boolean
+}
+
+const createParticles = (centerX: number, centerY: number): Particle[] =>
+  Array.from({ length: PARTICLE_COUNT }, () => ({
+    x: centerX,
+    y: centerY,
+    vx: (Math.random() - 0.5) * 8,
+    vy: -(Math.random() * 6 + 4),
+    size: Math.random() * 4 + 2,
+    color: COLORS[Math.floor(Math.random() * COLORS.length)],
+    rotation: Math.random() * 360,
+    rotationSpeed: (Math.random() - 0.5) * 10,
+    opacity: 1,
+    isCircle: Math.random() > 0.5,
+  }))
+
+const ConfettiBurst = ({ trigger, anchorRef }: ConfettiBurstProps): null => {
+  const prevTriggerRef = useRef(false)
+  const rafRef = useRef<number>(0)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  useEffect(() => {
+    if (!trigger || prevTriggerRef.current || !anchorRef.current) {
+      prevTriggerRef.current = trigger
+      return
+    }
+    prevTriggerRef.current = trigger
+
+    const rect = anchorRef.current.getBoundingClientRect()
+    const centerX = rect.left + rect.width / 2
+    const centerY = rect.top + rect.height / 2
+
+    const canvas = document.createElement('canvas')
+    canvas.width = window.innerWidth
+    canvas.height = window.innerHeight
+    canvas.style.position = 'fixed'
+    canvas.style.top = '0'
+    canvas.style.left = '0'
+    canvas.style.pointerEvents = 'none'
+    canvas.style.zIndex = '9999'
+    document.body.appendChild(canvas)
+    canvasRef.current = canvas
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return () => {
+        if (canvasRef.current) {
+          canvasRef.current.remove()
+          canvasRef.current = null
+        }
+      }
+    }
+
+    const particles = createParticles(centerX, centerY)
+    const startTime = performance.now()
+
+    const animate = (now: number): void => {
+      const elapsed = now - startTime
+      if (elapsed > DURATION_MS) {
+        canvas.remove()
+        canvasRef.current = null
+        return
+      }
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      for (const p of particles) {
+        p.x += p.vx
+        p.vy += 0.15
+        p.y += p.vy
+        p.rotation += p.rotationSpeed
+        if (elapsed > DURATION_MS * 0.6) {
+          p.opacity = Math.max(0, 1 - (elapsed - DURATION_MS * 0.6) / (DURATION_MS * 0.4))
+        }
+
+        ctx.save()
+        ctx.globalAlpha = p.opacity
+        ctx.translate(p.x, p.y)
+        ctx.rotate((p.rotation * Math.PI) / 180)
+        ctx.fillStyle = p.color
+
+        if (p.isCircle) {
+          ctx.beginPath()
+          ctx.arc(0, 0, p.size / 2, 0, Math.PI * 2)
+          ctx.fill()
+        } else {
+          ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size * 0.6)
+        }
+
+        ctx.restore()
+      }
+
+      rafRef.current = requestAnimationFrame(animate)
+    }
+
+    rafRef.current = requestAnimationFrame(animate)
+
+    return () => {
+      cancelAnimationFrame(rafRef.current)
+      if (canvasRef.current) {
+        canvasRef.current.remove()
+        canvasRef.current = null
+      }
+    }
+  }, [trigger, anchorRef])
+
+  return null
+}
+
+export default ConfettiBurst

--- a/packages/web/src/components/ConfettiBurst/types.ts
+++ b/packages/web/src/components/ConfettiBurst/types.ts
@@ -1,0 +1,4 @@
+export interface ConfettiBurstProps {
+  trigger: boolean
+  anchorRef: React.RefObject<HTMLElement | null>
+}

--- a/packages/web/src/components/StreakIndicator/index.styled.tsx
+++ b/packages/web/src/components/StreakIndicator/index.styled.tsx
@@ -1,0 +1,21 @@
+import { styled } from '@mui/material/styles'
+import { streakPulse } from '../../utils/styles/stepAnimations'
+
+export const StreakBadge = styled('div')({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '0.15rem',
+  padding: '0.1rem 0.35rem',
+  borderRadius: '10px',
+  background: 'linear-gradient(135deg, rgba(245, 158, 11, 0.15) 0%, rgba(251, 191, 36, 0.15) 100%)',
+  border: '1px solid rgba(245, 158, 11, 0.25)',
+  fontSize: '0.65rem',
+  fontWeight: 700,
+  color: '#d97706',
+  animation: `${streakPulse} 0.35s ease forwards`,
+  whiteSpace: 'nowrap',
+  '& .streak-icon': {
+    fontSize: '0.7rem',
+    lineHeight: 1,
+  },
+})

--- a/packages/web/src/components/StreakIndicator/index.test.tsx
+++ b/packages/web/src/components/StreakIndicator/index.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import StreakIndicator from '.'
+
+describe('Given the StreakIndicator component', () => {
+  it('should show streak count when visible and count >= 3', () => {
+    render(<StreakIndicator count={5} visible />)
+    expect(screen.getByText('x5')).toBeVisible()
+  })
+
+  it('should not render when visible is false', () => {
+    const { container } = render(<StreakIndicator count={5} visible={false} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should not render when count is less than 3', () => {
+    const { container } = render(<StreakIndicator count={2} visible />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should display the bolt icon', () => {
+    render(<StreakIndicator count={3} visible />)
+    expect(screen.getByText('⚡')).toBeVisible()
+  })
+})

--- a/packages/web/src/components/StreakIndicator/index.tsx
+++ b/packages/web/src/components/StreakIndicator/index.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+import { StreakBadge } from './index.styled'
+import { StreakIndicatorProps } from './types'
+
+const AUTO_HIDE_MS = 2000
+
+const StreakIndicator = ({ count, visible }: StreakIndicatorProps): React.ReactElement | null => {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    if (visible && count >= 3) {
+      setShow(true)
+      const timer = setTimeout(() => setShow(false), AUTO_HIDE_MS)
+      return () => clearTimeout(timer)
+    }
+    setShow(false)
+  }, [visible, count])
+
+  if (!show) return null
+
+  return (
+    <StreakBadge key={count}>
+      <span className="streak-icon">⚡</span>
+      x{count}
+    </StreakBadge>
+  )
+}
+
+export default StreakIndicator

--- a/packages/web/src/components/StreakIndicator/types.ts
+++ b/packages/web/src/components/StreakIndicator/types.ts
@@ -1,0 +1,4 @@
+export interface StreakIndicatorProps {
+  count: number
+  visible: boolean
+}

--- a/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
+++ b/packages/web/src/components/ToDoItemPreviewDrawer/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { Box, Checkbox, Chip, FormControlLabel, Typography } from '@mui/material'
 import AssignmentIcon from '@mui/icons-material/Assignment'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
@@ -8,9 +8,13 @@ import EditIcon from '@mui/icons-material/Edit'
 import dayjs from 'dayjs'
 import { ITodoItem } from '../../api/toDoList/retrieve/types'
 import { usePreviewDrawerActions } from '../../hooks/usePreviewDrawerActions'
+import { useStepCompletionRewards } from '../../hooks/useStepCompletionRewards'
+import { StepRewardState } from '../../hooks/useStepCompletionRewards/types'
 import BasePreviewDrawer from '../BasePreviewDrawer'
 import DrawerActionButton from '../DrawerActionButton'
 import PrivateItemBadge from '../PrivateItemBadge'
+import ConfettiBurst from '../ConfettiBurst'
+import CompleteTaskBanner from '../CompleteTaskBanner'
 import {
   ContentContainer,
   DescriptionText,
@@ -30,8 +34,11 @@ interface ToDoItemPreviewDrawerProps {
   onDelete?: (id: string) => void
 }
 
-const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle, onDelete }: ToDoItemPreviewDrawerProps) => {
+const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle, onDelete }: ToDoItemPreviewDrawerProps): React.ReactElement => {
   const onEditItem = useMemo(() => (todoItem: ITodoItem) => onEdit(todoItem.id), [onEdit])
+  const [rewardState, setRewardState] = useState<StepRewardState | null>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const { processStepToggle } = useStepCompletionRewards()
 
   const { handleEdit, handleDelete } = usePreviewDrawerActions({
     item,
@@ -47,6 +54,33 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
   }, [item, onMarkDone, onClose])
 
   const steps = item?.steps ?? []
+  const doneCount = steps.filter(s => s.isDone).length
+  const totalSteps = steps.length
+  const percent = totalSteps > 0 ? Math.round((doneCount / totalSteps) * 100) : 0
+  const isAllComplete = totalSteps > 0 && doneCount === totalSteps
+
+  // Sort steps: unchecked first, checked second
+  const displaySteps = useMemo(() => {
+    const unchecked = steps.filter(s => !s.isDone)
+    const checked = steps.filter(s => s.isDone)
+    return [...unchecked, ...checked]
+  }, [steps])
+
+  const handleStepChange = useCallback((stepId: string, currentIsDone: boolean) => {
+    if (!item) return
+    const newIsDone = !currentIsDone
+    const updatedSteps = steps.map(s => (s.id === stepId ? { ...s, isDone: newIsDone } : s))
+
+    const state = processStepToggle({
+      previousSteps: steps,
+      updatedSteps,
+      toggledStepId: stepId,
+      newIsDone,
+    })
+    setRewardState(state)
+
+    onStepToggle?.(item.id, stepId, newIsDone)
+  }, [item, steps, onStepToggle, processStepToggle])
 
   return (
     <BasePreviewDrawer
@@ -65,7 +99,7 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
       }
       paperSx={{ maxHeight: '80vh' }}
     >
-      <ContentContainer>
+      <ContentContainer ref={contentRef}>
         <ItemName>
           {item?.name}
           {item?.visibility === 'private' && <PrivateItemBadge />}
@@ -84,26 +118,63 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
           <NoDescriptionText>No description</NoDescriptionText>
         )}
 
-        {steps.length > 0 && (
+        {totalSteps > 0 && (
           <Box sx={{ mt: 2 }}>
-            <Typography
-              variant="subtitle2"
-              sx={{ fontWeight: 600, mb: 1, color: 'text.secondary', letterSpacing: 0.5, textTransform: 'uppercase', fontSize: '0.75rem' }}
-            >
-              Sub-steps
-            </Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+              <Typography
+                variant="subtitle2"
+                sx={{ fontWeight: 600, color: 'text.secondary', letterSpacing: 0.5, textTransform: 'uppercase', fontSize: '0.75rem' }}
+              >
+                Sub-steps
+              </Typography>
+              <Typography
+                variant="caption"
+                sx={{
+                  fontWeight: 600,
+                  fontSize: '0.72rem',
+                  color: isAllComplete ? '#059669' : 'text.secondary',
+                }}
+              >
+                {percent}% · {doneCount}/{totalSteps}
+              </Typography>
+            </Box>
+
+            {/* Progress bar */}
+            <Box sx={{
+              width: '100%',
+              height: '4px',
+              borderRadius: '2px',
+              background: 'rgba(99, 102, 241, 0.08)',
+              overflow: 'hidden',
+              mb: 1.5,
+            }}>
+              <Box sx={{
+                height: '100%',
+                borderRadius: '2px',
+                background: isAllComplete
+                  ? 'linear-gradient(135deg, #059669 0%, #047857 100%)'
+                  : 'linear-gradient(135deg, #6366f1 0%, #7c3aed 100%)',
+                width: `${percent}%`,
+                transition: 'width 0.4s cubic-bezier(0.4, 0, 0.2, 1), background 0.3s ease',
+              }} />
+            </Box>
+
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-              {steps.map(step => (
+              {displaySteps.map(step => (
                 <FormControlLabel
                   key={step.id}
                   control={
                     <Checkbox
                       checked={step.isDone}
-                      onChange={() => onStepToggle?.(item!.id, step.id, !step.isDone)}
+                      onChange={() => handleStepChange(step.id, step.isDone)}
                       size="small"
                       sx={{
                         color: 'rgba(102, 126, 234, 0.5)',
-                        '&.Mui-checked': { color: '#667eea' },
+                        '&.Mui-checked': {
+                          color: '#667eea',
+                          animation: 'none',
+                        },
+                        transition: 'transform 0.2s ease',
                       }}
                     />
                   }
@@ -111,8 +182,13 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
                     <Typography
                       variant="body2"
                       sx={{
-                        textDecoration: step.isDone ? 'line-through' : 'none',
                         color: step.isDone ? 'text.disabled' : 'text.primary',
+                        textDecoration: 'none',
+                        backgroundImage: 'linear-gradient(currentColor, currentColor)',
+                        backgroundRepeat: 'no-repeat',
+                        backgroundPosition: '0 50%',
+                        backgroundSize: step.isDone ? '100% 1.5px' : '0% 1.5px',
+                        transition: 'background-size 0.3s ease 0.1s, color 0.2s ease',
                       }}
                     >
                       {step.name}
@@ -132,7 +208,12 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
       </ContentContainer>
 
       <Footer>
-        {!item?.isDone && onMarkDone && (
+        {isAllComplete && onMarkDone && !item?.isDone && (
+          <Box sx={{ mb: 1 }}>
+            <CompleteTaskBanner onClick={handleMarkDone} />
+          </Box>
+        )}
+        {!isAllComplete && !item?.isDone && onMarkDone && (
           <DrawerActionButton
             gradient="linear-gradient(135deg, #059669 0%, #047857 100%)"
             icon={<CheckCircleIcon />}
@@ -156,6 +237,11 @@ const ToDoItemPreviewDrawer = ({ item, onClose, onEdit, onMarkDone, onStepToggle
           sx={{ mt: 1 }}
         />
       </Footer>
+
+      <ConfettiBurst
+        trigger={rewardState?.shouldConfetti ?? false}
+        anchorRef={contentRef}
+      />
     </BasePreviewDrawer>
   )
 }

--- a/packages/web/src/hooks/useStepCompletionRewards/index.test.ts
+++ b/packages/web/src/hooks/useStepCompletionRewards/index.test.ts
@@ -1,0 +1,174 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useStepCompletionRewards } from '.'
+import { IStep } from '../../api/toDoList/retrieve/types'
+
+vi.mock('../useHapticFeedback', () => ({
+  useHapticFeedback: () => ({ triggerHaptic: vi.fn() }),
+}))
+
+vi.mock('../../utils/audio/completionSound', () => ({
+  playCompletionSound: vi.fn(),
+}))
+
+const makeSteps = (doneCount: number, total: number): IStep[] =>
+  Array.from({ length: total }, (_, i) => ({
+    id: `step-${i}`,
+    name: `Step ${i}`,
+    isDone: i < doneCount,
+  }))
+
+describe('Given the useStepCompletionRewards hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should detect the 50% milestone', () => {
+    const { result } = renderHook(() => useStepCompletionRewards())
+
+    const previousSteps = makeSteps(1, 4)
+    const updatedSteps = makeSteps(2, 4)
+
+    let state: ReturnType<typeof result.current.processStepToggle>
+    act(() => {
+      state = result.current.processStepToggle({
+        previousSteps,
+        updatedSteps,
+        toggledStepId: 'step-1',
+        newIsDone: true,
+      })
+    })
+
+    expect(state!.milestoneReached).toBe(50)
+    expect(state!.percentComplete).toBe(50)
+    expect(state!.shouldConfetti).toBe(false)
+  })
+
+  it('should detect the 75% milestone', () => {
+    const { result } = renderHook(() => useStepCompletionRewards())
+
+    const previousSteps = makeSteps(2, 4)
+    const updatedSteps = makeSteps(3, 4)
+
+    let state: ReturnType<typeof result.current.processStepToggle>
+    act(() => {
+      state = result.current.processStepToggle({
+        previousSteps,
+        updatedSteps,
+        toggledStepId: 'step-2',
+        newIsDone: true,
+      })
+    })
+
+    expect(state!.milestoneReached).toBe(75)
+    expect(state!.percentComplete).toBe(75)
+  })
+
+  it('should detect the 100% milestone and trigger confetti', () => {
+    const { result } = renderHook(() => useStepCompletionRewards())
+
+    const previousSteps = makeSteps(3, 4)
+    const updatedSteps = makeSteps(4, 4)
+
+    let state: ReturnType<typeof result.current.processStepToggle>
+    act(() => {
+      state = result.current.processStepToggle({
+        previousSteps,
+        updatedSteps,
+        toggledStepId: 'step-3',
+        newIsDone: true,
+      })
+    })
+
+    expect(state!.milestoneReached).toBe(100)
+    expect(state!.isAllComplete).toBe(true)
+    expect(state!.shouldConfetti).toBe(true)
+  })
+
+  it('should not trigger confetti when unchecking at 100%', () => {
+    const { result } = renderHook(() => useStepCompletionRewards())
+
+    const previousSteps = makeSteps(4, 4)
+    const updatedSteps = makeSteps(3, 4)
+
+    let state: ReturnType<typeof result.current.processStepToggle>
+    act(() => {
+      state = result.current.processStepToggle({
+        previousSteps,
+        updatedSteps,
+        toggledStepId: 'step-3',
+        newIsDone: false,
+      })
+    })
+
+    expect(state!.shouldConfetti).toBe(false)
+    expect(state!.isAllComplete).toBe(false)
+  })
+
+  it('should increment streak when checking steps rapidly', () => {
+    const { result } = renderHook(() => useStepCompletionRewards())
+
+    act(() => {
+      result.current.processStepToggle({
+        previousSteps: makeSteps(0, 4),
+        updatedSteps: makeSteps(1, 4),
+        toggledStepId: 'step-0',
+        newIsDone: true,
+      })
+    })
+
+    let state: ReturnType<typeof result.current.processStepToggle>
+    act(() => {
+      state = result.current.processStepToggle({
+        previousSteps: makeSteps(1, 4),
+        updatedSteps: makeSteps(2, 4),
+        toggledStepId: 'step-1',
+        newIsDone: true,
+      })
+    })
+
+    expect(state!.streakCount).toBe(2)
+  })
+
+  it('should reset streak on uncheck', () => {
+    const { result } = renderHook(() => useStepCompletionRewards())
+
+    act(() => {
+      result.current.processStepToggle({
+        previousSteps: makeSteps(0, 4),
+        updatedSteps: makeSteps(1, 4),
+        toggledStepId: 'step-0',
+        newIsDone: true,
+      })
+    })
+
+    let state: ReturnType<typeof result.current.processStepToggle>
+    act(() => {
+      state = result.current.processStepToggle({
+        previousSteps: makeSteps(1, 4),
+        updatedSteps: makeSteps(0, 4),
+        toggledStepId: 'step-0',
+        newIsDone: false,
+      })
+    })
+
+    expect(state!.streakCount).toBe(0)
+  })
+
+  it('should return no milestone when none is crossed', () => {
+    const { result } = renderHook(() => useStepCompletionRewards())
+
+    let state: ReturnType<typeof result.current.processStepToggle>
+    act(() => {
+      state = result.current.processStepToggle({
+        previousSteps: makeSteps(0, 10),
+        updatedSteps: makeSteps(1, 10),
+        toggledStepId: 'step-0',
+        newIsDone: true,
+      })
+    })
+
+    expect(state!.milestoneReached).toBeNull()
+    expect(state!.percentComplete).toBe(10)
+  })
+})

--- a/packages/web/src/hooks/useStepCompletionRewards/index.ts
+++ b/packages/web/src/hooks/useStepCompletionRewards/index.ts
@@ -1,0 +1,86 @@
+import { useCallback, useRef, useState } from 'react'
+import { useHapticFeedback } from '../useHapticFeedback'
+import { playCompletionSound } from '../../utils/audio/completionSound'
+import { StepCompletionEvent, StepRewardState } from './types'
+
+const STREAK_WINDOW_MS = 3000
+const MILESTONES = [50, 75, 100] as const
+
+const calcPercent = (steps: { isDone: boolean }[]): number => {
+  if (steps.length === 0) return 0
+  return Math.round((steps.filter(s => s.isDone).length / steps.length) * 100)
+}
+
+export const useStepCompletionRewards = (): {
+  processStepToggle: (event: StepCompletionEvent) => StepRewardState
+  streakCount: number
+  resetStreak: () => void
+} => {
+  const { triggerHaptic } = useHapticFeedback()
+  const [streakCount, setStreakCount] = useState(0)
+  const lastToggleTimeRef = useRef(0)
+
+  const resetStreak = useCallback((): void => {
+    setStreakCount(0)
+  }, [])
+
+  const processStepToggle = useCallback((event: StepCompletionEvent): StepRewardState => {
+    const { previousSteps, updatedSteps, newIsDone } = event
+    const prevPercent = calcPercent(previousSteps)
+    const newPercent = calcPercent(updatedSteps)
+
+    let milestoneReached: 50 | 75 | 100 | null = null
+    for (const threshold of MILESTONES) {
+      if (prevPercent < threshold && newPercent >= threshold) {
+        milestoneReached = threshold
+      }
+    }
+
+    const isAllComplete = newPercent === 100
+    const shouldConfetti = milestoneReached === 100 && newIsDone
+
+    // Streak tracking
+    let newStreakCount = 0
+    if (newIsDone) {
+      const now = Date.now()
+      const timeSinceLast = now - lastToggleTimeRef.current
+      if (timeSinceLast < STREAK_WINDOW_MS && lastToggleTimeRef.current > 0) {
+        newStreakCount = streakCount + 1
+      } else {
+        newStreakCount = 1
+      }
+      lastToggleTimeRef.current = now
+    }
+    setStreakCount(newStreakCount)
+
+    // Haptic feedback
+    if (newIsDone) {
+      if (milestoneReached === 100) {
+        triggerHaptic('heavy')
+      } else if (milestoneReached === 50 || milestoneReached === 75) {
+        triggerHaptic('medium')
+      } else {
+        triggerHaptic('light')
+      }
+    } else {
+      triggerHaptic('selection')
+    }
+
+    // Sound at 100%
+    if (shouldConfetti) {
+      playCompletionSound()
+    }
+
+    return {
+      milestoneReached,
+      isAllComplete,
+      streakCount: newStreakCount,
+      shouldConfetti,
+      percentComplete: newPercent,
+    }
+  }, [streakCount, triggerHaptic])
+
+  return { processStepToggle, streakCount, resetStreak }
+}
+
+export default useStepCompletionRewards

--- a/packages/web/src/hooks/useStepCompletionRewards/types.ts
+++ b/packages/web/src/hooks/useStepCompletionRewards/types.ts
@@ -1,0 +1,16 @@
+import { IStep } from '../../api/toDoList/retrieve/types'
+
+export interface StepCompletionEvent {
+  previousSteps: IStep[]
+  updatedSteps: IStep[]
+  toggledStepId: string
+  newIsDone: boolean
+}
+
+export interface StepRewardState {
+  milestoneReached: 50 | 75 | 100 | null
+  isAllComplete: boolean
+  streakCount: number
+  shouldConfetti: boolean
+  percentComplete: number
+}

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskCard/index.styled.tsx
@@ -1,13 +1,46 @@
 import { styled } from '@mui/material/styles'
+import {
+  checkboxBounce,
+  progressGlow,
+  milestoneShine,
+  cardGlowPulse,
+  cardGlowPulseGreen,
+} from '../../../../../../utils/styles/stepAnimations'
 
-export const CardWrapper = styled('div')<{ $dueDateClass?: string }>(({ theme, $dueDateClass }) => ({
+type MilestoneValue = 50 | 75 | 100 | null
+
+const getProgressGradient = (milestone: MilestoneValue): string => {
+  switch (milestone) {
+    case 100:
+      return 'linear-gradient(135deg, #059669 0%, #047857 100%)'
+    case 75:
+      return 'linear-gradient(135deg, #6366f1 0%, #10b981 100%)'
+    case 50:
+      return 'linear-gradient(135deg, #6366f1 0%, #3b82f6 100%)'
+    default:
+      return 'linear-gradient(135deg, #6366f1 0%, #7c3aed 100%)'
+  }
+}
+
+export const CardWrapper = styled('div')<{
+  $dueDateClass?: string
+  $milestone?: MilestoneValue
+}>(({ theme, $dueDateClass, $milestone }) => ({
   borderRadius: '12px',
   padding: '0.5rem 0.65rem',
   background: 'linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,1) 100%)',
-  border: '1px solid rgba(99, 102, 241, 0.08)',
+  border:
+    $milestone === 100
+      ? '1px solid rgba(5, 150, 105, 0.2)'
+      : '1px solid rgba(99, 102, 241, 0.08)',
   position: 'relative',
   overflow: 'hidden',
   transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+  ...($milestone && $milestone >= 50
+    ? {
+        animation: `${$milestone === 100 ? cardGlowPulseGreen : cardGlowPulse} 0.8s ease forwards`,
+      }
+    : {}),
   '&:before': {
     content: '""',
     position: 'absolute',
@@ -19,8 +52,8 @@ export const CardWrapper = styled('div')<{ $dueDateClass?: string }>(({ theme, $
       $dueDateClass === 'overdue'
         ? theme.palette.error.main
         : $dueDateClass === 'today'
-        ? 'linear-gradient(135deg, #6366f1 0%, #7c3aed 100%)'
-        : 'transparent',
+          ? 'linear-gradient(135deg, #6366f1 0%, #7c3aed 100%)'
+          : 'transparent',
     borderRadius: '3px 0 0 3px',
   },
   '&:active': {
@@ -48,25 +81,27 @@ export const TaskTitle = styled('div')(({ theme }) => ({
   whiteSpace: 'nowrap',
 }))
 
-export const DueLabel = styled('span')<{ $dueDateClass?: string }>(({ theme, $dueDateClass }) => ({
-  fontSize: '0.68rem',
-  fontWeight: 600,
-  flexShrink: 0,
-  padding: '0.1rem 0.4rem',
-  borderRadius: '6px',
-  color:
-    $dueDateClass === 'overdue'
-      ? theme.palette.error.main
-      : $dueDateClass === 'today'
-      ? '#d97706'
-      : theme.palette.text.secondary,
-  background:
-    $dueDateClass === 'overdue'
-      ? `${theme.palette.error.main}14`
-      : $dueDateClass === 'today'
-      ? 'rgba(217, 119, 6, 0.1)'
-      : 'rgba(99, 102, 241, 0.06)',
-}))
+export const DueLabel = styled('span')<{ $dueDateClass?: string }>(
+  ({ theme, $dueDateClass }) => ({
+    fontSize: '0.68rem',
+    fontWeight: 600,
+    flexShrink: 0,
+    padding: '0.1rem 0.4rem',
+    borderRadius: '6px',
+    color:
+      $dueDateClass === 'overdue'
+        ? theme.palette.error.main
+        : $dueDateClass === 'today'
+          ? '#d97706'
+          : theme.palette.text.secondary,
+    background:
+      $dueDateClass === 'overdue'
+        ? `${theme.palette.error.main}14`
+        : $dueDateClass === 'today'
+          ? 'rgba(217, 119, 6, 0.1)'
+          : 'rgba(99, 102, 241, 0.06)',
+  }),
+)
 
 export const ProgressBarTrack = styled('div')({
   width: '100%',
@@ -77,68 +112,106 @@ export const ProgressBarTrack = styled('div')({
   marginBottom: '0.1rem',
 })
 
-export const ProgressBarFill = styled('div')<{ $percent: number }>(({ $percent }) => ({
+export const ProgressBarFill = styled('div')<{
+  $percent: number
+  $milestone?: MilestoneValue
+  $animateGlow?: boolean
+}>(({ $percent, $milestone, $animateGlow }) => ({
   height: '100%',
   borderRadius: '2px',
-  background: 'linear-gradient(135deg, #6366f1 0%, #7c3aed 100%)',
+  background: getProgressGradient($milestone ?? null),
   width: `${$percent}%`,
-  transition: 'width 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+  transition: 'width 0.4s cubic-bezier(0.4, 0, 0.2, 1), background 0.3s ease',
+  ...($animateGlow
+    ? { animation: `${progressGlow} 0.6s ease forwards` }
+    : {}),
+  ...($milestone && $milestone >= 50
+    ? {
+        backgroundSize: '200% 100%',
+        animationName: `${milestoneShine}`,
+        animationDuration: '0.8s',
+        animationTimingFunction: 'ease',
+        animationIterationCount: 1,
+      }
+    : {}),
 }))
+
+export const ProgressLabelRow = styled('div')({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: '0.25rem',
+})
 
 export const ProgressLabel = styled('div')(({ theme }) => ({
   fontSize: '0.65rem',
   fontWeight: 500,
   color: theme.palette.text.secondary,
-  textAlign: 'right',
-  marginBottom: '0.25rem',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.2rem',
+  cursor: 'pointer',
 }))
 
 export const StepsContainer = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   gap: '0.15rem',
+  position: 'relative',
 })
 
-export const StepRow = styled('div')<{ $isDone: boolean }>(({ theme, $isDone }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  gap: '0.3rem',
-  padding: '0.2rem 0.15rem',
-  borderRadius: '6px',
-  cursor: 'pointer',
-  transition: 'background 0.15s ease',
-  '&:hover': {
-    background: 'rgba(99, 102, 241, 0.05)',
-  },
-  '&:active': {
-    background: 'rgba(99, 102, 241, 0.1)',
-  },
-  '& .step-checkbox': {
-    width: '16px',
-    height: '16px',
-    borderRadius: '4px',
-    border: $isDone
-      ? 'none'
-      : `1.5px solid rgba(99, 102, 241, 0.35)`,
-    background: $isDone
-      ? 'linear-gradient(135deg, #6366f1 0%, #7c3aed 100%)'
-      : 'transparent',
+export const StepRow = styled('div')<{ $isDone: boolean; $justChecked?: boolean }>(
+  ({ theme, $isDone, $justChecked }) => ({
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    transition: 'all 0.2s ease',
-    color: 'white',
-    fontSize: '0.6rem',
-  },
-  '& .step-name': {
-    fontSize: '0.72rem',
-    color: $isDone ? theme.palette.text.disabled : theme.palette.text.primary,
-    textDecoration: $isDone ? 'line-through' : 'none',
-    lineHeight: 1.3,
-    flex: 1,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-}))
+    gap: '0.3rem',
+    padding: '0.2rem 0.15rem',
+    borderRadius: '6px',
+    cursor: 'pointer',
+    transition: 'background 0.15s ease, transform 0.3s ease, opacity 0.3s ease',
+    '&:hover': {
+      background: 'rgba(99, 102, 241, 0.05)',
+    },
+    '&:active': {
+      background: 'rgba(99, 102, 241, 0.1)',
+    },
+    '& .step-checkbox': {
+      width: '16px',
+      height: '16px',
+      borderRadius: '4px',
+      border: $isDone ? 'none' : `1.5px solid rgba(99, 102, 241, 0.35)`,
+      background: $isDone
+        ? 'linear-gradient(135deg, #6366f1 0%, #7c3aed 100%)'
+        : 'transparent',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexShrink: 0,
+      transition: 'all 0.2s ease',
+      color: 'white',
+      fontSize: '0.6rem',
+      ...($justChecked
+        ? { animation: `${checkboxBounce} 0.4s ease` }
+        : {}),
+    },
+    '& .step-name': {
+      fontSize: '0.72rem',
+      color: $isDone ? theme.palette.text.disabled : theme.palette.text.primary,
+      lineHeight: 1.3,
+      flex: 1,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      backgroundImage: 'linear-gradient(currentColor, currentColor)',
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: '0 50%',
+      backgroundSize: $isDone ? '100% 1.5px' : '0% 1.5px',
+      transition: 'background-size 0.3s ease 0.1s, color 0.2s ease',
+      textDecoration: 'none',
+    },
+  }),
+)
+
+export const BannerContainer = styled('div')({
+  marginTop: '0.3rem',
+})

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskCard/index.tsx
@@ -1,9 +1,14 @@
-import React, { useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import CheckIcon from '@mui/icons-material/Check'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { Collapse } from '@mui/material'
 import { ITodoItem, IStep } from '../../../../../../api/toDoList/retrieve/types'
 import { getDueDateClass, formatDueDateRelative } from '../../../../../../utils/dateTime'
+import { useStepCompletionRewards } from '../../../../../../hooks/useStepCompletionRewards'
+import { StepRewardState } from '../../../../../../hooks/useStepCompletionRewards/types'
+import ConfettiBurst from '../../../../../../components/ConfettiBurst'
+import CompleteTaskBanner from '../../../../../../components/CompleteTaskBanner'
+import StreakIndicator from '../../../../../../components/StreakIndicator'
 import {
   CardWrapper,
   CardHeader,
@@ -11,70 +16,126 @@ import {
   DueLabel,
   ProgressBarTrack,
   ProgressBarFill,
+  ProgressLabelRow,
   ProgressLabel,
   StepsContainer,
   StepRow,
+  BannerContainer,
 } from './index.styled'
 
 interface TaskCardProps {
   item: ITodoItem
   onStepToggle: (todoId: string, stepId: string, isDone: boolean) => void
   onCardClick: (item: ITodoItem) => void
+  onMarkDone?: (id: string) => void
 }
 
-const TaskCard: React.FC<TaskCardProps> = ({ item, onStepToggle, onCardClick }) => {
+const sortSteps = (steps: IStep[]): IStep[] => {
+  const unchecked = steps.filter(s => !s.isDone)
+  const checked = steps.filter(s => s.isDone)
+  return [...unchecked, ...checked]
+}
+
+const TaskCard: React.FC<TaskCardProps> = ({ item, onStepToggle, onCardClick, onMarkDone }) => {
   const [isStepsExpanded, setIsStepsExpanded] = useState(false)
+  const [justCheckedId, setJustCheckedId] = useState<string | null>(null)
+  const [rewardState, setRewardState] = useState<StepRewardState | null>(null)
+  const [shouldReorder, setShouldReorder] = useState(true)
+  const cardRef = useRef<HTMLDivElement>(null)
+  const { processStepToggle, streakCount } = useStepCompletionRewards()
+
   const dueDateClass = getDueDateClass(item.dueDate)
   const dueDateLabel = formatDueDateRelative(item.dueDate)
   const steps = item.steps ?? []
   const doneCount = steps.filter(s => s.isDone).length
   const totalSteps = steps.length
   const percent = totalSteps > 0 ? Math.round((doneCount / totalSteps) * 100) : 0
+  const isAllComplete = totalSteps > 0 && doneCount === totalSteps
 
-  const handleStepClick = (e: React.MouseEvent, step: IStep) => {
-    e.stopPropagation()
-    onStepToggle(item.id, step.id, !step.isDone)
-  }
+  const displaySteps = useMemo(
+    () => (shouldReorder ? sortSteps(steps) : steps),
+    [steps, shouldReorder],
+  )
 
-  const handleProgressClick = (e: React.MouseEvent) => {
+  const handleStepClick = useCallback(
+    (e: React.MouseEvent, step: IStep) => {
+      e.stopPropagation()
+      const newIsDone = !step.isDone
+      const updatedSteps = steps.map(s => (s.id === step.id ? { ...s, isDone: newIsDone } : s))
+
+      const state = processStepToggle({
+        previousSteps: steps,
+        updatedSteps,
+        toggledStepId: step.id,
+        newIsDone,
+      })
+      setRewardState(state)
+
+      // Trigger bounce animation
+      setJustCheckedId(newIsDone ? step.id : null)
+      setTimeout(() => setJustCheckedId(null), 400)
+
+      // Delay reorder so check animation plays first
+      if (newIsDone) {
+        setShouldReorder(false)
+        setTimeout(() => setShouldReorder(true), 500)
+      }
+
+      onStepToggle(item.id, step.id, newIsDone)
+    },
+    [steps, item.id, onStepToggle, processStepToggle],
+  )
+
+  const handleProgressClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
     setIsStepsExpanded(v => !v)
-  }
+  }, [])
+
+  const handleMarkDone = useCallback(() => {
+    onMarkDone?.(item.id)
+  }, [onMarkDone, item.id])
 
   return (
-    <CardWrapper $dueDateClass={dueDateClass}>
+    <CardWrapper
+      ref={cardRef}
+      $dueDateClass={dueDateClass}
+      $milestone={rewardState?.milestoneReached}
+    >
       <CardHeader onClick={() => onCardClick(item)}>
         <TaskTitle>{item.name}</TaskTitle>
-        {dueDateLabel && (
-          <DueLabel $dueDateClass={dueDateClass}>{dueDateLabel}</DueLabel>
-        )}
+        {dueDateLabel && <DueLabel $dueDateClass={dueDateClass}>{dueDateLabel}</DueLabel>}
       </CardHeader>
 
       {totalSteps > 0 && (
         <>
           <ProgressBarTrack>
-            <ProgressBarFill $percent={percent} />
-          </ProgressBarTrack>
-          <ProgressLabel
-            onClick={handleProgressClick}
-            style={{ cursor: 'pointer', display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: '0.2rem' }}
-          >
-            {doneCount}/{totalSteps} steps
-            <ExpandMoreIcon
-              sx={{
-                fontSize: '0.8rem',
-                transform: isStepsExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                transition: 'transform 150ms ease',
-              }}
+            <ProgressBarFill
+              $percent={percent}
+              $milestone={rewardState?.milestoneReached}
+              $animateGlow={rewardState !== null && rewardState.percentComplete > 0}
             />
-          </ProgressLabel>
+          </ProgressBarTrack>
+          <ProgressLabelRow>
+            <StreakIndicator count={streakCount} visible={streakCount >= 3} />
+            <ProgressLabel onClick={handleProgressClick} data-testid="progress-label">
+              {percent}% · {doneCount}/{totalSteps}
+              <ExpandMoreIcon
+                sx={{
+                  fontSize: '0.8rem',
+                  transform: isStepsExpanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                  transition: 'transform 150ms ease',
+                }}
+              />
+            </ProgressLabel>
+          </ProgressLabelRow>
 
           <Collapse in={isStepsExpanded} timeout={150} unmountOnExit>
             <StepsContainer>
-              {steps.map(step => (
+              {displaySteps.map(step => (
                 <StepRow
                   key={step.id}
                   $isDone={step.isDone}
+                  $justChecked={justCheckedId === step.id}
                   onClick={e => handleStepClick(e, step)}
                 >
                   <div className="step-checkbox">
@@ -83,10 +144,20 @@ const TaskCard: React.FC<TaskCardProps> = ({ item, onStepToggle, onCardClick }) 
                   <span className="step-name">{step.name}</span>
                 </StepRow>
               ))}
+              {isAllComplete && onMarkDone && (
+                <BannerContainer>
+                  <CompleteTaskBanner onClick={handleMarkDone} compact />
+                </BannerContainer>
+              )}
             </StepsContainer>
           </Collapse>
         </>
       )}
+
+      <ConfettiBurst
+        trigger={rewardState?.shouldConfetti ?? false}
+        anchorRef={cardRef}
+      />
     </CardWrapper>
   )
 }

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskList/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskList/index.tsx
@@ -13,9 +13,10 @@ interface TaskListProps {
   isError?: boolean
   onStepToggle: (todoId: string, stepId: string, isDone: boolean) => void
   onCardClick: (item: ITodoItem) => void
+  onMarkDone?: (id: string) => void
 }
 
-const TaskList: React.FC<TaskListProps> = ({ items, isError, onStepToggle, onCardClick }) => {
+const TaskList: React.FC<TaskListProps> = ({ items, isError, onStepToggle, onCardClick, onMarkDone }) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
   if (items.length === 0) {
@@ -34,6 +35,7 @@ const TaskList: React.FC<TaskListProps> = ({ items, isError, onStepToggle, onCar
           item={item}
           onStepToggle={onStepToggle}
           onCardClick={onCardClick}
+          onMarkDone={onMarkDone}
         />
       ))}
 

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.test.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.test.tsx
@@ -106,9 +106,10 @@ describe('PlannerSection component', () => {
 
       renderWithTheme(<PlannerSection {...defaultProps} toDoStats={toDoStats} />)
 
-      expect(screen.getByText('1/3 steps')).toBeInTheDocument()
+      const progressLabel = screen.getByTestId('progress-label')
+      expect(progressLabel).toHaveTextContent('33% · 1/3')
       // Steps are collapsed by default — expand to see them
-      fireEvent.click(screen.getByText('1/3 steps'))
+      fireEvent.click(progressLabel)
       expect(screen.getByText('Pack clothes')).toBeInTheDocument()
       expect(screen.getByText('Buy tickets')).toBeInTheDocument()
       expect(screen.getByText('Buy snacks')).toBeInTheDocument()
@@ -128,7 +129,7 @@ describe('PlannerSection component', () => {
       renderWithTheme(<PlannerSection {...defaultProps} toDoStats={toDoStats} onStepToggle={onStepToggle} />)
 
       // Steps are collapsed by default — expand first
-      fireEvent.click(screen.getByText('0/1 steps'))
+      fireEvent.click(screen.getByTestId('progress-label'))
       fireEvent.click(screen.getByText('Pack clothes'))
 
       expect(onStepToggle).toHaveBeenCalledWith('1', 's1', true)

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -16,6 +16,7 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
   isError,
   onStepToggle,
   onCardClick,
+  onMarkDone,
   onMealClick,
   onAdventureClick,
 }) => {
@@ -44,6 +45,7 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
           isError={isError}
           onStepToggle={onStepToggle}
           onCardClick={onCardClick}
+          onMarkDone={onMarkDone}
         />
       </SectionCard>
 

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/types.ts
@@ -15,6 +15,7 @@ export interface IToDoSectionProps {
   isError: boolean
   onStepToggle: (todoId: string, stepId: string, isDone: boolean) => void
   onCardClick: (item: ITodoItem) => void
+  onMarkDone?: (id: string) => void
   onMealClick?: (meal: ITodayMealItem) => void
   onAdventureClick?: (adventure: IAdventure) => void
 }

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -167,6 +167,7 @@ const HomeDataContent = () => {
           isError={isToDoError}
           onStepToggle={handleStepToggle}
           onCardClick={interactions.handleToDoItemSelect}
+          onMarkDone={handleMarkDone}
           onMealClick={handleMealClick}
           onAdventureClick={handleAdventureClick}
         />

--- a/packages/web/src/utils/audio/completionSound.ts
+++ b/packages/web/src/utils/audio/completionSound.ts
@@ -1,0 +1,34 @@
+let audioContext: AudioContext | null = null
+
+const getAudioContext = (): AudioContext | null => {
+  if (typeof window === 'undefined' || typeof AudioContext === 'undefined') return null
+  if (!audioContext) {
+    audioContext = new AudioContext()
+  }
+  return audioContext
+}
+
+export const playCompletionSound = (): void => {
+  const enabled = localStorage.getItem('kairos:soundEffects')
+  if (enabled === 'false') return
+
+  const ctx = getAudioContext()
+  if (!ctx) return
+
+  const playTone = (frequency: number, startTime: number, duration: number): void => {
+    const oscillator = ctx.createOscillator()
+    const gain = ctx.createGain()
+    oscillator.connect(gain)
+    gain.connect(ctx.destination)
+    oscillator.type = 'sine'
+    oscillator.frequency.value = frequency
+    gain.gain.setValueAtTime(0.15, startTime)
+    gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration)
+    oscillator.start(startTime)
+    oscillator.stop(startTime + duration)
+  }
+
+  const now = ctx.currentTime
+  playTone(880, now, 0.1)
+  playTone(1100, now + 0.05, 0.12)
+}

--- a/packages/web/src/utils/styles/stepAnimations.ts
+++ b/packages/web/src/utils/styles/stepAnimations.ts
@@ -1,0 +1,42 @@
+import { keyframes } from '@mui/material/styles'
+
+export const checkboxBounce = keyframes`
+  0% { transform: scale(1); }
+  30% { transform: scale(1.3); }
+  60% { transform: scale(0.9); }
+  100% { transform: scale(1); }
+`
+
+export const progressGlow = keyframes`
+  0% { box-shadow: 0 0 0px transparent; }
+  50% { box-shadow: 0 0 8px rgba(99, 102, 241, 0.5); }
+  100% { box-shadow: 0 0 0px transparent; }
+`
+
+export const milestoneShine = keyframes`
+  0% { background-position: -200px 0; }
+  100% { background-position: calc(200px + 100%) 0; }
+`
+
+export const cardGlowPulse = keyframes`
+  0% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.3); }
+  70% { box-shadow: 0 0 0 6px rgba(99, 102, 241, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0); }
+`
+
+export const cardGlowPulseGreen = keyframes`
+  0% { box-shadow: 0 0 0 0 rgba(5, 150, 105, 0.3); }
+  70% { box-shadow: 0 0 0 6px rgba(5, 150, 105, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(5, 150, 105, 0); }
+`
+
+export const streakPulse = keyframes`
+  0% { transform: scale(0.5); opacity: 0; }
+  60% { transform: scale(1.15); opacity: 1; }
+  100% { transform: scale(1); opacity: 1; }
+`
+
+export const slideIn = keyframes`
+  0% { transform: translateY(8px); opacity: 0; }
+  100% { transform: translateY(0); opacity: 1; }
+`


### PR DESCRIPTION
Add multi-tier reward system for completing sub-tasks (steps) in the
tasks widget on the home page and preview drawer:

Tier 1 (Polish):
- Haptic feedback on step toggle (light/medium/heavy by milestone)
- Checkbox bounce animation on check
- Progress bar glow animation when advancing
- Progress label now shows percentage (e.g. "75% · 3/4")

Tier 2 (Meaningful):
- Milestone celebrations at 50%, 75%, 100% with card glow pulse
- Progress bar gradient shifts by milestone (indigo→blue→emerald→green)
- Animated strikethrough on step text (draws progressively)
- Completed steps slide to bottom of list (delayed reorder)

Tier 3 (Delightful):
- Canvas-based confetti burst on 100% completion (~40 particles)
- Streak indicator (bolt badge) when checking 3+ steps within 3s
- Optional completion sound via Web Audio API synthesis

When all steps complete, a green "Complete Task" banner appears inline,
prompting the user to mark the parent task as done.

New components: ConfettiBurst, CompleteTaskBanner, StreakIndicator
New hook: useStepCompletionRewards (milestone detection, streak, haptic)
New utilities: stepAnimations (CSS keyframes), completionSound (Web Audio)

https://claude.ai/code/session_01B3C23uScwsW6vs2FfFHCYG