### PR TITLE
feat: show upcoming adventures in planner grouped view

### DIFF
--- a/packages/web/src/components/Planner/GroupedView/AdventureGroupedItem/index.styled.tsx
+++ b/packages/web/src/components/Planner/GroupedView/AdventureGroupedItem/index.styled.tsx
@@ -1,0 +1,92 @@
+import { styled } from '@mui/system'
+import { Card, CardActionArea, CardContent } from '@mui/material'
+import ExploreOutlinedIcon from '@mui/icons-material/ExploreOutlined'
+
+export const Container = styled(Card)(({ theme }) => ({
+  display: 'flex',
+  borderRadius: '14px',
+  minHeight: '64px',
+  margin: '2px 0',
+  width: '100%',
+  justifyContent: 'flex-start',
+  boxSizing: 'border-box',
+  transition: 'all 300ms cubic-bezier(0.4, 0, 0.2, 1)',
+  position: 'relative',
+  boxShadow: '0 3px 16px rgba(0, 0, 0, 0.08), 0 1px 6px rgba(0, 0, 0, 0.04)',
+  border: `1px solid ${theme?.palette?.divider || 'rgba(0, 0, 0, 0.06)'}`,
+  backgroundColor: theme?.palette?.background?.paper || '#ffffff',
+  background: `linear-gradient(145deg, ${theme?.palette?.background?.paper || '#ffffff'}, ${theme?.palette?.background?.default || '#fafafa'})`,
+  overflow: 'hidden',
+  '&::before': {
+    content: '""',
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    width: '4px',
+    background: 'linear-gradient(180deg, #06b6d4, #0891b2)',
+  },
+  '&:hover': {
+    transform: 'translateY(-3px) scale(1.005)',
+    boxShadow: '0 10px 32px rgba(0, 0, 0, 0.14), 0 4px 12px rgba(0, 0, 0, 0.08)',
+    borderColor: theme?.palette?.primary?.light || '#e3f2fd',
+  },
+}))
+
+export const ActionArea = styled(CardActionArea)({
+  display: 'flex',
+  padding: '0',
+  borderRadius: '14px',
+  height: '100%',
+  '&:hover .MuiCardActionArea-focusHighlight': {
+    opacity: 0,
+  },
+})
+
+export const Content = styled(CardContent)({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+  textAlign: 'left',
+  flexGrow: 1,
+  padding: '16px 18px',
+  gap: '4px',
+  borderRadius: '14px',
+  background: 'transparent',
+  height: '100%',
+  minHeight: '64px',
+  '&:last-child': {
+    paddingBottom: '16px',
+  },
+})
+
+export const Name = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  fontSize: '17px',
+  fontWeight: 600,
+  color: theme?.palette?.text?.primary || '#1a1a1a',
+  letterSpacing: '-0.3px',
+  lineHeight: '1.25',
+  wordBreak: 'break-word',
+  overflowWrap: 'break-word',
+  maxWidth: '100%',
+  fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+}))
+
+export const DetailRow = styled('div')(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  fontSize: '13px',
+  fontWeight: 400,
+  color: theme?.palette?.text?.secondary || '#6b7280',
+  lineHeight: '1.4',
+  fontFamily: '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+}))
+
+export const AdventureIcon = styled(ExploreOutlinedIcon)({
+  fontSize: '18px',
+  color: '#06b6d4',
+})

--- a/packages/web/src/components/Planner/GroupedView/AdventureGroupedItem/index.test.tsx
+++ b/packages/web/src/components/Planner/GroupedView/AdventureGroupedItem/index.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AdventureGroupedItem from '.'
+import { IAdventure } from '../../../../types/adventure'
+
+const mockAdventure: IAdventure = {
+  id: 'adv-1',
+  projectId: 'project-1',
+  name: 'Trip to Paris',
+  date: '2026-05-15',
+  location: 'Paris, France',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+}
+
+describe('Given the AdventureGroupedItem component', () => {
+  const mockOnClick = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('When rendering an adventure', () => {
+    it('should display the adventure name', () => {
+      render(<AdventureGroupedItem adventure={mockAdventure} onClick={mockOnClick} />)
+
+      expect(screen.getByText('Trip to Paris')).toBeInTheDocument()
+    })
+
+    it('should display the adventure location', () => {
+      render(<AdventureGroupedItem adventure={mockAdventure} onClick={mockOnClick} />)
+
+      expect(screen.getByText(/Paris, France/)).toBeInTheDocument()
+    })
+
+    it('should display the formatted date', () => {
+      render(<AdventureGroupedItem adventure={mockAdventure} onClick={mockOnClick} />)
+
+      expect(screen.getByText(/15 May 2026/)).toBeInTheDocument()
+    })
+  })
+
+  describe('When rendering a multi-day adventure', () => {
+    it('should display the date range', () => {
+      const multiDayAdventure: IAdventure = {
+        ...mockAdventure,
+        endDate: '2026-05-20',
+      }
+
+      render(<AdventureGroupedItem adventure={multiDayAdventure} onClick={mockOnClick} />)
+
+      expect(screen.getByText(/15 May 2026/)).toBeInTheDocument()
+      expect(screen.getByText(/20 May 2026/)).toBeInTheDocument()
+    })
+  })
+
+  describe('When rendering an adventure without a location', () => {
+    it('should not display a location row', () => {
+      const noLocationAdventure: IAdventure = {
+        ...mockAdventure,
+        location: undefined,
+      }
+
+      render(<AdventureGroupedItem adventure={noLocationAdventure} onClick={mockOnClick} />)
+
+      expect(screen.queryByText(/📍/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('When rendering a private adventure', () => {
+    it('should display the private badge', () => {
+      const privateAdventure: IAdventure = {
+        ...mockAdventure,
+        visibility: 'private',
+      }
+
+      render(<AdventureGroupedItem adventure={privateAdventure} onClick={mockOnClick} />)
+
+      expect(screen.getByTestId('VisibilityOffOutlinedIcon')).toBeInTheDocument()
+    })
+  })
+
+  describe('When clicking on the adventure', () => {
+    it('should call onClick with the adventure id', async () => {
+      render(<AdventureGroupedItem adventure={mockAdventure} onClick={mockOnClick} />)
+
+      await userEvent.click(screen.getByText('Trip to Paris'))
+
+      expect(mockOnClick).toHaveBeenCalledWith('adv-1')
+    })
+  })
+})

--- a/packages/web/src/components/Planner/GroupedView/AdventureGroupedItem/index.tsx
+++ b/packages/web/src/components/Planner/GroupedView/AdventureGroupedItem/index.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useMemo, memo } from 'react'
+import { Container, ActionArea, Content, Name, DetailRow, AdventureIcon } from './index.styled'
+import { IAdventureGroupedItemProps } from './types'
+import PrivateItemBadge from '../../../PrivateItemBadge'
+
+const formatAdventureDate = (date: string, endDate?: string): string => {
+  const [year, month, day] = date.split('-').map(Number)
+  const start = new Date(year, month - 1, day)
+  const dayName = start.toLocaleDateString('en-US', { weekday: 'short' })
+  const dateString = start.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+
+  if (!endDate) {
+    return `${dayName}, ${dateString}`
+  }
+
+  const [eYear, eMonth, eDay] = endDate.split('-').map(Number)
+  const end = new Date(eYear, eMonth - 1, eDay)
+  const endDateString = end.toLocaleDateString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  })
+
+  return `${dayName}, ${dateString} – ${endDateString}`
+}
+
+const AdventureGroupedItem = memo(({ adventure, onClick }: IAdventureGroupedItemProps) => {
+  const handleClick = useCallback(() => {
+    onClick(adventure.id)
+  }, [adventure.id, onClick])
+
+  const formattedDate = useMemo(
+    () => formatAdventureDate(adventure.date, adventure.endDate),
+    [adventure.date, adventure.endDate],
+  )
+
+  return (
+    <Container>
+      <ActionArea onClick={handleClick}>
+        <Content>
+          <Name>
+            <AdventureIcon />
+            {adventure.name}
+            {adventure.visibility === 'private' && <PrivateItemBadge />}
+          </Name>
+          <DetailRow>📅 {formattedDate}</DetailRow>
+          {adventure.location && <DetailRow>📍 {adventure.location}</DetailRow>}
+        </Content>
+      </ActionArea>
+    </Container>
+  )
+})
+
+AdventureGroupedItem.displayName = 'AdventureGroupedItem'
+
+export default AdventureGroupedItem

--- a/packages/web/src/components/Planner/GroupedView/AdventureGroupedItem/types.ts
+++ b/packages/web/src/components/Planner/GroupedView/AdventureGroupedItem/types.ts
@@ -1,0 +1,6 @@
+import { IAdventure } from '../../../../types/adventure'
+
+export interface IAdventureGroupedItemProps {
+  adventure: IAdventure
+  onClick: (id: string) => void
+}

--- a/packages/web/src/components/Planner/GroupedView/index.test.tsx
+++ b/packages/web/src/components/Planner/GroupedView/index.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import GroupedView from '.';
-import { IGroupedTodoItem, TimeGroup } from '../utils/timeGrouping';
+import { IGroupedTodoItem, IGroupedAdventureItem, TimeGroup } from '../utils/timeGrouping';
 
 const mockGroupedToDoItems: IGroupedTodoItem[] = [
   {
@@ -40,9 +41,39 @@ const mockGroupedToDoItems: IGroupedTodoItem[] = [
   },
 ];
 
+const mockGroupedAdventures: IGroupedAdventureItem[] = [
+  {
+    group: TimeGroup.TODAY,
+    groupLabel: 'Today',
+    priority: 2,
+    items: [
+      {
+        id: 'adv-1',
+        projectId: 'project-1',
+        name: 'Visit Museum',
+        date: '2026-04-05',
+        location: 'London',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+    ],
+  },
+];
+
 describe('Given the GroupedView component', () => {
   const mockOnSwipeAction = vi.fn();
   const mockOnEditAction = vi.fn();
+  const mockOnAdventureClick = vi.fn();
+
+  const defaultProps = {
+    groupedToDoItems: mockGroupedToDoItems,
+    groupedAdventures: [] as IGroupedAdventureItem[],
+    allExpanded: true,
+    expandKey: 0,
+    onSwipeAction: mockOnSwipeAction,
+    onEditAction: mockOnEditAction,
+    onAdventureClick: mockOnAdventureClick,
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,15 +81,7 @@ describe('Given the GroupedView component', () => {
 
   describe('When rendering with grouped to-do items', () => {
     it('should display the time group sections with items', () => {
-      render(
-        <GroupedView
-          groupedToDoItems={mockGroupedToDoItems}
-          allExpanded={true}
-          expandKey={0}
-          onSwipeAction={mockOnSwipeAction}
-          onEditAction={mockOnEditAction}
-        />
-      );
+      render(<GroupedView {...defaultProps} />);
 
       expect(screen.getByText('Overdue (2)')).toBeInTheDocument();
       expect(screen.getByText('Due Today')).toBeInTheDocument();
@@ -68,44 +91,20 @@ describe('Given the GroupedView component', () => {
     });
 
     it('should display the appropriate time group icons', () => {
-      render(
-        <GroupedView
-          groupedToDoItems={mockGroupedToDoItems}
-          allExpanded={true}
-          expandKey={0}
-          onSwipeAction={mockOnSwipeAction}
-          onEditAction={mockOnEditAction}
-        />
-      );
+      render(<GroupedView {...defaultProps} />);
 
       expect(screen.getByText('⚠️')).toBeInTheDocument(); // Overdue emoji
       expect(screen.getByText('📅')).toBeInTheDocument(); // Today emoji
     });
 
     it('should render collapsible sections for each time group', () => {
-      render(
-        <GroupedView
-          groupedToDoItems={mockGroupedToDoItems}
-          allExpanded={true}
-          expandKey={0}
-          onSwipeAction={mockOnSwipeAction}
-          onEditAction={mockOnEditAction}
-        />
-      );
+      render(<GroupedView {...defaultProps} />);
 
       expect(screen.getAllByLabelText('Collapse')).toHaveLength(2);
     });
 
     it('should render the container with proper structure', () => {
-      const { container } = render(
-        <GroupedView
-          groupedToDoItems={mockGroupedToDoItems}
-          allExpanded={true}
-          expandKey={0}
-          onSwipeAction={mockOnSwipeAction}
-          onEditAction={mockOnEditAction}
-        />
-      );
+      const { container } = render(<GroupedView {...defaultProps} />);
 
       const containerDiv = container.firstChild;
       expect(containerDiv).toBeInTheDocument();
@@ -116,11 +115,9 @@ describe('Given the GroupedView component', () => {
     it('should pass expand props to CollapsibleSections', () => {
       render(
         <GroupedView
-          groupedToDoItems={mockGroupedToDoItems}
+          {...defaultProps}
           allExpanded={false}
           expandKey="test-key"
-          onSwipeAction={mockOnSwipeAction}
-          onEditAction={mockOnEditAction}
         />
       );
 
@@ -132,16 +129,63 @@ describe('Given the GroupedView component', () => {
   describe('When rendering with empty grouped to-do items', () => {
     it('should render without errors', () => {
       const { container } = render(
-        <GroupedView
-          groupedToDoItems={[]}
-          allExpanded={true}
-          expandKey={0}
-          onSwipeAction={mockOnSwipeAction}
-          onEditAction={mockOnEditAction}
-        />
+        <GroupedView {...defaultProps} groupedToDoItems={[]} />
       );
 
       expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+
+  describe('When rendering with grouped adventures', () => {
+    it('should display the adventure sections', () => {
+      render(
+        <GroupedView {...defaultProps} groupedAdventures={mockGroupedAdventures} />
+      );
+
+      expect(screen.getByText('Today')).toBeInTheDocument();
+      expect(screen.getByText('Visit Museum')).toBeInTheDocument();
+    });
+
+    it('should display the adventure section icon', () => {
+      render(
+        <GroupedView {...defaultProps} groupedAdventures={mockGroupedAdventures} />
+      );
+
+      expect(screen.getByText('🧭')).toBeInTheDocument();
+    });
+
+    it('should display adventure sections before todo sections', () => {
+      render(
+        <GroupedView {...defaultProps} groupedAdventures={mockGroupedAdventures} />
+      );
+
+      const allSectionTitles = screen.getAllByLabelText('Collapse');
+      expect(allSectionTitles).toHaveLength(3);
+    });
+
+    it('should call onAdventureClick when an adventure is clicked', async () => {
+      render(
+        <GroupedView {...defaultProps} groupedAdventures={mockGroupedAdventures} />
+      );
+
+      await userEvent.click(screen.getByText('Visit Museum'));
+
+      expect(mockOnAdventureClick).toHaveBeenCalledWith('adv-1');
+    });
+  });
+
+  describe('When rendering with only adventures and no todos', () => {
+    it('should render only adventure sections', () => {
+      render(
+        <GroupedView
+          {...defaultProps}
+          groupedToDoItems={[]}
+          groupedAdventures={mockGroupedAdventures}
+        />
+      );
+
+      expect(screen.getByText('Visit Museum')).toBeInTheDocument();
+      expect(screen.queryByText('Overdue (2)')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/web/src/components/Planner/GroupedView/index.tsx
+++ b/packages/web/src/components/Planner/GroupedView/index.tsx
@@ -1,6 +1,7 @@
 import ToDoItem from '../../ToDoItem';
 import CollapsibleSection from '../../CollapsibleSection';
 import SwipeableList from '../../SwipeableList';
+import AdventureGroupedItem from './AdventureGroupedItem';
 import { Container } from './index.styled';
 import { IGroupedViewProps } from './types';
 import { TimeGroup } from '../utils/timeGrouping';
@@ -16,13 +17,37 @@ const TIME_GROUP_ICON_MAP: Record<TimeGroup, SectionIcon> = {
   [TimeGroup.NO_DUE_DATE]: { emoji: '📝', backgroundColor: '#f5f5f5', foregroundColor: '#6b7280' },
 };
 
+const ADVENTURE_ICON: SectionIcon = {
+  emoji: '🧭',
+  backgroundColor: '#ecfeff',
+  foregroundColor: '#0891b2',
+};
+
 const GroupedView = ({
   groupedToDoItems,
+  groupedAdventures,
   onSwipeAction,
-  onEditAction
+  onEditAction,
+  onAdventureClick,
 }: IGroupedViewProps) => {
   return (
     <Container>
+      {groupedAdventures.map(({ group, groupLabel, items }) => (
+        <CollapsibleSection
+          key={`adventure-${group}`}
+          title={groupLabel}
+          icon={ADVENTURE_ICON}
+          items={items}
+        >
+          {items.map((adventure) => (
+            <AdventureGroupedItem
+              key={adventure.id}
+              adventure={adventure}
+              onClick={onAdventureClick}
+            />
+          ))}
+        </CollapsibleSection>
+      ))}
       {groupedToDoItems.map(({ group, groupLabel, items }) => (
         <CollapsibleSection
           key={group}

--- a/packages/web/src/components/Planner/GroupedView/types.ts
+++ b/packages/web/src/components/Planner/GroupedView/types.ts
@@ -1,7 +1,9 @@
-import { IGroupedTodoItem } from '../utils/timeGrouping';
+import { IGroupedTodoItem, IGroupedAdventureItem } from '../utils/timeGrouping';
 
 export interface IGroupedViewProps {
   groupedToDoItems: IGroupedTodoItem[];
+  groupedAdventures: IGroupedAdventureItem[];
   onSwipeAction: (id: string) => void;
   onEditAction: (id: string) => void;
+  onAdventureClick: (id: string) => void;
 };

--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -8,7 +8,7 @@ import { ActionName } from '../../providers/AppStateProvider/enums';
 import { removeTodoItems, updateToDoItems } from '../../api/toDoList';
 import { showAlert } from '../../utils/alert';
 import { Route } from '../../enums/route';
-import { groupTodosByTime } from './utils/timeGrouping';
+import { groupTodosByTime, groupAdventuresByTime } from './utils/timeGrouping';
 import { PlannerViewMode } from '../../enums/plannerViewMode';
 import { ITodoItem } from '../../api/toDoList/retrieve/types';
 import { IBirthdayItem } from '../../api/birthdays/retrieve/types';
@@ -53,6 +53,10 @@ export const Planner = ({
   const groupedToDoItems = useMemo(() => {
     return groupTodosByTime(visibleToDoItems);
   }, [visibleToDoItems]);
+
+  const groupedAdventures = useMemo(() => {
+    return groupAdventuresByTime(adventures);
+  }, [adventures]);
 
   const clearSelectedTodoItems = useCallback((id: string) => {
     dispatch({
@@ -220,16 +224,21 @@ export const Planner = ({
     return <Placeholder />
   }
 
-  if (toDoList.length === 0) {
+  if (toDoList.length === 0 && adventures.length === 0) {
     return <EmptyPlanner />
   }
 
   return (
-    <GroupedView
-      groupedToDoItems={groupedToDoItems}
-      onSwipeAction={markToDoItemAsDone}
-      onEditAction={handleEdit}
-    />
+    <>
+      <GroupedView
+        groupedToDoItems={groupedToDoItems}
+        groupedAdventures={groupedAdventures}
+        onSwipeAction={markToDoItemAsDone}
+        onEditAction={handleEdit}
+        onAdventureClick={handleAdventurePreview}
+      />
+      {drawers}
+    </>
   );
 };
 

--- a/packages/web/src/components/Planner/utils/timeGrouping.test.ts
+++ b/packages/web/src/components/Planner/utils/timeGrouping.test.ts
@@ -1,0 +1,127 @@
+import { groupAdventuresByTime, TimeGroup } from './timeGrouping'
+import { IAdventure } from '../../../types/adventure'
+
+const createAdventure = (overrides: Partial<IAdventure> = {}): IAdventure => ({
+  id: 'adv-1',
+  projectId: 'project-1',
+  name: 'Test Adventure',
+  date: '2026-04-05',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  ...overrides,
+})
+
+const formatDate = (date: Date): string => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+describe('Given the groupAdventuresByTime utility', () => {
+  describe('When grouping adventures by time', () => {
+    it('should group an adventure happening today into the TODAY group', () => {
+      const today = formatDate(new Date())
+      const adventure = createAdventure({ id: 'today-adv', date: today })
+
+      const result = groupAdventuresByTime([adventure])
+
+      expect(result).toHaveLength(1)
+      expect(result[0].group).toBe(TimeGroup.TODAY)
+      expect(result[0].items).toHaveLength(1)
+      expect(result[0].items[0].id).toBe('today-adv')
+    })
+
+    it('should group an adventure happening tomorrow into the TOMORROW group', () => {
+      const tomorrow = new Date()
+      tomorrow.setDate(tomorrow.getDate() + 1)
+      const adventure = createAdventure({ id: 'tmr-adv', date: formatDate(tomorrow) })
+
+      const result = groupAdventuresByTime([adventure])
+
+      expect(result).toHaveLength(1)
+      expect(result[0].group).toBe(TimeGroup.TOMORROW)
+    })
+
+    it('should exclude past adventures', () => {
+      const yesterday = new Date()
+      yesterday.setDate(yesterday.getDate() - 1)
+      const adventure = createAdventure({ date: formatDate(yesterday) })
+
+      const result = groupAdventuresByTime([adventure])
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should group a far-future adventure into the LATER group', () => {
+      const futureDate = new Date()
+      futureDate.setMonth(futureDate.getMonth() + 3)
+      const adventure = createAdventure({ date: formatDate(futureDate) })
+
+      const result = groupAdventuresByTime([adventure])
+
+      expect(result).toHaveLength(1)
+      expect(result[0].group).toBe(TimeGroup.LATER)
+    })
+
+    it('should sort groups by priority', () => {
+      const today = formatDate(new Date())
+      const futureDate = new Date()
+      futureDate.setMonth(futureDate.getMonth() + 3)
+
+      const adventures = [
+        createAdventure({ id: 'later', date: formatDate(futureDate) }),
+        createAdventure({ id: 'today', date: today }),
+      ]
+
+      const result = groupAdventuresByTime(adventures)
+
+      expect(result[0].group).toBe(TimeGroup.TODAY)
+      expect(result[1].group).toBe(TimeGroup.LATER)
+    })
+
+    it('should sort adventures within a group by date', () => {
+      const futureDate1 = new Date()
+      futureDate1.setMonth(futureDate1.getMonth() + 3)
+      const futureDate2 = new Date()
+      futureDate2.setMonth(futureDate2.getMonth() + 4)
+
+      const adventures = [
+        createAdventure({ id: 'later-2', date: formatDate(futureDate2) }),
+        createAdventure({ id: 'later-1', date: formatDate(futureDate1) }),
+      ]
+
+      const result = groupAdventuresByTime(adventures)
+
+      expect(result[0].items[0].id).toBe('later-1')
+      expect(result[0].items[1].id).toBe('later-2')
+    })
+
+    it('should return an empty array when there are no adventures', () => {
+      const result = groupAdventuresByTime([])
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should include the item count in the group label when there are multiple items', () => {
+      const today = formatDate(new Date())
+      const adventures = [
+        createAdventure({ id: 'adv-1', date: today }),
+        createAdventure({ id: 'adv-2', date: today }),
+      ]
+
+      const result = groupAdventuresByTime(adventures)
+
+      expect(result[0].groupLabel).toBe('Today (2)')
+    })
+
+    it('should not include count in the group label for a single item', () => {
+      const today = formatDate(new Date())
+      const adventure = createAdventure({ date: today })
+
+      const result = groupAdventuresByTime([adventure])
+
+      expect(result[0].groupLabel).toBe('Today')
+    })
+  })
+})

--- a/packages/web/src/components/Planner/utils/timeGrouping.ts
+++ b/packages/web/src/components/Planner/utils/timeGrouping.ts
@@ -1,4 +1,5 @@
 import { ITodoItem } from '../../../api/toDoList/retrieve/types'
+import { IAdventure } from '../../../types/adventure'
 
 export enum TimeGroup {
   OVERDUE = 'overdue',
@@ -162,4 +163,94 @@ export const groupTodosByTime = (todos: ITodoItem[]): IGroupedTodoItem[] => {
 
 export const getTotalItemsCount = (groupedItems: IGroupedTodoItem[]): number => {
   return groupedItems.reduce((total, group) => total + group.items.length, 0)
+}
+
+export interface IGroupedAdventureItem {
+  group: TimeGroup
+  groupLabel: string
+  items: IAdventure[]
+  priority: number
+}
+
+const getTimeGroupForDateString = (dateString: string): TimeGroup => {
+  const [year, month, day] = dateString.split('-').map(Number)
+  const date = new Date(year, month - 1, day)
+  const now = new Date()
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+
+  if (date < today) {
+    return TimeGroup.OVERDUE
+  }
+
+  if (isToday(date)) {
+    return TimeGroup.TODAY
+  }
+
+  if (isTomorrow(date)) {
+    return TimeGroup.TOMORROW
+  }
+
+  if (isThisWeek(date)) {
+    return TimeGroup.THIS_WEEK
+  }
+
+  if (isNextWeek(date)) {
+    return TimeGroup.NEXT_WEEK
+  }
+
+  return TimeGroup.LATER
+}
+
+const getAdventureGroupLabel = (group: TimeGroup, itemsCount: number): string => {
+  const count = itemsCount > 1 ? ` (${itemsCount})` : ''
+  switch (group) {
+    case TimeGroup.TODAY:
+      return `Today${count}`
+    case TimeGroup.TOMORROW:
+      return `Tomorrow${count}`
+    case TimeGroup.THIS_WEEK:
+      return `This Week${count}`
+    case TimeGroup.NEXT_WEEK:
+      return `Next Week${count}`
+    case TimeGroup.LATER:
+      return `Later${count}`
+    default:
+      return `Upcoming${count}`
+  }
+}
+
+export const groupAdventuresByTime = (adventures: IAdventure[]): IGroupedAdventureItem[] => {
+  const upcomingAdventures = adventures.filter(adventure => {
+    const group = getTimeGroupForDateString(adventure.date)
+    return group !== TimeGroup.OVERDUE
+  })
+
+  const groups = new Map<TimeGroup, IAdventure[]>()
+
+  upcomingAdventures.forEach(adventure => {
+    const group = getTimeGroupForDateString(adventure.date)
+    const existingItems = groups.get(group) || []
+    groups.set(group, [...existingItems, adventure])
+  })
+
+  groups.forEach((items) => {
+    items.sort((a, b) => a.date.localeCompare(b.date))
+  })
+
+  const result: IGroupedAdventureItem[] = []
+
+  groups.forEach((items, group) => {
+    if (items.length > 0) {
+      result.push({
+        group,
+        groupLabel: getAdventureGroupLabel(group, items.length),
+        items,
+        priority: TIME_GROUP_META[group].priority,
+      })
+    }
+  })
+
+  result.sort((a, b) => a.priority - b.priority)
+
+  return result
 }


### PR DESCRIPTION
Adventures are now displayed in the grouped view alongside todos,
organized by time period (Today, Tomorrow, This Week, etc.) with
a compass icon. Clicking an adventure opens the preview drawer.

https://claude.ai/code/session_01Nq9aJ28iTBavMBmK8g4yqk