### PR TITLE
feat: add shimmer loading placeholders to Tasks and Birthdays widgets

### DIFF
--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskList/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskList/index.styled.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material/styles'
+import { themedShimmerStyles } from '../../../../../../utils/styles/shimmer'
 
 export const TaskListContainer = styled('div')({
   display: 'flex',
@@ -35,4 +36,26 @@ export const EmptyMessage = styled('div')(({ theme }) => ({
   color: theme.palette.text.secondary,
   textAlign: 'center',
   padding: '0.5rem 0',
+}))
+
+export const TaskPlaceholderCard = styled('div')({
+  borderRadius: '12px',
+  padding: '0.5rem 0.65rem',
+  background: 'linear-gradient(135deg, rgba(255,255,255,0.95) 0%, rgba(248,250,252,1) 100%)',
+  border: '1px solid rgba(99, 102, 241, 0.08)',
+})
+
+export const TaskPlaceholderTitle = styled('div')(({ theme }) => ({
+  height: '0.85rem',
+  width: '68%',
+  borderRadius: '4px',
+  ...themedShimmerStyles(theme),
+}))
+
+export const TaskPlaceholderMeta = styled('div')(({ theme }) => ({
+  height: '0.65rem',
+  width: '40%',
+  borderRadius: '4px',
+  marginTop: '0.35rem',
+  ...themedShimmerStyles(theme),
 }))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskList/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/TaskList/index.tsx
@@ -4,20 +4,38 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
 import { ITodoItem } from '../../../../../../api/toDoList/retrieve/types'
 import TaskCard from '../TaskCard'
-import { TaskListContainer, ExpandButton, EmptyMessage } from './index.styled'
+import { TaskListContainer, ExpandButton, EmptyMessage, TaskPlaceholderCard, TaskPlaceholderTitle, TaskPlaceholderMeta } from './index.styled'
 
 const DEFAULT_VISIBLE = 2
 
 interface TaskListProps {
   items: ITodoItem[]
+  isLoading?: boolean
   isError?: boolean
   onStepToggle: (todoId: string, stepId: string, isDone: boolean) => void
   onCardClick: (item: ITodoItem) => void
   onMarkDone?: (id: string) => void
 }
 
-const TaskList: React.FC<TaskListProps> = ({ items, isError, onStepToggle, onCardClick, onMarkDone }) => {
+const TaskPlaceholder: React.FC = () => (
+  <TaskListContainer>
+    <TaskPlaceholderCard>
+      <TaskPlaceholderTitle />
+      <TaskPlaceholderMeta />
+    </TaskPlaceholderCard>
+    <TaskPlaceholderCard>
+      <TaskPlaceholderTitle />
+      <TaskPlaceholderMeta />
+    </TaskPlaceholderCard>
+  </TaskListContainer>
+)
+
+const TaskList: React.FC<TaskListProps> = ({ items, isLoading, isError, onStepToggle, onCardClick, onMarkDone }) => {
   const [isExpanded, setIsExpanded] = useState(false)
+
+  if (isLoading && items.length === 0) {
+    return <TaskPlaceholder />
+  }
 
   if (items.length === 0) {
     return <EmptyMessage>{isError ? 'Unable to load tasks' : 'No tasks planned — enjoy the day!'}</EmptyMessage>

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.styled.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.styled.tsx
@@ -1,4 +1,5 @@
 import { styled } from '@mui/material/styles'
+import { themedShimmerStyles } from '../../../../../../utils/styles/shimmer'
 
 export const BirthdayList = styled('div')({
   display: 'flex',
@@ -103,4 +104,49 @@ export const MoreCount = styled('div')(({ theme }) => ({
   fontWeight: 600,
   paddingLeft: '0.5rem',
   paddingTop: '0.15rem',
+}))
+
+export const BirthdayPlaceholderEntry = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.6rem',
+  padding: '0.35rem 0.5rem',
+  borderRadius: '10px',
+})
+
+export const BirthdayPlaceholderBadge = styled('div')(({ theme }) => ({
+  flexShrink: 0,
+  width: '2.2rem',
+  height: '2.6rem',
+  borderRadius: '8px',
+  ...themedShimmerStyles(theme),
+}))
+
+export const BirthdayPlaceholderInfo = styled('div')({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.35rem',
+})
+
+export const BirthdayPlaceholderName = styled('div')(({ theme }) => ({
+  height: '0.8rem',
+  width: '55%',
+  borderRadius: '4px',
+  ...themedShimmerStyles(theme),
+}))
+
+export const BirthdayPlaceholderSub = styled('div')(({ theme }) => ({
+  height: '0.65rem',
+  width: '35%',
+  borderRadius: '4px',
+  ...themedShimmerStyles(theme),
+}))
+
+export const BirthdayPlaceholderPill = styled('div')(({ theme }) => ({
+  flexShrink: 0,
+  height: '1.4rem',
+  width: '2.2rem',
+  borderRadius: '99px',
+  ...themedShimmerStyles(theme),
 }))

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/components/UpcomingBirthdaysCard/index.tsx
@@ -13,13 +13,41 @@ import {
   BirthdaySubLine,
   MoreCount,
   CollapseGrid,
+  BirthdayPlaceholderEntry,
+  BirthdayPlaceholderBadge,
+  BirthdayPlaceholderInfo,
+  BirthdayPlaceholderName,
+  BirthdayPlaceholderSub,
+  BirthdayPlaceholderPill,
 } from './index.styled'
 
 interface IUpcomingBirthdaysCardProps {
   birthdays: IBirthdayItem[]
+  isLoading?: boolean
   isExpanded?: boolean
   isError?: boolean
 }
+
+const BirthdayPlaceholder: React.FC = () => (
+  <BirthdayList>
+    <BirthdayPlaceholderEntry>
+      <BirthdayPlaceholderBadge />
+      <BirthdayPlaceholderInfo>
+        <BirthdayPlaceholderName />
+        <BirthdayPlaceholderSub />
+      </BirthdayPlaceholderInfo>
+      <BirthdayPlaceholderPill />
+    </BirthdayPlaceholderEntry>
+    <BirthdayPlaceholderEntry>
+      <BirthdayPlaceholderBadge />
+      <BirthdayPlaceholderInfo>
+        <BirthdayPlaceholderName />
+        <BirthdayPlaceholderSub />
+      </BirthdayPlaceholderInfo>
+      <BirthdayPlaceholderPill />
+    </BirthdayPlaceholderEntry>
+  </BirthdayList>
+)
 
 const monthFormatter = new Intl.DateTimeFormat('en-US', { month: 'short' })
 
@@ -67,7 +95,11 @@ const BirthdayEntry: React.FC<{ b: SortedBirthday; showDetails: boolean }> = ({ 
   )
 }
 
-export const UpcomingBirthdaysCard: React.FC<IUpcomingBirthdaysCardProps> = ({ birthdays, isExpanded = false, isError = false }) => {
+export const UpcomingBirthdaysCard: React.FC<IUpcomingBirthdaysCardProps> = ({ birthdays, isLoading = false, isExpanded = false, isError = false }) => {
+  if (isLoading && birthdays.length === 0) {
+    return <BirthdayPlaceholder />
+  }
+
   if (birthdays.length === 0) {
     return <span style={{ fontSize: '0.75rem', color: 'var(--text-secondary, #888)' }}>{isError ? 'Unable to load birthdays' : 'No birthdays saved'}</span>
   }

--- a/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
+++ b/packages/web/src/routes/HomeRoute/components/PlannerSection/index.tsx
@@ -42,6 +42,7 @@ export const PlannerSection: React.FC<IToDoSectionProps> = ({
       >
         <TaskList
           items={toDoStats.sortedItems}
+          isLoading={isLoading}
           isError={isError}
           onStepToggle={onStepToggle}
           onCardClick={onCardClick}

--- a/packages/web/src/routes/HomeRoute/index.tsx
+++ b/packages/web/src/routes/HomeRoute/index.tsx
@@ -63,7 +63,7 @@ const HomeDataContent = () => {
   const { groceryList, isLoading: isGroceryLoading, isError: isGroceryError } = useGroceryListContext()
   const { toDoList, isLoading: isToDoLoading, isError: isToDoError, removeFromToDoList, updateToDoItemFields } = usePlannerContext()
   const { noiseTrackingItems, isLoading: isNoiseLoading, isError: isNoiseError } = useNoiseTrackingContext()
-  const { birthdays, isError: isBirthdayError } = useBirthdayContext()
+  const { birthdays, isLoading: isBirthdayLoading, isError: isBirthdayError } = useBirthdayContext()
   const { mealPlans, isLoading: isMealLoading } = useMealPlanContext()
   const { adventures, isLoading: isAdventureLoading, removeAdventure } = useAdventureContext()
   const { recipes } = useRecipeContext()
@@ -202,7 +202,7 @@ const HomeDataContent = () => {
               </Box>
             </MiniCardHeader>
             <MiniCardBody>
-              <UpcomingBirthdaysCard birthdays={birthdays} isExpanded={isBirthdaysExpanded} isError={isBirthdayError} />
+              <UpcomingBirthdaysCard birthdays={birthdays} isLoading={isBirthdayLoading} isExpanded={isBirthdaysExpanded} isError={isBirthdayError} />
             </MiniCardBody>
           </MiniCardContent>
         </BirthdayCard>


### PR DESCRIPTION
Both widgets now show animated shimmer skeletons while data is pending
instead of immediately rendering empty-state text like 'No birthdays saved'
or 'No tasks planned'. Uses the existing themedShimmerStyles utility to match
the loading pattern of Grocery, Noise and other widgets.

https://claude.ai/code/session_01X3i6rrSmPChykFsseEMQ15