### PR TITLE
refactor: replace ActionButtonsBar with SegmentedControl in planner view

### DIFF
--- a/packages/web/src/components/Planner/GroupedView/index.tsx
+++ b/packages/web/src/components/Planner/GroupedView/index.tsx
@@ -16,12 +16,10 @@ const TIME_GROUP_ICON_MAP: Record<TimeGroup, SectionIcon> = {
   [TimeGroup.NO_DUE_DATE]: { emoji: '📝', backgroundColor: '#f5f5f5', foregroundColor: '#6b7280' },
 };
 
-const GroupedView = ({ 
-  groupedToDoItems, 
-  allExpanded, 
-  expandKey, 
-  onSwipeAction, 
-  onEditAction 
+const GroupedView = ({
+  groupedToDoItems,
+  onSwipeAction,
+  onEditAction
 }: IGroupedViewProps) => {
   return (
     <Container>
@@ -31,8 +29,6 @@ const GroupedView = ({
           title={groupLabel}
           icon={TIME_GROUP_ICON_MAP[group]}
           items={items}
-          expandTo={allExpanded}
-          expandKey={expandKey}
         >
           <SwipeableList
             component={ToDoItem}

--- a/packages/web/src/components/Planner/GroupedView/types.ts
+++ b/packages/web/src/components/Planner/GroupedView/types.ts
@@ -2,8 +2,6 @@ import { IGroupedTodoItem } from '../utils/timeGrouping';
 
 export interface IGroupedViewProps {
   groupedToDoItems: IGroupedTodoItem[];
-  allExpanded?: boolean;
-  expandKey?: string | number;
   onSwipeAction: (id: string) => void;
   onEditAction: (id: string) => void;
 };

--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -29,8 +29,6 @@ import ToDoItemPreviewDrawer from '../ToDoItemPreviewDrawer';
 import { IToDoListProps } from './types';
 
 export const Planner = ({
-  allExpanded = true,
-  expandKey = 0,
   viewMode = PlannerViewMode.CALENDAR,
   mealPlans = [],
   onAddMealPlan,
@@ -229,8 +227,6 @@ export const Planner = ({
   return (
     <GroupedView
       groupedToDoItems={groupedToDoItems}
-      allExpanded={allExpanded}
-      expandKey={expandKey}
       onSwipeAction={markToDoItemAsDone}
       onEditAction={handleEdit}
     />

--- a/packages/web/src/components/Planner/types.ts
+++ b/packages/web/src/components/Planner/types.ts
@@ -2,8 +2,6 @@ import { PlannerViewMode } from '../../enums/plannerViewMode';
 import { IMealPlan } from '../../types/mealPlan';
 
 export interface IToDoListProps {
-  allExpanded?: boolean;
-  expandKey?: string | number;
   viewMode?: PlannerViewMode;
   mealPlans?: IMealPlan[];
   onAddMealPlan?: (date: string) => void;

--- a/packages/web/src/routes/PlannerRoute/index.test.tsx
+++ b/packages/web/src/routes/PlannerRoute/index.test.tsx
@@ -43,7 +43,7 @@ describe('Given the PlannerRoute component', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue([])
-    
+
     // Mock ProjectProvider
     vi.mocked(useProjectContext).mockReturnValue({
       projects: [MOCK_PROJECT],
@@ -163,52 +163,24 @@ describe('Given the PlannerRoute component', () => {
     expect(headerContainer).toBeInTheDocument()
   })
 
-  it('should render the ActionButtonsBar with correct status text when no items selected', async () => {
+  it('should render the SegmentedControl with view mode tabs', async () => {
     await act(async () => {
       renderComponent()
     })
 
-    // The ActionButtonsBar should show status text when no items are selected
     await waitFor(() => {
-      expect(screen.getByText('Your planner is empty')).toBeInTheDocument()
+      expect(screen.getByText('Weekly')).toBeInTheDocument()
     })
   })
 
-  it('should render the ActionButtonsBar with enabled button when items are selected', async () => {
-    // Mock state with selected items
-    vi.mocked(useAppState).mockReturnValue({
-      state: {
-        ...initialState,
-        selectedTodoItems: new Set(['1', '2'])
-      },
-      dispatch: vi.fn(),
-    })
-
-    const mockTodoItems = [
-      { id: '1', name: 'Task 1', isDone: false, description: '', dueDate: undefined },
-      { id: '2', name: 'Task 2', isDone: false, description: '', dueDate: undefined },
-    ]
-
-    vi.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue(mockTodoItems)
-
-    const queryClient = createTestQueryClient()
+  it('should default to weekly view', async () => {
     await act(async () => {
-      render(
-        <QueryClientProvider client={queryClient}>
-          <ThemeProvider theme={theme}>
-            <AppStateProvider>
-              <BrowserRouter>
-                <PlannerRoute />
-              </BrowserRouter>
-            </AppStateProvider>
-          </ThemeProvider>
-        </QueryClientProvider>
-      )
+      renderComponent()
     })
 
-    // The ActionButtonsBar should show the action button when items are selected
     await waitFor(() => {
-      expect(screen.getByText('Mark Tasks As Done')).toBeInTheDocument()
+      // Weekly tab should be visible with its label (active tab shows label with collapseInactive)
+      expect(screen.getByText('Weekly')).toBeInTheDocument()
     })
   })
 
@@ -223,63 +195,6 @@ describe('Given the PlannerRoute component', () => {
       expect(container).toBeInTheDocument()
     })
   })
-
-  it('should render the expand/collapse button (disabled in weekly view)', async () => {
-    const mockTodoItems = [
-      { id: '1', name: 'Task 1', isDone: false, description: '', dueDate: undefined },
-      { id: '2', name: 'Task 2', isDone: false, description: '', dueDate: undefined },
-    ]
-
-    vi.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue(mockTodoItems)
-
-    await act(async () => {
-      renderComponent()
-    })
-
-    // The expand/collapse button should be rendered but disabled in the default calendar view
-    await waitFor(() => {
-      expect(screen.getByLabelText('Collapse all')).toBeInTheDocument()
-      expect(screen.getByLabelText('Collapse all')).toBeDisabled()
-    })
-  })
-
-  it('should disable the expand/collapse button when no pending items', async () => {
-    const mockTodoItems = [
-      { id: '1', name: 'Task 1', isDone: true, description: '', dueDate: undefined },
-      { id: '2', name: 'Task 2', isDone: true, description: '', dueDate: undefined },
-    ]
-
-    vi.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue(mockTodoItems)
-
-    await act(async () => {
-      renderComponent()
-    })
-
-    // The expand/collapse button should be disabled when no pending items
-    await waitFor(() => {
-      const expandButton = screen.getByLabelText('Collapse all')
-      expect(expandButton).toBeDisabled()
-    })
-  })
-
-  it('should render the view toggle button', async () => {
-    const mockTodoItems = [
-      { id: '1', name: 'Task 1', isDone: false, description: '', dueDate: undefined },
-    ]
-
-    vi.spyOn(ToDoAPI, 'retrieveToDoList').mockResolvedValue(mockTodoItems)
-
-    await act(async () => {
-      renderComponent()
-    })
-
-    // The view toggle button should be rendered
-    await waitFor(() => {
-      expect(screen.getByLabelText('Toggle view mode')).toBeInTheDocument()
-    })
-  })
-
-
 })
 
 const renderComponent = () => {

--- a/packages/web/src/routes/PlannerRoute/index.tsx
+++ b/packages/web/src/routes/PlannerRoute/index.tsx
@@ -7,36 +7,57 @@ import { AdventureProvider } from '../../providers/AdventureProvider'
 import { useItemDefaults } from '../../hooks/useItemDefaults'
 import { retrieveGroceryListDefaults } from '../../api/groceryList'
 import Planner from '../../components/Planner'
-import ActionButtonsBar from '../../components/ActionButtonsBar'
+import SegmentedControl, { SegmentedControlTab } from '../../components/SegmentedControl'
 import ModernPageHeader from '../../components/ModernPageHeader'
 import MealPlanPreviewDrawer from '../../components/MealPlanPreviewDrawer'
 import ChecklistIcon from '@mui/icons-material/Checklist'
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 import ViewWeekIcon from '@mui/icons-material/ViewWeek'
 import ViewModuleIcon from '@mui/icons-material/ViewModule'
+import { Box } from '@mui/material'
 import { Container, PlannerScrollArea } from './index.styled'
 import { SECTION_GRADIENTS, SECTION_ACCENT_RGB } from '../../constants/sectionColors'
 import { useAppState } from '../../providers/AppStateProvider'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { showAlert } from '../../utils/alert'
 import { ActionName } from '../../providers/AppStateProvider/enums'
-import { useProjectContext } from '../../providers/ProjectProvider'
-import { updateToDoItems } from '../../api/toDoList'
 import { PlannerViewMode } from '../../enums/plannerViewMode'
 import { IMealPlan } from '../../types/mealPlan'
 import dayjs from 'dayjs'
 import { useNavigate } from 'react-router'
 import { Route } from '../../enums/route'
 
-const VIEW_MODE_CYCLE = [PlannerViewMode.WEEKLY, PlannerViewMode.CALENDAR, PlannerViewMode.GROUPED] as const
+const PLANNER_VIEW_TABS: Array<SegmentedControlTab<PlannerViewMode>> = [
+  {
+    id: PlannerViewMode.WEEKLY,
+    label: 'Weekly',
+    icon: <ViewWeekIcon sx={{ fontSize: '1.1rem' }} />,
+    activeColor: '#6366f1',
+    activeBg: '#ffffff',
+    activeShadow: 'rgba(99, 102, 241, 0.15)',
+  },
+  {
+    id: PlannerViewMode.CALENDAR,
+    label: 'Calendar',
+    icon: <CalendarMonthIcon sx={{ fontSize: '1.1rem' }} />,
+    activeColor: '#6366f1',
+    activeBg: '#ffffff',
+    activeShadow: 'rgba(99, 102, 241, 0.15)',
+  },
+  {
+    id: PlannerViewMode.GROUPED,
+    label: 'Grouped',
+    icon: <ViewModuleIcon sx={{ fontSize: '1.1rem' }} />,
+    activeColor: '#6366f1',
+    activeBg: '#ffffff',
+    activeShadow: 'rgba(99, 102, 241, 0.15)',
+  },
+]
 
 const PlannerContent = () => {
-  const { toDoList, updateToDoItemsBulk } = usePlannerContext()
-  const { state: { selectedTodoItems }, dispatch } = useAppState()
-  const { currentProject } = useProjectContext()
+  const { toDoList } = usePlannerContext()
+  const { dispatch } = useAppState()
   const navigate = useNavigate()
-  const [allExpanded, setAllExpanded] = useState(true)
-  const [expandKey, setExpandKey] = useState(0)
   const [viewMode, setViewMode] = useState<PlannerViewMode>(PlannerViewMode.WEEKLY)
   const { mealPlans, removeMealPlan } = useMealPlanContext()
   const { defaults } = useItemDefaults({ fetchMethod: retrieveGroceryListDefaults })
@@ -78,57 +99,6 @@ const PlannerContent = () => {
 
   const stats = viewMode === PlannerViewMode.GROUPED ? defaultStats : calendarStats
 
-  const statusText = useMemo(() => {
-    const totalItems = toDoList.length
-    const selectedCount = selectedTodoItems.size
-
-    if (totalItems === 0) {
-      return "Your planner is empty"
-    }
-
-    if (selectedCount === 0) {
-      if (viewMode === PlannerViewMode.CALENDAR) return "Tap a day to see its tasks"
-      if (viewMode === PlannerViewMode.WEEKLY)   return "Tap a task to view details"
-      return "Tap items to mark as done"
-    }
-
-    return `${selectedCount} of ${totalItems} item${totalItems === 1 ? '' : 's'} selected`
-  }, [toDoList.length, selectedTodoItems.size, viewMode])
-
-  const clearSelectedTodoItems = useCallback((selectedTodoItems: Set<string>) => {
-    dispatch({
-      type: ActionName.CLEAR_SELECTED_TODO_ITEMS,
-      payload: Array.from(selectedTodoItems)
-    })
-  }, [dispatch])
-
-  const markToDoItemsAsDone = useCallback(async () => {
-    const ids = Array.from(selectedTodoItems)
-    try {
-      await updateToDoItems(ids.map(id => ({ id, isDone: true })), currentProject!.id)
-      updateToDoItemsBulk(ids, { isDone: true })
-      clearSelectedTodoItems(selectedTodoItems)
-    } catch (error) {
-      console.error("Failed to mark to do items as done:", error)
-      showAlert({
-        description: "Failed to mark to do items as done",
-        severity: "error",
-      }, dispatch)
-    }
-  }, [selectedTodoItems, currentProject, dispatch, updateToDoItemsBulk, clearSelectedTodoItems])
-
-  const toggleAll = useCallback(() => {
-    setAllExpanded(!allExpanded)
-    setExpandKey(prev => prev + 1) // Force re-render of sections
-  }, [allExpanded])
-
-  const toggleViewMode = useCallback(() => {
-    setViewMode(prev => {
-      const idx = VIEW_MODE_CYCLE.indexOf(prev)
-      return VIEW_MODE_CYCLE[(idx + 1) % VIEW_MODE_CYCLE.length]
-    })
-  }, [])
-
   const handleAddMealPlan = useCallback((date: string) => {
     dispatch({ type: ActionName.SET_SELECTED_CALENDAR_DATE, payload: date })
     navigate(Route.AddPlannerItem, { state: { itemType: 'meal' } })
@@ -157,11 +127,6 @@ const PlannerContent = () => {
     }
   }, [removeMealPlan, dispatch])
 
-  const viewToggleIcon =
-    viewMode === PlannerViewMode.CALENDAR ? <CalendarMonthIcon /> :
-    viewMode === PlannerViewMode.WEEKLY ? <ViewWeekIcon /> :
-    <ViewModuleIcon />
-
   return (
     <StandardLayout>
       <ModernPageHeader
@@ -172,27 +137,16 @@ const PlannerContent = () => {
         accentRgb={SECTION_ACCENT_RGB.planner}
       />
       <Container>
-        <ActionButtonsBar
-          expandCollapseButton={{
-            isExpanded: allExpanded,
-            onToggle: toggleAll,
-            disabled: pendingItems.length === 0 || viewMode !== PlannerViewMode.GROUPED,
-          }}
-          actionButton={{
-            isEnabled: selectedTodoItems.size > 0,
-            onClick: markToDoItemsAsDone,
-            children: "Mark Tasks As Done",
-            statusText: statusText,
-          }}
-          viewToggleButton={{
-            children: viewToggleIcon,
-            onClick: toggleViewMode,
-          }}
-        />
+        <Box sx={{ px: 2, pt: 1, pb: 0.5 }}>
+          <SegmentedControl
+            tabs={PLANNER_VIEW_TABS}
+            activeTab={viewMode}
+            onChange={setViewMode}
+            collapseInactive
+          />
+        </Box>
         <PlannerScrollArea>
           <Planner
-            allExpanded={allExpanded}
-            expandKey={expandKey}
             viewMode={viewMode}
             mealPlans={mealPlans}
             onAddMealPlan={handleAddMealPlan}


### PR DESCRIPTION
Remove the reused grocery list ActionButtonsBar component from the planner
view, which showed redundant hint text like "Tap a task to view details".
Replace the cycling view mode toggle with a SegmentedControl that displays
all three view options (Weekly, Calendar, Grouped) at once. Remove bulk
mark-as-done and expand/collapse-all features as individual section
controls and swipe/preview drawer actions are sufficient.

https://claude.ai/code/session_01EVDSyMpDofhjPhGxSePeCy