### PR TITLE
feat: add Project Members subpage to user menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .claude/worktrees/
 .vscode/
+*.tsbuildinfo

--- a/packages/web/src/components/UserMenu/MembersSettingsSubpage.test.tsx
+++ b/packages/web/src/components/UserMenu/MembersSettingsSubpage.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
+import MembersSettingsSubpage from './MembersSettingsSubpage'
+import { ProjectRole } from '../../types/project'
+import { IProjectMemberDetails } from '../../types/projectMemberDetails'
+
+const mockMembers: IProjectMemberDetails[] = [
+  {
+    userId: 'user-1',
+    name: 'Alice Smith',
+    role: ProjectRole.OWNER,
+    avatar: 'https://example.com/alice.jpg',
+  },
+  {
+    userId: 'user-2',
+    name: 'Bob Jones',
+    role: ProjectRole.MEMBER,
+    givenName: 'Bob',
+  },
+]
+
+const mockUseProjectMembersContext = vi.fn(() => ({
+  members: mockMembers,
+  isLoading: false,
+  isError: false,
+}))
+
+vi.mock('../../providers/ProjectMembersProvider', () => ({
+  ProjectMembersProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useProjectMembersContext: () => mockUseProjectMembersContext(),
+}))
+
+describe('Given the MembersSettingsSubpage component', () => {
+  const defaultProps = {
+    onBack: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseProjectMembersContext.mockReturnValue({
+      members: mockMembers,
+      isLoading: false,
+      isError: false,
+    })
+  })
+
+  it('should render the subpage title', () => {
+    render(<MembersSettingsSubpage {...defaultProps} />)
+
+    expect(screen.getByText('Project Members')).toBeVisible()
+  })
+
+  it('should call onBack when back button is clicked', () => {
+    render(<MembersSettingsSubpage {...defaultProps} />)
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(defaultProps.onBack).toHaveBeenCalledTimes(1)
+  })
+
+  it('should render member names', () => {
+    render(<MembersSettingsSubpage {...defaultProps} />)
+
+    expect(screen.getByText('Alice Smith')).toBeVisible()
+    expect(screen.getByText('Bob Jones')).toBeVisible()
+  })
+
+  it('should render role badges', () => {
+    render(<MembersSettingsSubpage {...defaultProps} />)
+
+    expect(screen.getByText('Owner')).toBeVisible()
+    expect(screen.getByText('Member')).toBeVisible()
+  })
+
+  it('should render member avatars with initials as fallback', () => {
+    render(<MembersSettingsSubpage {...defaultProps} />)
+
+    expect(screen.getByText('B')).toBeVisible()
+  })
+
+  it('should show loading spinner when members are loading', () => {
+    mockUseProjectMembersContext.mockReturnValue({
+      members: [],
+      isLoading: true,
+      isError: false,
+    })
+
+    render(<MembersSettingsSubpage {...defaultProps} />)
+
+    expect(screen.getByRole('progressbar')).toBeVisible()
+  })
+
+  it('should show error message when loading fails', () => {
+    mockUseProjectMembersContext.mockReturnValue({
+      members: [],
+      isLoading: false,
+      isError: true,
+    })
+
+    render(<MembersSettingsSubpage {...defaultProps} />)
+
+    expect(screen.getByText('Failed to load members')).toBeVisible()
+  })
+
+  it('should show empty message when no members exist', () => {
+    mockUseProjectMembersContext.mockReturnValue({
+      members: [],
+      isLoading: false,
+      isError: false,
+    })
+
+    render(<MembersSettingsSubpage {...defaultProps} />)
+
+    expect(screen.getByText('No members found')).toBeVisible()
+  })
+})

--- a/packages/web/src/components/UserMenu/MembersSettingsSubpage.tsx
+++ b/packages/web/src/components/UserMenu/MembersSettingsSubpage.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import {
+  Avatar,
+  CircularProgress,
+  Divider,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { ArrowBack as ArrowBackIcon } from '@mui/icons-material'
+import * as Styled from './index.styled'
+import {
+  ProjectMembersProvider,
+  useProjectMembersContext,
+} from '../../providers/ProjectMembersProvider'
+import { ProjectRole } from '../../types/project'
+
+interface MembersSettingsSubpageProps {
+  onBack: () => void
+}
+
+const MembersList: React.FC = () => {
+  const { members, isLoading, isError } = useProjectMembersContext()
+
+  if (isLoading) {
+    return (
+      <Stack alignItems="center" py={3}>
+        <CircularProgress size={28} sx={{ color: '#667eea' }} />
+      </Stack>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ textAlign: 'center', py: 2 }}
+      >
+        Failed to load members
+      </Typography>
+    )
+  }
+
+  if (members.length === 0) {
+    return (
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ textAlign: 'center', py: 2 }}
+      >
+        No members found
+      </Typography>
+    )
+  }
+
+  return (
+    <Stack spacing={0.5}>
+      {members.map((member) => (
+        <Styled.MemberItem key={member.userId}>
+          <Avatar
+            src={member.avatar}
+            sx={{
+              width: 36,
+              height: 36,
+              bgcolor: '#667eea',
+              fontSize: '0.85rem',
+              fontWeight: 600,
+            }}
+          >
+            {member.name.charAt(0).toUpperCase()}
+          </Avatar>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <Styled.MemberNameText>{member.name}</Styled.MemberNameText>
+          </div>
+          <Styled.RoleBadge isOwner={member.role === ProjectRole.OWNER}>
+            {member.role === ProjectRole.OWNER ? 'Owner' : 'Member'}
+          </Styled.RoleBadge>
+        </Styled.MemberItem>
+      ))}
+    </Stack>
+  )
+}
+
+const MembersSettingsSubpage: React.FC<MembersSettingsSubpageProps> = ({
+  onBack,
+}) => {
+  return (
+    <>
+      <Styled.SubpageHeader>
+        <Styled.BackButton onClick={onBack}>
+          <ArrowBackIcon fontSize="small" />
+        </Styled.BackButton>
+        <Styled.SubpageTitle>Project Members</Styled.SubpageTitle>
+      </Styled.SubpageHeader>
+
+      <Divider sx={{ my: 1 }} />
+
+      <ProjectMembersProvider>
+        <MembersList />
+      </ProjectMembersProvider>
+    </>
+  )
+}
+
+export default MembersSettingsSubpage

--- a/packages/web/src/components/UserMenu/index.styled.tsx
+++ b/packages/web/src/components/UserMenu/index.styled.tsx
@@ -12,7 +12,7 @@ export const UserButton = styled(Button)({
   justifyContent: 'center',
   transition: 'all 0.2s ease',
   minWidth: 'auto',
-  
+
   '&:hover': {
     background: 'rgba(0, 0, 0, 0.05)',
   },
@@ -44,7 +44,7 @@ export const UserDropdown = styled(Box)({
   maxHeight: '400px',
   overflowY: 'auto',
   zIndex: 1000,
-  
+
   '&::before': {
     content: '""',
     position: 'absolute',
@@ -88,7 +88,7 @@ export const LogoutButton = styled(Button)({
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   textTransform: 'none',
-  
+
   '&:hover': {
     background: '#f3f4f6',
     borderColor: '#d1d5db',
@@ -110,18 +110,18 @@ export const CurrentProject = styled(Box)({
   alignItems: 'center',
   padding: '8px 0',
   marginBottom: '8px',
-  
+
   '& .MuiListItemIcon-root': {
     minWidth: '32px',
     color: '#667eea',
   },
-  
+
   '& .MuiListItemText-primary': {
     fontSize: '14px',
     fontWeight: 500,
     color: '#1f2937',
   },
-  
+
   '& .MuiListItemText-secondary': {
     fontSize: '12px',
     color: '#6b7280',
@@ -135,23 +135,23 @@ export const ProjectMenuItem = styled(Box)({
   borderRadius: '6px',
   cursor: 'pointer',
   transition: 'all 0.2s ease',
-  
+
   '&:hover': {
     background: '#f9fafb',
     paddingLeft: '8px',
     paddingRight: '8px',
   },
-  
+
   '& .MuiListItemIcon-root': {
     minWidth: '32px',
     color: '#6b7280',
   },
-  
+
   '& .MuiListItemText-primary': {
     fontSize: '14px',
     color: '#374151',
   },
-  
+
   '& .MuiListItemText-secondary': {
     fontSize: '12px',
     color: '#6b7280',
@@ -166,16 +166,16 @@ export const MainMenuItem = styled(Box)({
   cursor: 'pointer',
   transition: 'all 0.2s ease',
   marginBottom: '4px',
-  
+
   '&:hover': {
     background: '#f9fafb',
   },
-  
+
   '& .MuiListItemIcon-root': {
     minWidth: '36px',
     color: '#667eea',
   },
-  
+
   '& .MuiListItemText-primary': {
     fontSize: '14px',
     fontWeight: 500,
@@ -203,11 +203,11 @@ export const BackButton = styled(Button)({
   alignItems: 'center',
   justifyContent: 'center',
   transition: 'all 0.2s ease',
-  
+
   '&:hover': {
     background: '#f3f4f6',
   },
-  
+
   '& .MuiSvgIcon-root': {
     fontSize: '18px',
     color: '#6b7280',
@@ -228,3 +228,39 @@ export const VersionFooter = styled(Typography)({
   fontFamily: 'monospace',
   letterSpacing: '0.3px',
 })
+
+export const MemberItem = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '12px',
+  padding: '8px',
+  borderRadius: '8px',
+})
+
+export const MemberNameText = styled(Typography)({
+  fontSize: '14px',
+  fontWeight: 500,
+  color: '#1f2937',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+export const RoleBadge = styled('span')<{ isOwner: boolean }>(
+  ({ isOwner }) => ({
+    fontSize: '11px',
+    fontWeight: 600,
+    padding: '2px 8px',
+    borderRadius: '12px',
+    whiteSpace: 'nowrap',
+    ...(isOwner
+      ? {
+          background: 'rgba(102, 126, 234, 0.1)',
+          color: '#667eea',
+        }
+      : {
+          background: 'rgba(107, 114, 128, 0.1)',
+          color: '#6b7280',
+        }),
+  })
+)

--- a/packages/web/src/components/UserMenu/index.tsx
+++ b/packages/web/src/components/UserMenu/index.tsx
@@ -8,6 +8,7 @@ import {
   Notifications as NotificationsIcon,
   ShoppingCart as ShoppingCartIcon,
   VolumeUp as VolumeUpIcon,
+  People as PeopleIcon,
 } from '@mui/icons-material'
 import * as Styled from './index.styled'
 import { getPostLogoutRedirectUri, oidcConfig } from '../../config/oidc'
@@ -20,8 +21,9 @@ import LeaveProjectDialog from '../LeaveProjectDialog'
 import ProjectSettingsSubpage from './ProjectSettingsSubpage'
 import NotificationSettingsSubpage from './NotificationSettingsSubpage'
 import GrocerySettingsSubpage from './GrocerySettingsSubpage'
+import MembersSettingsSubpage from './MembersSettingsSubpage'
 
-type SubpageView = 'main' | 'projects' | 'notifications' | 'grocery'
+type SubpageView = 'main' | 'projects' | 'notifications' | 'grocery' | 'members'
 
 const UserMenu: React.FC = () => {
   const auth = useAuth()
@@ -96,6 +98,10 @@ const UserMenu: React.FC = () => {
 
   const handleShowGrocerySettings = () => {
     setCurrentView('grocery')
+  }
+
+  const handleShowMembersSettings = () => {
+    setCurrentView('members')
   }
 
   const handleNavigateToNoiseTracking = () => {
@@ -202,6 +208,13 @@ const UserMenu: React.FC = () => {
                     <ListItemText primary="Project Settings" />
                   </Styled.MainMenuItem>
 
+                  <Styled.MainMenuItem onClick={handleShowMembersSettings}>
+                    <ListItemIcon>
+                      <PeopleIcon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Project Members" />
+                  </Styled.MainMenuItem>
+
                   <Styled.MainMenuItem onClick={handleShowNotificationSettings}>
                     <ListItemIcon>
                       <NotificationsIcon fontSize="small" />
@@ -251,6 +264,10 @@ const UserMenu: React.FC = () => {
 
               {currentView === 'grocery' && (
                 <GrocerySettingsSubpage onBack={handleBackToMain} />
+              )}
+
+              {currentView === 'members' && (
+                <MembersSettingsSubpage onBack={handleBackToMain} />
               )}
             </Styled.UserDropdown>
           </>,


### PR DESCRIPTION
Adds a new "Project Members" entry in the user menu dropdown that shows
all members of the current project with their avatar, name, and role badge.

https://claude.ai/code/session_01KKZ2CyjL8T79xKfzHKn6t1