### PR TITLE
fix: align recipe and planner loading shimmers with actual components

### DIFF
--- a/packages/web/src/components/Planner/WeeklyView/Placeholder/index.styled.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/Placeholder/index.styled.tsx
@@ -1,0 +1,42 @@
+import { styled } from '@mui/material/styles'
+import { shimmerStyles } from '../../../../utils/styles/shimmer'
+
+export const NavButtonPlaceholder = styled('div')({
+  width: 34,
+  height: 34,
+  borderRadius: '50%',
+  flexShrink: 0,
+  ...shimmerStyles,
+})
+
+export const WeekLabelPlaceholder = styled('div')({
+  width: 140,
+  height: 20,
+  borderRadius: 4,
+  flex: 1,
+  margin: '0 8px',
+  ...shimmerStyles,
+})
+
+export const DayNamePlaceholder = styled('div')({
+  width: 24,
+  height: 8,
+  borderRadius: 3,
+  marginBottom: 5,
+  ...shimmerStyles,
+})
+
+export const DayNumberPlaceholder = styled('div')({
+  width: 22,
+  height: 22,
+  borderRadius: 4,
+  ...shimmerStyles,
+})
+
+export const DayItemPlaceholder = styled('div')<{ width?: number }>(({ width = 80 }) => ({
+  width,
+  height: 28,
+  borderRadius: 8,
+  flexShrink: 0,
+  ...shimmerStyles,
+}))

--- a/packages/web/src/components/Planner/WeeklyView/Placeholder/index.tsx
+++ b/packages/web/src/components/Planner/WeeklyView/Placeholder/index.tsx
@@ -1,0 +1,52 @@
+import {
+  WeeklyContainer,
+  WeekHeader,
+  DayRow,
+  DayRowHeader,
+  DayRowItems,
+} from '../index.styled'
+import {
+  NavButtonPlaceholder,
+  WeekLabelPlaceholder,
+  DayNamePlaceholder,
+  DayNumberPlaceholder,
+  DayItemPlaceholder,
+} from './index.styled'
+
+const DAY_ITEMS: number[][] = [
+  [90, 70],
+  [80],
+  [100, 60],
+  [],
+  [75, 85],
+  [95],
+  [],
+]
+
+const WeeklyViewPlaceholder = () => (
+  <WeeklyContainer aria-label="Loading weekly view">
+    <WeekHeader>
+      <NavButtonPlaceholder />
+      <WeekLabelPlaceholder />
+      <NavButtonPlaceholder />
+    </WeekHeader>
+
+    <div style={{ flex: 1, padding: '0 12px 16px', display: 'flex', flexDirection: 'column', gap: 4 }}>
+      {DAY_ITEMS.map((items, index) => (
+        <DayRow key={index}>
+          <DayRowHeader>
+            <DayNamePlaceholder />
+            <DayNumberPlaceholder />
+          </DayRowHeader>
+          <DayRowItems>
+            {items.map((width, i) => (
+              <DayItemPlaceholder key={i} width={width} />
+            ))}
+          </DayRowItems>
+        </DayRow>
+      ))}
+    </div>
+  </WeeklyContainer>
+)
+
+export default WeeklyViewPlaceholder

--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -22,6 +22,7 @@ import GroupedView from './GroupedView';
 import CalendarView from './CalendarView';
 import CalendarViewPlaceholder from './CalendarView/Placeholder';
 import WeeklyView from './WeeklyView';
+import WeeklyViewPlaceholder from './WeeklyView/Placeholder';
 import Placeholder from './Placeholder';
 import EmptyPlanner from './EmptyPlanner';
 import ToDoItemPreviewDrawer from '../ToDoItemPreviewDrawer';
@@ -197,7 +198,7 @@ export const Planner = ({
   if (viewMode === PlannerViewMode.WEEKLY) {
     return (
       <>
-        {isLoading ? <Placeholder /> : (
+        {isLoading ? <WeeklyViewPlaceholder /> : (
           <WeeklyView
             visibleToDoItems={toDoList}
             onItemClick={handlePreview}

--- a/packages/web/src/components/RecipeList/index.tsx
+++ b/packages/web/src/components/RecipeList/index.tsx
@@ -1,12 +1,14 @@
 import { useMemo } from 'react'
-import { Box, Typography, Skeleton } from '@mui/material'
+import { Typography } from '@mui/material'
 import MenuBookIcon from '@mui/icons-material/MenuBook'
 import { COLORS } from '../../constants/colors'
 import { IRecipe } from '../../types/recipe'
 import { MealType } from '../../enums/mealType'
 import { RecipeDishType } from '../../enums/recipeDishType'
 import { useRecipeContext } from '../../providers/RecipeProvider'
+import { shimmerStyles } from '../../utils/styles/shimmer'
 import RecipeItem from '../RecipeItem'
+import { RecipeCard, RecipeCardBody, RecipeMetaRow } from '../RecipeItem/index.styled'
 import {
   RecipeListContainer,
   EmptyStateContainer,
@@ -22,16 +24,15 @@ interface RecipeListProps {
 }
 
 const RecipeSkeletonCard = () => (
-  <Box sx={{ borderRadius: '14px', boxShadow: '0 2px 8px rgba(0,0,0,0.06)', overflow: 'hidden' }}>
-    <Skeleton variant="rectangular" sx={{ width: '100%', aspectRatio: '4 / 3' }} />
-    <Box sx={{ padding: '0.625rem', display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
-      <Skeleton variant="text" width="80%" height={20} />
-      <Box sx={{ display: 'flex', gap: '0.3rem' }}>
-        <Skeleton variant="rounded" width={75} height={20} />
-        <Skeleton variant="rounded" width={50} height={20} />
-      </Box>
-    </Box>
-  </Box>
+  <RecipeCard>
+    <div style={{ width: '100%', aspectRatio: '4 / 3', ...shimmerStyles }} />
+    <RecipeCardBody>
+      <div style={{ width: '80%', height: 14, borderRadius: 4, ...shimmerStyles }} />
+      <RecipeMetaRow>
+        <div style={{ width: 75, height: 20, borderRadius: 16, ...shimmerStyles }} />
+      </RecipeMetaRow>
+    </RecipeCardBody>
+  </RecipeCard>
 )
 
 const RecipeList = ({ search = '', onViewRecipe, selectedMealTypes = [], selectedDishTypes = [] }: RecipeListProps) => {


### PR DESCRIPTION
Recipe skeleton now uses actual RecipeCard styled components and custom
shimmer animation instead of MUI Skeleton, and shows 1 chip placeholder
to match the real RecipeItem. Weekly planner view gets its own dedicated
placeholder matching the day-row layout instead of reusing the grouped
view's collapsible sections placeholder.

https://claude.ai/code/session_01AeH7EN55dpv9LtCfppEEyS