### PR TITLE
fix: prevent horizontal scroll wobble in planner grouped view

### DIFF
--- a/packages/web/src/layout/standardLayout/index.styled.tsx
+++ b/packages/web/src/layout/standardLayout/index.styled.tsx
@@ -22,5 +22,6 @@ export const Content = styled('div')<IContentProps>(({ centerVertically }) => ({
     width: '100%',
     flex: 1,
     padding: '0 0.75rem',
-    overflow: 'scroll',
+    overflowY: 'auto',
+    overflowX: 'hidden',
 }))


### PR DESCRIPTION
The Content container in standardLayout used `overflow: 'scroll'` which
enabled scrolling on both axes. This caused horizontal wobble when
scrolling vertically on the planner grouped view. Split into
`overflowY: 'auto'` and `overflowX: 'hidden'` to lock horizontal axis.

https://claude.ai/code/session_012QEjno15tDCSujsyQUnd6L