### PR TITLE
feat: allow members to leave shared projects

### DIFF
--- a/packages/infra/modules/api_gateway/openapi/projects.yml
+++ b/packages/infra/modules/api_gateway/openapi/projects.yml
@@ -108,6 +108,30 @@ paths:
         httpMethod: "POST"
         uri: "${lambda_functions.get_project_members_details.invoke_arn}"
         passthroughBehavior: "when_no_match"
+    delete:
+      summary: Leave a project
+      security:
+        - CognitoAuthorizer: []
+      parameters:
+        - $ref: "#/components/parameters/ProjectIDHeader"
+      responses:
+        "200":
+          description: "Successfully left the project"
+        "400":
+          description: "Cannot leave personal project"
+        "401":
+          description: "Unauthorized"
+        "403":
+          description: "Project owner cannot leave"
+        "404":
+          description: "Not a member of this project"
+        "500":
+          description: "Internal server error"
+      x-amazon-apigateway-integration:
+        type: "aws_proxy"
+        httpMethod: "POST"
+        uri: "${lambda_functions.leave_project.invoke_arn}"
+        passthroughBehavior: "when_no_match"
     options:
       responses:
         "200":
@@ -127,7 +151,7 @@ paths:
           default:
             statusCode: "200"
             responseParameters:
-              method.response.header.Access-Control-Allow-Methods: "'GET'"
+              method.response.header.Access-Control-Allow-Methods: "'GET, DELETE'"
               method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Project-ID'"
               method.response.header.Access-Control-Allow-Origin: "'*'"
         requestTemplates:

--- a/packages/infra/modules/lambda/locals.tf
+++ b/packages/infra/modules/lambda/locals.tf
@@ -326,6 +326,19 @@ locals {
         }
       }
     },
+    "leave_project" = {
+      environment_variables = {}
+      permissions = {
+        database = {
+          projects           = "read-only"
+          project_members    = "read-write"
+          push_subscriptions = "none"
+        }
+        sns = {
+          todo_notifications = "none"
+        }
+      }
+    },
     "get_project_invite_info" = {
       environment_variables = {}
       permissions = {

--- a/packages/lambdas/sources/leave_project/database/index.ts
+++ b/packages/lambdas/sources/leave_project/database/index.ts
@@ -1,0 +1,34 @@
+import { DynamoDBTable, getItem, deleteItem } from '@kairos-lambdas-libs/dynamodb';
+import { IProject, IProjectMember } from '@kairos-lambdas-libs/dynamodb/types/projects';
+
+export const getMembership = async (
+  projectId: string,
+  userId: string
+): Promise<IProjectMember | null> => {
+  return await getItem({
+    tableName: DynamoDBTable.PROJECT_MEMBERS,
+    item: {
+      projectId,
+      userId,
+    },
+  });
+};
+
+export const getProject = async (projectId: string): Promise<IProject | null> => {
+  return await getItem({
+    tableName: DynamoDBTable.PROJECTS,
+    item: {
+      id: projectId,
+    },
+  });
+};
+
+export const deleteProjectMembership = async (projectId: string, userId: string): Promise<void> => {
+  await deleteItem({
+    tableName: DynamoDBTable.PROJECT_MEMBERS,
+    key: {
+      projectId,
+      userId,
+    },
+  });
+};

--- a/packages/lambdas/sources/leave_project/index.test.ts
+++ b/packages/lambdas/sources/leave_project/index.test.ts
@@ -1,0 +1,185 @@
+import { handler } from './index';
+import { getItem, deleteItem } from '@kairos-lambdas-libs/dynamodb';
+import { DynamoDBTable } from '@kairos-lambdas-libs/dynamodb/enums';
+import {
+  IProject,
+  IProjectMember,
+  ProjectRole,
+} from '@kairos-lambdas-libs/dynamodb/types/projects';
+
+vi.mock('@kairos-lambdas-libs/dynamodb', async () => ({
+  DynamoDBTable: {
+    PROJECT_MEMBERS: 'ProjectMembers',
+    PROJECTS: 'Projects',
+  },
+  getItem: vi.fn(),
+  deleteItem: vi.fn(),
+}));
+
+describe('Given the leave_project lambda handler', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('When user is not authenticated', () => {
+    it('should return status 401', async () => {
+      const result = await runHandler({ userId: null, projectId: 'project-1' });
+
+      expect(result.statusCode).toBe(401);
+      expect(result.body).toBe('User not authenticated');
+    });
+  });
+
+  describe('When project ID is missing', () => {
+    it('should return status 400', async () => {
+      const result = await runHandler({ userId: 'user-123', projectId: null });
+
+      expect(result.statusCode).toBe(400);
+      expect(result.body).toBe('Project ID is required.');
+    });
+  });
+
+  describe('When user is not a member of the project', () => {
+    it('should return status 404', async () => {
+      vi.mocked(getItem).mockResolvedValue(null);
+
+      const result = await runHandler({ userId: 'user-123', projectId: 'project-1' });
+
+      expect(result.statusCode).toBe(404);
+      expect(result.body).toBe('You are not a member of this project.');
+
+      expect(getItem).toHaveBeenCalledWith({
+        tableName: DynamoDBTable.PROJECT_MEMBERS,
+        item: {
+          projectId: 'project-1',
+          userId: 'user-123',
+        },
+      });
+    });
+  });
+
+  describe('When trying to leave a personal project', () => {
+    it('should return status 400', async () => {
+      const personalProject: IProject = {
+        id: 'user-123',
+        name: 'Personal Project',
+        ownerId: 'user-123',
+        createdAt: 1234567890,
+        isPersonal: true,
+      };
+
+      const membership: IProjectMember = {
+        projectId: 'user-123',
+        userId: 'user-123',
+        role: ProjectRole.OWNER,
+        joinedAt: 1234567890,
+      };
+
+      vi.mocked(getItem).mockResolvedValueOnce(membership).mockResolvedValueOnce(personalProject);
+
+      const result = await runHandler({ userId: 'user-123', projectId: 'user-123' });
+
+      expect(result.statusCode).toBe(400);
+      expect(result.body).toBe('Cannot leave a personal project.');
+    });
+  });
+
+  describe('When the owner tries to leave', () => {
+    it('should return status 403', async () => {
+      const sharedProject: IProject = {
+        id: 'project-1',
+        name: 'Shared Project',
+        ownerId: 'user-123',
+        createdAt: 1234567890,
+        isPersonal: false,
+        inviteCode: 'ABC123',
+      };
+
+      const membership: IProjectMember = {
+        projectId: 'project-1',
+        userId: 'user-123',
+        role: ProjectRole.OWNER,
+        joinedAt: 1234567890,
+      };
+
+      vi.mocked(getItem).mockResolvedValueOnce(membership).mockResolvedValueOnce(sharedProject);
+
+      const result = await runHandler({ userId: 'user-123', projectId: 'project-1' });
+
+      expect(result.statusCode).toBe(403);
+      expect(result.body).toBe('Project owner cannot leave the project.');
+    });
+  });
+
+  describe('When leaving successfully', () => {
+    it('should delete membership and return success', async () => {
+      const sharedProject: IProject = {
+        id: 'project-1',
+        name: 'Shared Project',
+        ownerId: 'user-456',
+        createdAt: 1234567890,
+        isPersonal: false,
+        inviteCode: 'ABC123',
+      };
+
+      const membership: IProjectMember = {
+        projectId: 'project-1',
+        userId: 'user-123',
+        role: ProjectRole.MEMBER,
+        joinedAt: 1234567890,
+      };
+
+      vi.mocked(getItem).mockResolvedValueOnce(membership).mockResolvedValueOnce(sharedProject);
+      vi.mocked(deleteItem).mockResolvedValue(undefined as never);
+
+      const result = await runHandler({ userId: 'user-123', projectId: 'project-1' });
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body).toBe('Successfully left the project.');
+
+      expect(deleteItem).toHaveBeenCalledWith({
+        tableName: DynamoDBTable.PROJECT_MEMBERS,
+        key: {
+          projectId: 'project-1',
+          userId: 'user-123',
+        },
+      });
+    });
+  });
+
+  describe('When database operation fails', () => {
+    it('should return status 500', async () => {
+      vi.mocked(getItem).mockRejectedValue(new Error('Database error'));
+
+      const result = await runHandler({ userId: 'user-123', projectId: 'project-1' });
+
+      expect(result.statusCode).toBe(500);
+      expect(result.body).toBe('Failed to leave project');
+    });
+  });
+});
+
+interface MockEvent {
+  userId: string | null;
+  projectId: string | null;
+}
+
+const runHandler = async ({ userId, projectId }: MockEvent) => {
+  const event = {
+    ...(userId
+      ? {
+          requestContext: {
+            authorizer: {
+              claims: {
+                sub: userId,
+              },
+            },
+          },
+        }
+      : {}),
+    headers: projectId ? { 'X-Project-ID': projectId } : {},
+    body: null,
+  };
+
+  return await handler(event as any, {} as any, {} as any);
+};

--- a/packages/lambdas/sources/leave_project/index.ts
+++ b/packages/lambdas/sources/leave_project/index.ts
@@ -1,0 +1,67 @@
+import { APIGatewayProxyEvent, Handler } from 'aws-lambda';
+import { middleware, AuthenticatedEvent } from '@kairos-lambdas-libs/middleware';
+import { createResponse } from '@kairos-lambdas-libs/response';
+import { getMembership, getProject, deleteProjectMembership } from './database';
+import { validateMembershipExists, validateNotOwner, validateNotPersonalProject } from './utils';
+
+export const handler: Handler<APIGatewayProxyEvent> = middleware(
+  async (event: AuthenticatedEvent) => {
+    if (!event.userId) {
+      return createResponse({
+        statusCode: 401,
+        message: 'User not authenticated',
+      });
+    }
+
+    if (!event.projectId) {
+      return createResponse({
+        statusCode: 400,
+        message: 'Project ID is required.',
+      });
+    }
+
+    try {
+      const [membership, project] = await Promise.all([
+        getMembership(event.projectId, event.userId),
+        getProject(event.projectId),
+      ]);
+
+      const membershipError = validateMembershipExists(membership);
+      if (membershipError) {
+        return createResponse({
+          statusCode: 404,
+          message: membershipError,
+        });
+      }
+
+      const personalError = validateNotPersonalProject(project);
+      if (personalError) {
+        return createResponse({
+          statusCode: 400,
+          message: personalError,
+        });
+      }
+
+      const ownerError = validateNotOwner(membership!);
+      if (ownerError) {
+        return createResponse({
+          statusCode: 403,
+          message: ownerError,
+        });
+      }
+
+      await deleteProjectMembership(event.projectId, event.userId);
+
+      return createResponse({
+        statusCode: 200,
+        message: 'Successfully left the project.',
+      });
+    } catch (error) {
+      console.error('Failed to leave project:', error);
+      return createResponse({
+        statusCode: 500,
+        message: 'Failed to leave project',
+      });
+    }
+  }
+);

--- a/packages/lambdas/sources/leave_project/package.json
+++ b/packages/lambdas/sources/leave_project/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "leave_project",
+  "version": "1.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@kairos-lambdas-libs/dynamodb": "1.0.0",
+    "@kairos-lambdas-libs/middleware": "1.0.0",
+    "@kairos-lambdas-libs/response": "1.0.0"
+  },
+  "devDependencies": {
+    "@kairos-lambdas-libs/types": "1.0.0"
+  }
+}

--- a/packages/lambdas/sources/leave_project/utils/index.ts
+++ b/packages/lambdas/sources/leave_project/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './validation';

--- a/packages/lambdas/sources/leave_project/utils/validation.ts
+++ b/packages/lambdas/sources/leave_project/utils/validation.ts
@@ -1,0 +1,26 @@
+import {
+  IProject,
+  IProjectMember,
+  ProjectRole,
+} from '@kairos-lambdas-libs/dynamodb/types/projects';
+
+export const validateMembershipExists = (membership: IProjectMember | null): string | null => {
+  if (!membership) {
+    return 'You are not a member of this project.';
+  }
+  return null;
+};
+
+export const validateNotOwner = (membership: IProjectMember): string | null => {
+  if (membership.role === ProjectRole.OWNER) {
+    return 'Project owner cannot leave the project.';
+  }
+  return null;
+};
+
+export const validateNotPersonalProject = (project: IProject | null): string | null => {
+  if (project?.isPersonal) {
+    return 'Cannot leave a personal project.';
+  }
+  return null;
+};

--- a/packages/web/src/api/projects/index.ts
+++ b/packages/web/src/api/projects/index.ts
@@ -1,4 +1,5 @@
 export * from './retrieve'
 export * from './create'
 export * from './join'
+export * from './leave'
 export * from './getInviteInfo'

--- a/packages/web/src/api/projects/leave/index.ts
+++ b/packages/web/src/api/projects/leave/index.ts
@@ -1,0 +1,22 @@
+import { API_BASE_URL } from '../../index'
+import { createFetchOptions } from '../../../utils/api'
+
+export const leaveProject = async (
+  projectId: string,
+  accessToken?: string
+): Promise<void> => {
+  const response = await fetch(
+    `${API_BASE_URL}/projects/members`,
+    createFetchOptions(
+      {
+        method: 'DELETE',
+      },
+      projectId,
+      accessToken
+    )
+  )
+
+  if (!response.ok) {
+    throw new Error('Failed to leave project')
+  }
+}

--- a/packages/web/src/components/LeaveProjectDialog/index.test.tsx
+++ b/packages/web/src/components/LeaveProjectDialog/index.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+import LeaveProjectDialog from './index'
+
+const theme = createTheme()
+
+const defaultProps = {
+  open: true,
+  projectName: 'Test Project',
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+}
+
+const renderDialog = (props = {}) => {
+  return render(
+    <ThemeProvider theme={theme}>
+      <LeaveProjectDialog {...defaultProps} {...props} />
+    </ThemeProvider>
+  )
+}
+
+describe('Given the LeaveProjectDialog component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render dialog when open', () => {
+    renderDialog()
+
+    expect(screen.getAllByText('Leave Project').length).toBeGreaterThanOrEqual(
+      1
+    )
+    expect(screen.getByText(/Test Project/)).toBeInTheDocument()
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Leave Project' })
+    ).toBeInTheDocument()
+  })
+
+  it('should not render dialog when closed', () => {
+    renderDialog({ open: false })
+
+    expect(screen.queryByText('Leave Project')).not.toBeInTheDocument()
+  })
+
+  it('should display the project name in the confirmation message', () => {
+    renderDialog({ projectName: 'Family Groceries' })
+
+    expect(screen.getByText(/Family Groceries/)).toBeInTheDocument()
+  })
+
+  it('should call onClose when cancel button is clicked', () => {
+    const onClose = vi.fn()
+    renderDialog({ onClose })
+
+    fireEvent.click(screen.getByText('Cancel'))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('should call onConfirm when leave button is clicked', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    renderDialog({ onConfirm })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave Project' }))
+
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled()
+    })
+  })
+
+  it('should display error message when leaving fails', async () => {
+    const onConfirm = vi.fn().mockRejectedValue(new Error('Network error'))
+    renderDialog({ onConfirm })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave Project' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
+
+  it('should close dialog after successful leave', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined)
+    const onClose = vi.fn()
+    renderDialog({ onConfirm, onClose })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Leave Project' }))
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/web/src/components/LeaveProjectDialog/index.tsx
+++ b/packages/web/src/components/LeaveProjectDialog/index.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Alert,
+  CircularProgress,
+  Typography,
+} from '@mui/material'
+import { ILeaveProjectDialogProps } from './types'
+
+export const LeaveProjectDialog: React.FC<ILeaveProjectDialogProps> = ({
+  open,
+  projectName,
+  onClose,
+  onConfirm,
+}) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleClose = () => {
+    setError('')
+    setIsLoading(false)
+    onClose()
+  }
+
+  const handleConfirm = async () => {
+    setIsLoading(true)
+    setError('')
+
+    try {
+      await onConfirm()
+      handleClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to leave project')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Typography variant="h6">Leave Project</Typography>
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography variant="body1">
+          Are you sure you want to leave <strong>{projectName}</strong>? You
+          will lose access to all data in this project. You can rejoin later
+          using an invite code.
+        </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 3 }}>
+        <Button onClick={handleClose} disabled={isLoading}>
+          Cancel
+        </Button>
+        <Button
+          onClick={handleConfirm}
+          variant="contained"
+          color="error"
+          disabled={isLoading}
+          sx={{ minWidth: 100 }}
+        >
+          {isLoading ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : (
+            'Leave Project'
+          )}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default LeaveProjectDialog

--- a/packages/web/src/components/LeaveProjectDialog/types.ts
+++ b/packages/web/src/components/LeaveProjectDialog/types.ts
@@ -1,0 +1,6 @@
+export interface ILeaveProjectDialogProps {
+  open: boolean
+  projectName: string
+  onClose: () => void
+  onConfirm: () => void
+}

--- a/packages/web/src/components/UserMenu/ProjectSettingsSubpage.tsx
+++ b/packages/web/src/components/UserMenu/ProjectSettingsSubpage.tsx
@@ -1,6 +1,20 @@
 import React, { useState } from 'react'
-import { Divider, ListItemIcon, ListItemText, Collapse, IconButton } from '@mui/material'
-import { Add as AddIcon, Group as GroupIcon, FolderOpen as ProjectIcon, ArrowBack as ArrowBackIcon, ExpandMore as ExpandMoreIcon } from '@mui/icons-material'
+import {
+  Divider,
+  ListItemIcon,
+  ListItemText,
+  Collapse,
+  IconButton,
+} from '@mui/material'
+import {
+  Add as AddIcon,
+  Group as GroupIcon,
+  FolderOpen as ProjectIcon,
+  ArrowBack as ArrowBackIcon,
+  ExpandMore as ExpandMoreIcon,
+  ExitToApp as LeaveIcon,
+} from '@mui/icons-material'
+import { useAuth } from 'react-oidc-context'
 import * as Styled from './index.styled'
 import { useProjectContext } from '../../providers/ProjectProvider'
 import ProjectInviteDisplay from '../ProjectInviteDisplay'
@@ -10,20 +24,26 @@ interface ProjectSettingsSubpageProps {
   onCreateProject: () => void
   onJoinProject: () => void
   onProjectSwitch: (projectId: string) => void
+  onLeaveProject: (projectId: string) => void
 }
 
 const ProjectSettingsSubpage: React.FC<ProjectSettingsSubpageProps> = ({
   onBack,
   onCreateProject,
   onJoinProject,
-  onProjectSwitch
+  onProjectSwitch,
+  onLeaveProject,
 }) => {
+  const auth = useAuth()
   const { projects, currentProject } = useProjectContext()
-  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set())
+  const userId = auth.user?.profile?.sub
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(
+    new Set()
+  )
   const [successMessage, setSuccessMessage] = useState('')
 
   const toggleProjectExpansion = (projectId: string) => {
-    setExpandedProjects(prev => {
+    setExpandedProjects((prev) => {
       const newSet = new Set(prev)
       if (newSet.has(projectId)) {
         newSet.delete(projectId)
@@ -56,16 +76,18 @@ const ProjectSettingsSubpage: React.FC<ProjectSettingsSubpageProps> = ({
       <Divider sx={{ my: 1 }} />
 
       {successMessage && (
-        <div style={{
-          background: '#dcfce7',
-          color: '#166534',
-          padding: '8px 12px',
-          borderRadius: '8px',
-          fontSize: '12px',
-          marginBottom: '12px',
-          textAlign: 'center',
-          border: '1px solid #bbf7d0'
-        }}>
+        <div
+          style={{
+            background: '#dcfce7',
+            color: '#166534',
+            padding: '8px 12px',
+            borderRadius: '8px',
+            fontSize: '12px',
+            marginBottom: '12px',
+            textAlign: 'center',
+            border: '1px solid #bbf7d0',
+          }}
+        >
           {successMessage}
         </div>
       )}
@@ -77,7 +99,7 @@ const ProjectSettingsSubpage: React.FC<ProjectSettingsSubpageProps> = ({
             <ListItemIcon>
               <ProjectIcon fontSize="small" />
             </ListItemIcon>
-            <ListItemText 
+            <ListItemText
               primary={currentProject.name}
               secondary={currentProject.isPersonal ? 'Personal' : 'Shared'}
             />
@@ -85,8 +107,10 @@ const ProjectSettingsSubpage: React.FC<ProjectSettingsSubpageProps> = ({
               size="small"
               onClick={() => toggleProjectExpansion(currentProject.id)}
               style={{
-                transform: expandedProjects.has(currentProject.id) ? 'rotate(180deg)' : 'rotate(0deg)',
-                transition: 'transform 0.2s ease'
+                transform: expandedProjects.has(currentProject.id)
+                  ? 'rotate(180deg)'
+                  : 'rotate(0deg)',
+                transition: 'transform 0.2s ease',
               }}
             >
               <ExpandMoreIcon fontSize="small" />
@@ -101,6 +125,18 @@ const ProjectSettingsSubpage: React.FC<ProjectSettingsSubpageProps> = ({
                 onShareSuccess={() => handleShareSuccess(currentProject.name)}
                 compact
               />
+              {!currentProject.isPersonal &&
+                currentProject.ownerId !== userId && (
+                  <Styled.ProjectMenuItem
+                    onClick={() => onLeaveProject(currentProject.id)}
+                    sx={{ mt: 1, color: 'error.main' }}
+                  >
+                    <ListItemIcon sx={{ color: 'inherit' }}>
+                      <LeaveIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Leave Project" />
+                  </Styled.ProjectMenuItem>
+                )}
             </div>
           </Collapse>
         </>
@@ -110,14 +146,14 @@ const ProjectSettingsSubpage: React.FC<ProjectSettingsSubpageProps> = ({
         <>
           <Styled.SectionTitle>Other Projects</Styled.SectionTitle>
           {projects
-            .filter(project => project.id !== currentProject?.id)
-            .map(project => (
+            .filter((project) => project.id !== currentProject?.id)
+            .map((project) => (
               <div key={project.id}>
                 <Styled.ProjectMenuItem>
                   <ListItemIcon>
                     <ProjectIcon fontSize="small" />
                   </ListItemIcon>
-                  <ListItemText 
+                  <ListItemText
                     primary={project.name}
                     secondary={project.isPersonal ? 'Personal' : 'Shared'}
                     onClick={() => onProjectSwitch(project.id)}
@@ -130,15 +166,23 @@ const ProjectSettingsSubpage: React.FC<ProjectSettingsSubpageProps> = ({
                       toggleProjectExpansion(project.id)
                     }}
                     style={{
-                      transform: expandedProjects.has(project.id) ? 'rotate(180deg)' : 'rotate(0deg)',
-                      transition: 'transform 0.2s ease'
+                      transform: expandedProjects.has(project.id)
+                        ? 'rotate(180deg)'
+                        : 'rotate(0deg)',
+                      transition: 'transform 0.2s ease',
                     }}
                   >
                     <ExpandMoreIcon fontSize="small" />
                   </IconButton>
                 </Styled.ProjectMenuItem>
                 <Collapse in={expandedProjects.has(project.id)}>
-                  <div style={{ paddingLeft: '8px', paddingRight: '8px', marginBottom: '8px' }}>
+                  <div
+                    style={{
+                      paddingLeft: '8px',
+                      paddingRight: '8px',
+                      marginBottom: '8px',
+                    }}
+                  >
                     <ProjectInviteDisplay
                       inviteCode={project.inviteCode}
                       projectName={project.name}
@@ -146,23 +190,33 @@ const ProjectSettingsSubpage: React.FC<ProjectSettingsSubpageProps> = ({
                       onShareSuccess={() => handleShareSuccess(project.name)}
                       compact
                     />
+                    {!project.isPersonal && project.ownerId !== userId && (
+                      <Styled.ProjectMenuItem
+                        onClick={() => onLeaveProject(project.id)}
+                        sx={{ mt: 1, color: 'error.main' }}
+                      >
+                        <ListItemIcon sx={{ color: 'inherit' }}>
+                          <LeaveIcon fontSize="small" />
+                        </ListItemIcon>
+                        <ListItemText primary="Leave Project" />
+                      </Styled.ProjectMenuItem>
+                    )}
                   </div>
                 </Collapse>
               </div>
-            ))
-          }
+            ))}
         </>
       )}
 
       <Divider sx={{ my: 1 }} />
-      
+
       <Styled.ProjectMenuItem onClick={onCreateProject}>
         <ListItemIcon>
           <AddIcon fontSize="small" />
         </ListItemIcon>
         <ListItemText primary="Create Project" />
       </Styled.ProjectMenuItem>
-      
+
       <Styled.ProjectMenuItem onClick={onJoinProject}>
         <ListItemIcon>
           <GroupIcon fontSize="small" />

--- a/packages/web/src/components/UserMenu/index.test.tsx
+++ b/packages/web/src/components/UserMenu/index.test.tsx
@@ -16,8 +16,8 @@ const defaultMockAuthState = {
     profile: {
       name: 'John Doe',
       email: 'john@example.com',
-      picture: 'https://example.com/avatar.jpg' as string | undefined
-    }
+      picture: 'https://example.com/avatar.jpg' as string | undefined,
+    },
   } as any,
 }
 
@@ -43,20 +43,29 @@ const locationMock = {
   reload: vi.fn(),
   toString: vi.fn(() => ''),
   hostname: 'localhost',
-  get href() { return '' },
-  set href(value: string) { mockHref(value) },
+  get href() {
+    return ''
+  },
+  set href(value: string) {
+    mockHref(value)
+  },
 }
 vi.stubGlobal('location', locationMock)
 
 // Mock dependencies used by UserMenu component
 vi.mock('../../providers/ProjectProvider', () => ({
   useProjectContext: vi.fn(() => ({
-    currentProject: { id: 'project-1', name: 'Test Project', isPersonal: false },
+    currentProject: {
+      id: 'project-1',
+      name: 'Test Project',
+      isPersonal: false,
+    },
     projects: [],
     isLoading: false,
     switchProject: vi.fn(),
     createProject: vi.fn(),
     joinProject: vi.fn(),
+    leaveProject: vi.fn(),
     fetchProjects: vi.fn(),
     getProjectInviteInfo: vi.fn(),
   })),
@@ -110,15 +119,15 @@ describe('UserMenu', () => {
 
   it('should render user button', () => {
     render(<UserMenu />)
-    
+
     expect(screen.getByRole('button')).toBeVisible()
   })
 
   it('should show dropdown when clicked', () => {
     render(<UserMenu />)
-    
+
     fireEvent.click(screen.getByRole('button'))
-    
+
     expect(screen.getByText('John Doe')).toBeVisible()
     expect(screen.getByText('john@example.com')).toBeVisible()
     expect(screen.getByRole('button', { name: /sign out/i })).toBeVisible()
@@ -136,9 +145,7 @@ describe('UserMenu', () => {
 
     // Verify the logout logic was invoked by checking that href was set
     // (our mock captures href assignments via mockHref)
-    expect(mockHref).toHaveBeenCalledWith(
-      expect.stringContaining('logout')
-    )
+    expect(mockHref).toHaveBeenCalledWith(expect.stringContaining('logout'))
   })
 
   it('should show user initials when no picture', () => {
@@ -147,15 +154,15 @@ describe('UserMenu', () => {
       user: {
         profile: {
           ...defaultMockAuthState.user.profile,
-          picture: undefined
-        }
-      }
+          picture: undefined,
+        },
+      },
     })
-    
+
     render(<UserMenu />)
-    
+
     fireEvent.click(screen.getByRole('button'))
-    
+
     expect(screen.getByText('J')).toBeVisible()
   })
 
@@ -182,9 +189,9 @@ describe('UserMenu', () => {
   describe('Portal functionality', () => {
     it('should render dropdown using createPortal when opened', () => {
       render(<UserMenu />)
-      
+
       fireEvent.click(screen.getByRole('button'))
-      
+
       expect(createPortal).toHaveBeenCalledWith(
         expect.anything(),
         document.body
@@ -193,7 +200,7 @@ describe('UserMenu', () => {
 
     it('should not call createPortal when dropdown is closed', () => {
       render(<UserMenu />)
-      
+
       expect(createPortal).not.toHaveBeenCalled()
     })
   })
@@ -202,9 +209,9 @@ describe('UserMenu', () => {
     it('should calculate dropdown position based on button position', async () => {
       render(<UserMenu />)
       const button = screen.getByRole('button')
-      
+
       fireEvent.click(button)
-      
+
       await waitFor(() => {
         expect(mockGetBoundingClientRect).toHaveBeenCalled()
       })
@@ -212,18 +219,18 @@ describe('UserMenu', () => {
 
     it('should position dropdown relative to button with correct offset', async () => {
       render(<UserMenu />)
-      
+
       fireEvent.click(screen.getByRole('button'))
-      
+
       // Wait for the positioning to be calculated and check the rendered DOM
       await waitFor(() => {
         // Look for the dropdown in the actual DOM
         const dropdown = document.querySelector('[style*="position: fixed"]')
         expect(dropdown).toBeTruthy()
-        
+
         const style = window.getComputedStyle(dropdown!)
         expect(style.position).toBe('fixed')
-        
+
         // Check that getBoundingClientRect was called for positioning
         expect(mockGetBoundingClientRect).toHaveBeenCalled()
       })
@@ -234,14 +241,14 @@ describe('UserMenu', () => {
     it('should close dropdown when Escape key is pressed', async () => {
       const user = userEvent.setup()
       render(<UserMenu />)
-      
+
       // Open dropdown
       fireEvent.click(screen.getByRole('button'))
       expect(screen.getByText('John Doe')).toBeVisible()
-      
+
       // Press Escape
       await user.keyboard('{Escape}')
-      
+
       await waitFor(() => {
         expect(screen.queryByText('John Doe')).not.toBeInTheDocument()
       })
@@ -250,16 +257,16 @@ describe('UserMenu', () => {
     it('should not close dropdown on other key presses', async () => {
       const user = userEvent.setup()
       render(<UserMenu />)
-      
+
       // Open dropdown
       fireEvent.click(screen.getByRole('button'))
       expect(screen.getByText('John Doe')).toBeVisible()
-      
+
       // Press other keys
       await user.keyboard('{Enter}')
       await user.keyboard('{Space}')
       await user.keyboard('a')
-      
+
       expect(screen.getByText('John Doe')).toBeVisible()
     })
   })
@@ -267,28 +274,36 @@ describe('UserMenu', () => {
   describe('Overlay interactions', () => {
     it('should close dropdown when overlay is clicked', () => {
       render(<UserMenu />)
-      
+
       // Open dropdown
       fireEvent.click(screen.getByRole('button'))
       expect(screen.getByText('John Doe')).toBeVisible()
-      
+
       // Find and click overlay (it's rendered as the first child in the portal)
-      const portalCall = (createPortal as Mock).mock.calls.find(call => 
-        call[0]?.props?.children?.some?.((child: any) => 
-          child?.props?.onClick
-        )
+      const portalCall = (createPortal as Mock).mock.calls.find((call) =>
+        call[0]?.props?.children?.some?.((child: any) => child?.props?.onClick)
       )
-      
+
       expect(portalCall).toBeDefined()
-      const overlayElement = (portalCall as [{ props: { children: { props: { onClick?: () => void; style?: { position?: string } } }[] } }])[0].props.children.find(
+      const overlayElement = (
+        portalCall as [
+          {
+            props: {
+              children: {
+                props: { onClick?: () => void; style?: { position?: string } }
+              }[]
+            }
+          },
+        ]
+      )[0].props.children.find(
         (child: any) => child?.props?.onClick && !child?.props?.style?.position
       )
 
       // Simulate the overlay click by calling the onClick handler directly
       act(() => {
-        (overlayElement as { props: { onClick: () => void } }).props.onClick()
+        ;(overlayElement as { props: { onClick: () => void } }).props.onClick()
       })
-      
+
       expect(screen.queryByText('John Doe')).not.toBeInTheDocument()
     })
   })
@@ -300,16 +315,16 @@ describe('UserMenu', () => {
         user: {
           profile: {
             ...defaultMockAuthState.user.profile,
-            picture: 'https://invalid-url.com/image.jpg'
-          }
-        }
+            picture: 'https://invalid-url.com/image.jpg',
+          },
+        },
       })
-      
+
       render(<UserMenu />)
-      
+
       const avatar = screen.getByAltText('John Doe')
       fireEvent.error(avatar)
-      
+
       // The fallback should be shown (initials)
       expect(screen.getByText('J')).toBeVisible()
     })
@@ -321,15 +336,15 @@ describe('UserMenu', () => {
           profile: {
             given_name: 'Jane',
             email: 'jane@example.com',
-            picture: undefined
-          }
-        }
+            picture: undefined,
+          },
+        },
       })
-      
+
       render(<UserMenu />)
-      
+
       fireEvent.click(screen.getByRole('button'))
-      
+
       expect(screen.getByText('Jane')).toBeVisible()
       expect(screen.getByText('J')).toBeVisible() // Initial
     })
@@ -340,15 +355,15 @@ describe('UserMenu', () => {
         user: {
           profile: {
             name: 'John Doe',
-            picture: undefined
-          }
-        }
+            picture: undefined,
+          },
+        },
       })
-      
+
       render(<UserMenu />)
-      
+
       fireEvent.click(screen.getByRole('button'))
-      
+
       expect(screen.getByText('John Doe')).toBeVisible()
       expect(screen.queryByText('@')).not.toBeInTheDocument()
     })
@@ -357,30 +372,33 @@ describe('UserMenu', () => {
   describe('Component lifecycle', () => {
     it('should clean up event listeners when component unmounts', () => {
       const removeEventListenerSpy = vi.spyOn(document, 'removeEventListener')
-      
+
       const { unmount } = render(<UserMenu />)
-      
+
       // Open dropdown to add event listeners
       fireEvent.click(screen.getByRole('button'))
-      
+
       unmount()
-      
-      expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function))
-      
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'keydown',
+        expect.any(Function)
+      )
+
       removeEventListenerSpy.mockRestore()
     })
 
     it('should update position when dropdown is reopened', () => {
       render(<UserMenu />)
-      
+
       // Open dropdown first time
       const userButton = screen.getByRole('button')
       fireEvent.click(userButton)
       expect(mockGetBoundingClientRect).toHaveBeenCalledTimes(1)
-      
+
       // Close dropdown by clicking the user button again
       fireEvent.click(userButton)
-      
+
       // Update mock position
       mockGetBoundingClientRect.mockReturnValue({
         bottom: 150,
@@ -390,10 +408,10 @@ describe('UserMenu', () => {
         width: 50,
         height: 50,
       })
-      
+
       // Open dropdown again
       fireEvent.click(userButton)
-      
+
       expect(mockGetBoundingClientRect).toHaveBeenCalledTimes(2)
     })
   })

--- a/packages/web/src/components/UserMenu/index.tsx
+++ b/packages/web/src/components/UserMenu/index.tsx
@@ -3,7 +3,12 @@ import { createPortal } from 'react-dom'
 import { useAuth } from 'react-oidc-context'
 import { useNavigate } from 'react-router'
 import { Divider, ListItemIcon, ListItemText } from '@mui/material'
-import { Settings as SettingsIcon, Notifications as NotificationsIcon, ShoppingCart as ShoppingCartIcon, VolumeUp as VolumeUpIcon } from '@mui/icons-material'
+import {
+  Settings as SettingsIcon,
+  Notifications as NotificationsIcon,
+  ShoppingCart as ShoppingCartIcon,
+  VolumeUp as VolumeUpIcon,
+} from '@mui/icons-material'
 import * as Styled from './index.styled'
 import { getPostLogoutRedirectUri, oidcConfig } from '../../config/oidc'
 import { useProjectContext } from '../../providers/ProjectProvider'
@@ -11,6 +16,7 @@ import { useVersion } from '../../hooks/useVersion'
 import { Route } from '../../enums/route'
 import CreateProjectDialog from '../CreateProjectDialog'
 import JoinProjectDialog from '../JoinProjectDialog'
+import LeaveProjectDialog from '../LeaveProjectDialog'
 import ProjectSettingsSubpage from './ProjectSettingsSubpage'
 import NotificationSettingsSubpage from './NotificationSettingsSubpage'
 import GrocerySettingsSubpage from './GrocerySettingsSubpage'
@@ -20,22 +26,25 @@ type SubpageView = 'main' | 'projects' | 'notifications' | 'grocery'
 const UserMenu: React.FC = () => {
   const auth = useAuth()
   const navigate = useNavigate()
-  const { switchProject } = useProjectContext()
+  const { projects, switchProject, leaveProject } = useProjectContext()
   const { version } = useVersion()
   const [isOpen, setIsOpen] = useState(false)
   const [currentView, setCurrentView] = useState<SubpageView>('main')
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, right: 0 })
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [showJoinDialog, setShowJoinDialog] = useState(false)
+  const [showLeaveDialog, setShowLeaveDialog] = useState(false)
+  const [projectToLeave, setProjectToLeave] = useState<string | null>(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
 
   const handleLogout = () => {
-    const clientId = oidcConfig.client_id;
-    const logoutUri = getPostLogoutRedirectUri();
-    const cognitoDomain = "https://5rndghxqgv-kairos.auth.eu-west-2.amazoncognito.com";
-    
-    window.location.href = `${cognitoDomain}/logout?client_id=${clientId}&logout_uri=${encodeURIComponent(logoutUri)}`;
-  
+    const clientId = oidcConfig.client_id
+    const logoutUri = getPostLogoutRedirectUri()
+    const cognitoDomain =
+      'https://5rndghxqgv-kairos.auth.eu-west-2.amazoncognito.com'
+
+    window.location.href = `${cognitoDomain}/logout?client_id=${clientId}&logout_uri=${encodeURIComponent(logoutUri)}`
+
     auth.removeUser()
   }
 
@@ -49,7 +58,7 @@ const UserMenu: React.FC = () => {
   }
 
   const handleProjectSwitch = (projectId: string) => {
-    switchProject(projectId).catch(error => {
+    switchProject(projectId).catch((error) => {
       console.error('Failed to switch project:', error)
     })
     closeDropdown()
@@ -63,6 +72,18 @@ const UserMenu: React.FC = () => {
   const handleJoinProject = () => {
     setShowJoinDialog(true)
     closeDropdown()
+  }
+
+  const handleLeaveProject = (projectId: string) => {
+    setProjectToLeave(projectId)
+    setShowLeaveDialog(true)
+    closeDropdown()
+  }
+
+  const handleLeaveProjectConfirm = async () => {
+    if (projectToLeave) {
+      await leaveProject(projectToLeave)
+    }
   }
 
   const handleShowProjectSettings = () => {
@@ -91,7 +112,7 @@ const UserMenu: React.FC = () => {
       const rect = buttonRef.current.getBoundingClientRect()
       setDropdownPosition({
         top: rect.bottom + 8,
-        right: window.innerWidth - rect.right
+        right: window.innerWidth - rect.right,
       })
     }
   }, [isOpen])
@@ -123,8 +144,8 @@ const UserMenu: React.FC = () => {
     <>
       <Styled.UserButton ref={buttonRef} onClick={toggleDropdown}>
         {user?.picture ? (
-          <Styled.UserAvatar 
-            src={user.picture} 
+          <Styled.UserAvatar
+            src={user.picture}
             alt={userName}
             onError={(e: React.SyntheticEvent<HTMLImageElement, Event>) => {
               // Hide the failed image and show the fallback
@@ -134,106 +155,108 @@ const UserMenu: React.FC = () => {
             }}
           />
         ) : null}
-        <div 
-          style={{ 
-            width: 32, 
-            height: 32, 
-            borderRadius: '50%', 
-            background: '#667eea', 
+        <div
+          style={{
+            width: 32,
+            height: 32,
+            borderRadius: '50%',
+            background: '#667eea',
             display: user?.picture ? 'none' : 'flex',
-            alignItems: 'center', 
-            justifyContent: 'center', 
-            color: 'white', 
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'white',
             fontSize: '14px',
-            fontWeight: 'bold'
+            fontWeight: 'bold',
           }}
         >
           {userInitial}
         </div>
       </Styled.UserButton>
-      
-      {isOpen && createPortal(
-        <>
-          <Styled.DropdownOverlay onClick={closeDropdown} />
-          <Styled.UserDropdown style={{ 
-            position: 'fixed',
-            top: dropdownPosition.top,
-            right: dropdownPosition.right,
-          }}>
-            {currentView === 'main' && (
-              <>
-                <Styled.UserInfo>
-                  <Styled.UserName>{userName}</Styled.UserName>
-                  {userEmail && <Styled.UserEmail>{userEmail}</Styled.UserEmail>}
-                </Styled.UserInfo>
-                
-                <Divider sx={{ my: 1 }} />
-                
-                <Styled.MainMenuItem onClick={handleShowProjectSettings}>
-                  <ListItemIcon>
-                    <SettingsIcon fontSize="small" />
-                  </ListItemIcon>
-                  <ListItemText primary="Project Settings" />
-                </Styled.MainMenuItem>
-                
-                <Styled.MainMenuItem onClick={handleShowNotificationSettings}>
-                  <ListItemIcon>
-                    <NotificationsIcon fontSize="small" />
-                  </ListItemIcon>
-                  <ListItemText primary="Notification Settings" />
-                </Styled.MainMenuItem>
 
-                <Styled.MainMenuItem onClick={handleShowGrocerySettings}>
-                  <ListItemIcon>
-                    <ShoppingCartIcon fontSize="small" />
-                  </ListItemIcon>
-                  <ListItemText primary="Grocery Settings" />
-                </Styled.MainMenuItem>
+      {isOpen &&
+        createPortal(
+          <>
+            <Styled.DropdownOverlay onClick={closeDropdown} />
+            <Styled.UserDropdown
+              style={{
+                position: 'fixed',
+                top: dropdownPosition.top,
+                right: dropdownPosition.right,
+              }}
+            >
+              {currentView === 'main' && (
+                <>
+                  <Styled.UserInfo>
+                    <Styled.UserName>{userName}</Styled.UserName>
+                    {userEmail && (
+                      <Styled.UserEmail>{userEmail}</Styled.UserEmail>
+                    )}
+                  </Styled.UserInfo>
 
-                <Styled.MainMenuItem onClick={handleNavigateToNoiseTracking}>
-                  <ListItemIcon>
-                    <VolumeUpIcon fontSize="small" />
-                  </ListItemIcon>
-                  <ListItemText primary="Noise Tracking" />
-                </Styled.MainMenuItem>
+                  <Divider sx={{ my: 1 }} />
 
-                <Divider sx={{ my: 1 }} />
+                  <Styled.MainMenuItem onClick={handleShowProjectSettings}>
+                    <ListItemIcon>
+                      <SettingsIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Project Settings" />
+                  </Styled.MainMenuItem>
 
-                <Styled.LogoutButton onClick={handleLogout}>
-                  Sign Out
-                </Styled.LogoutButton>
+                  <Styled.MainMenuItem onClick={handleShowNotificationSettings}>
+                    <ListItemIcon>
+                      <NotificationsIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Notification Settings" />
+                  </Styled.MainMenuItem>
 
-                {version && (
-                  <Styled.VersionFooter>{version}</Styled.VersionFooter>
-                )}
-              </>
-            )}
+                  <Styled.MainMenuItem onClick={handleShowGrocerySettings}>
+                    <ListItemIcon>
+                      <ShoppingCartIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Grocery Settings" />
+                  </Styled.MainMenuItem>
 
-            {currentView === 'projects' && (
-              <ProjectSettingsSubpage
-                onBack={handleBackToMain}
-                onCreateProject={handleCreateProject}
-                onJoinProject={handleJoinProject}
-                onProjectSwitch={handleProjectSwitch}
-              />
-            )}
+                  <Styled.MainMenuItem onClick={handleNavigateToNoiseTracking}>
+                    <ListItemIcon>
+                      <VolumeUpIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Noise Tracking" />
+                  </Styled.MainMenuItem>
 
-            {currentView === 'notifications' && (
-              <NotificationSettingsSubpage
-                onBack={handleBackToMain}
-              />
-            )}
+                  <Divider sx={{ my: 1 }} />
 
-            {currentView === 'grocery' && (
-              <GrocerySettingsSubpage
-                onBack={handleBackToMain}
-              />
-            )}
-          </Styled.UserDropdown>
-        </>,
-        document.body
-      )}
-      
+                  <Styled.LogoutButton onClick={handleLogout}>
+                    Sign Out
+                  </Styled.LogoutButton>
+
+                  {version && (
+                    <Styled.VersionFooter>{version}</Styled.VersionFooter>
+                  )}
+                </>
+              )}
+
+              {currentView === 'projects' && (
+                <ProjectSettingsSubpage
+                  onBack={handleBackToMain}
+                  onCreateProject={handleCreateProject}
+                  onJoinProject={handleJoinProject}
+                  onProjectSwitch={handleProjectSwitch}
+                  onLeaveProject={handleLeaveProject}
+                />
+              )}
+
+              {currentView === 'notifications' && (
+                <NotificationSettingsSubpage onBack={handleBackToMain} />
+              )}
+
+              {currentView === 'grocery' && (
+                <GrocerySettingsSubpage onBack={handleBackToMain} />
+              )}
+            </Styled.UserDropdown>
+          </>,
+          document.body
+        )}
+
       <CreateProjectDialog
         open={showCreateDialog}
         onClose={() => setShowCreateDialog(false)}
@@ -242,7 +265,7 @@ const UserMenu: React.FC = () => {
           setShowCreateDialog(false)
         }}
       />
-      
+
       <JoinProjectDialog
         open={showJoinDialog}
         onClose={() => setShowJoinDialog(false)}
@@ -250,6 +273,16 @@ const UserMenu: React.FC = () => {
           // Projects will automatically be refreshed by ProjectProvider
           setShowJoinDialog(false)
         }}
+      />
+
+      <LeaveProjectDialog
+        open={showLeaveDialog}
+        projectName={projects.find((p) => p.id === projectToLeave)?.name || ''}
+        onClose={() => {
+          setShowLeaveDialog(false)
+          setProjectToLeave(null)
+        }}
+        onConfirm={handleLeaveProjectConfirm}
       />
     </>
   )

--- a/packages/web/src/providers/ProjectProvider/ProjectProvider.tsx
+++ b/packages/web/src/providers/ProjectProvider/ProjectProvider.tsx
@@ -1,20 +1,42 @@
-import { createContext, useContext, useState, useCallback, useEffect, useMemo } from 'react'
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+} from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useAuth } from 'react-oidc-context'
 import { IProjectProviderProps } from './types'
-import { IProject, IProjectContext, ICreateProjectRequest, IJoinProjectRequest } from '../../types/project'
-import { retrieveUserProjects, createProject as createProjectAPI, joinProject as joinProjectAPI, getProjectInviteInfo } from '../../api/projects'
-import { getUserPreferences, updateUserPreferences } from '../../api/userPreferences'
+import {
+  IProject,
+  IProjectContext,
+  ICreateProjectRequest,
+  IJoinProjectRequest,
+} from '../../types/project'
+import {
+  retrieveUserProjects,
+  createProject as createProjectAPI,
+  joinProject as joinProjectAPI,
+  leaveProject as leaveProjectAPI,
+  getProjectInviteInfo,
+} from '../../api/projects'
+import {
+  getUserPreferences,
+  updateUserPreferences,
+} from '../../api/userPreferences'
 
 export const initialState: IProjectContext = {
   projects: [],
   currentProject: null,
   isLoading: false,
-  createProject: async () => ({} as IProject),
+  createProject: async () => ({}) as IProject,
   joinProject: async () => {},
+  leaveProject: async () => {},
   switchProject: async () => {},
   fetchProjects: async () => {},
-  getProjectInviteInfo: async () => ({} as any),
+  getProjectInviteInfo: async () => ({}) as any,
 }
 
 export const ProjectContext = createContext<IProjectContext>(initialState)
@@ -23,17 +45,18 @@ export const useProjectContext = () => useContext(ProjectContext)
 
 export const ProjectProvider = ({ children }: IProjectProviderProps) => {
   const auth = useAuth()
-const [projects, setProjects] = useState<IProject[]>([])
+  const [projects, setProjects] = useState<IProject[]>([])
   const [currentProject, setCurrentProject] = useState<IProject | null>(null)
 
   const queryKey = ['projects', auth.user?.access_token]
 
   const query = useQuery({
     queryKey,
-    queryFn: () => Promise.all([
-      retrieveUserProjects(auth.user!.access_token),
-      getUserPreferences(auth.user!.access_token),
-    ]),
+    queryFn: () =>
+      Promise.all([
+        retrieveUserProjects(auth.user!.access_token),
+        getUserPreferences(auth.user!.access_token),
+      ]),
     enabled: !!auth.isAuthenticated && !!auth.user?.access_token,
   })
 
@@ -52,7 +75,9 @@ const [projects, setProjects] = useState<IProject[]>([])
     setProjects(userProjects)
 
     if (userPreferences.currentProjectId) {
-      const savedProject = userProjects.find((p: IProject) => p.id === userPreferences.currentProjectId)
+      const savedProject = userProjects.find(
+        (p: IProject) => p.id === userPreferences.currentProjectId
+      )
       if (savedProject) {
         setCurrentProject(savedProject)
         return
@@ -62,12 +87,20 @@ const [projects, setProjects] = useState<IProject[]>([])
     const personalProject = userProjects.find((p: IProject) => p.isPersonal)
     if (personalProject) {
       setCurrentProject(personalProject)
-      updateUserPreferences({ currentProjectId: personalProject.id }, auth.user!.access_token)
-        .catch((error) => console.error('Failed to save project preference:', error))
+      updateUserPreferences(
+        { currentProjectId: personalProject.id },
+        auth.user!.access_token
+      ).catch((error) =>
+        console.error('Failed to save project preference:', error)
+      )
     } else if (userProjects.length > 0) {
       setCurrentProject(userProjects[0])
-      updateUserPreferences({ currentProjectId: userProjects[0].id }, auth.user!.access_token)
-        .catch((error) => console.error('Failed to save project preference:', error))
+      updateUserPreferences(
+        { currentProjectId: userProjects[0].id },
+        auth.user!.access_token
+      ).catch((error) =>
+        console.error('Failed to save project preference:', error)
+      )
     }
   }, [query.data, auth.user?.access_token])
 
@@ -83,53 +116,86 @@ const [projects, setProjects] = useState<IProject[]>([])
     await query.refetch()
   }, [query.refetch])
 
-  const createProject = useCallback(async (request: ICreateProjectRequest): Promise<IProject> => {
-    if (!auth.user?.access_token) throw new Error('User not authenticated')
+  const createProject = useCallback(
+    async (request: ICreateProjectRequest): Promise<IProject> => {
+      if (!auth.user?.access_token) throw new Error('User not authenticated')
 
-    try {
-      const newProject = await createProjectAPI(request, auth.user.access_token)
-      setProjects((prev) => [...prev, newProject])
-      return newProject
-    } catch (error) {
-      console.error('Failed to create project:', error)
-      throw error
-    }
-  }, [auth.user?.access_token])
-
-  const joinProject = useCallback(async (request: IJoinProjectRequest): Promise<void> => {
-    if (!auth.user?.access_token) throw new Error('User not authenticated')
-
-    try {
-      await joinProjectAPI(request, auth.user.access_token)
-      await query.refetch()
-    } catch (error) {
-      console.error('Failed to join project:', error)
-      throw error
-    }
-  }, [auth.user?.access_token, query.refetch])
-
-  const switchProject = useCallback(async (projectId: string) => {
-    const project = projects.find((p) => p.id === projectId)
-    if (project && auth.user?.access_token) {
-      setCurrentProject(project)
       try {
-        await updateUserPreferences({ currentProjectId: projectId }, auth.user.access_token)
+        const newProject = await createProjectAPI(
+          request,
+          auth.user.access_token
+        )
+        setProjects((prev) => [...prev, newProject])
+        return newProject
       } catch (error) {
-        console.error('Failed to update user preferences:', error)
+        console.error('Failed to create project:', error)
+        throw error
       }
-    }
-  }, [projects, auth.user?.access_token])
+    },
+    [auth.user?.access_token]
+  )
 
-  const getProjectInviteInfoHandler = useCallback(async (inviteCode: string) => {
-    if (!auth.user?.access_token) throw new Error('User not authenticated')
+  const joinProject = useCallback(
+    async (request: IJoinProjectRequest): Promise<void> => {
+      if (!auth.user?.access_token) throw new Error('User not authenticated')
 
-    try {
-      return await getProjectInviteInfo(inviteCode, auth.user.access_token)
-    } catch (error) {
-      console.error('Failed to get project invite info:', error)
-      throw error
-    }
-  }, [auth.user?.access_token])
+      try {
+        await joinProjectAPI(request, auth.user.access_token)
+        await query.refetch()
+      } catch (error) {
+        console.error('Failed to join project:', error)
+        throw error
+      }
+    },
+    [auth.user?.access_token, query.refetch]
+  )
+
+  const leaveProject = useCallback(
+    async (projectId: string): Promise<void> => {
+      if (!auth.user?.access_token) throw new Error('User not authenticated')
+
+      try {
+        await leaveProjectAPI(projectId, auth.user.access_token)
+        await query.refetch()
+      } catch (error) {
+        console.error('Failed to leave project:', error)
+        throw error
+      }
+    },
+    [auth.user?.access_token, query.refetch]
+  )
+
+  const switchProject = useCallback(
+    async (projectId: string) => {
+      const project = projects.find((p) => p.id === projectId)
+      if (project && auth.user?.access_token) {
+        setCurrentProject(project)
+        try {
+          await updateUserPreferences(
+            { currentProjectId: projectId },
+            auth.user.access_token
+          )
+        } catch (error) {
+          console.error('Failed to update user preferences:', error)
+        }
+      }
+    },
+    [projects, auth.user?.access_token]
+  )
+
+  const getProjectInviteInfoHandler = useCallback(
+    async (inviteCode: string) => {
+      if (!auth.user?.access_token) throw new Error('User not authenticated')
+
+      try {
+        return await getProjectInviteInfo(inviteCode, auth.user.access_token)
+      } catch (error) {
+        console.error('Failed to get project invite info:', error)
+        throw error
+      }
+    },
+    [auth.user?.access_token]
+  )
 
   const value = useMemo(
     () => ({
@@ -138,16 +204,25 @@ const [projects, setProjects] = useState<IProject[]>([])
       isLoading: query.isLoading,
       createProject,
       joinProject,
+      leaveProject,
       switchProject,
       fetchProjects,
       getProjectInviteInfo: getProjectInviteInfoHandler,
     }),
-    [projects, currentProject, query.isLoading, createProject, joinProject, switchProject, fetchProjects, getProjectInviteInfoHandler]
+    [
+      projects,
+      currentProject,
+      query.isLoading,
+      createProject,
+      joinProject,
+      leaveProject,
+      switchProject,
+      fetchProjects,
+      getProjectInviteInfoHandler,
+    ]
   )
 
   return (
-    <ProjectContext.Provider value={value}>
-      {children}
-    </ProjectContext.Provider>
+    <ProjectContext.Provider value={value}>{children}</ProjectContext.Provider>
   )
 }

--- a/packages/web/src/types/project.ts
+++ b/packages/web/src/types/project.ts
@@ -42,6 +42,7 @@ export interface IProjectContext {
   isLoading: boolean
   createProject: (request: ICreateProjectRequest) => Promise<IProject>
   joinProject: (request: IJoinProjectRequest) => Promise<void>
+  leaveProject: (projectId: string) => Promise<void>
   switchProject: (projectId: string) => Promise<void>
   fetchProjects: () => Promise<void>
   getProjectInviteInfo: (inviteCode: string) => Promise<IProjectInviteInfo>


### PR DESCRIPTION
Add full-stack support for project members to leave shared projects:

- New `leave_project` Lambda with validation (prevents owner/personal project leave)
- OpenAPI contract update: DELETE /projects/members endpoint
- Terraform config for the new Lambda function
- Frontend API client, ProjectProvider `leaveProject` method
- LeaveProjectDialog confirmation component with error handling
- Leave button in ProjectSettingsSubpage for non-owner shared projects
- Unit tests for Lambda (7 tests) and dialog component (7 tests)

https://claude.ai/code/session_0135eEa4AvZnKFBPD8e8eZaG