### PR TITLE
feat: add quick adventure + button to calendar day cell

### DIFF
--- a/packages/web/src/components/Planner/CalendarView/index.tsx
+++ b/packages/web/src/components/Planner/CalendarView/index.tsx
@@ -56,6 +56,7 @@ interface ICalendarViewProps {
   onAddTask?: (date: string) => void
   adventures?: IAdventure[]
   onAdventureClick?: (id: string) => void
+  onAddAdventure?: (date: string) => void
   officeAttendance?: IOfficeAttendance[]
   onAddOfficeDay?: (date: string) => void
   onRemoveAttendance?: (id: string) => void
@@ -72,6 +73,7 @@ const CalendarView = ({
   onAddTask,
   adventures = [],
   onAdventureClick,
+  onAddAdventure,
   officeAttendance = [],
   onAddOfficeDay,
   onRemoveAttendance,
@@ -372,6 +374,7 @@ const CalendarView = ({
         onAddMealPlan={onAddMealPlan}
         onMealPlanClick={onMealPlanClick}
         onAdventureClick={onAdventureClick}
+        onAddAdventure={onAddAdventure}
         onAddTask={onAddTask}
         officeAttendance={selectedDayOfficeAttendance}
         onAddOfficeDay={onAddOfficeDay}

--- a/packages/web/src/components/Planner/index.tsx
+++ b/packages/web/src/components/Planner/index.tsx
@@ -268,6 +268,7 @@ export const Planner = ({
             onAddTask={handleAddTask}
             adventures={adventures}
             onAdventureClick={handleAdventurePreview}
+            onAddAdventure={onAddAdventure ?? handleAddAdventure}
             officeAttendance={officeAttendance}
             onAddOfficeDay={onAddOfficeDay}
             onRemoveAttendance={onRemoveAttendance}


### PR DESCRIPTION
Wire onAddAdventure through Planner -> CalendarView -> DayPreviewDrawer
so the Adventures section in the calendar day drawer shows the same
quick + button pattern already used by Tasks, Meals and Office.